### PR TITLE
Fix: State corruption on undo after blast-promotion and connectN-removal

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -68,6 +68,7 @@ struct StateInfo {
   Piece      unpromotedBycatch[SQUARE_NB];
   Bitboard   promotedBycatch;
   Bitboard   demotedBycatch;
+  Bitboard   blastPromotedSquares;
   StateInfo* previous;
   Bitboard   blockersForKing[COLOR_NB];
   Bitboard   pinners[COLOR_NB];


### PR DESCRIPTION
Addresses an issue where undoing a move involving both blast-promotion and connectN-removal on the same square could lead to an incorrect board state.

The problem occurred because the connectN-removal logic would overwrite undo information (specifically st->unpromotedBycatch and st->demotedBycatch) that was previously set by the blast-promotion logic. During undo, this led to the game incorrectly restoring the promoted form of the piece instead of the original piece that was initially on the square before the blast-promotion.

The fix introduces a new Bitboard `blastPromotedSquares` in `StateInfo` to track squares where blast-promotion has occurred during a move.

- `do_move` is updated to set the corresponding bit in `blastPromotedSquares` when a blast-promotion happens.
- `undo_move` is modified to check this new bitboard. If a square was blast-promoted and then later cleared by connectN (or another blast effect), `undo_move` now correctly restores the original unpromoted piece and sets its promotion status to false, bypassing the standard demotion/promotion restoration logic for that square.

This ensures that the original piece state is preserved and correctly restored, preventing game state corruption in this specific scenario. The "pond" variant in variants.ini can be used to test this interaction.