### PR TITLE
Fix packaging README path

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include AUTHORS Copying.txt Readme.md test.py
+include AUTHORS Copying.txt README.md test.py
 recursive-include src *.h *.cpp


### PR DESCRIPTION
## Summary
- fix README path case in MANIFEST.in

## Testing
- `python3 test.py`
- `bash tests/perft.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f708272508330bb1010fa95438340