### PR TITLE
Fix blast SEE evaluation for mating explosions

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2835,6 +2835,14 @@ Value Position::blast_see(Move m) const {
   Bitboard fromto = type_of(m) == DROP ? square_bb(to) : from | to;
   Bitboard blast = blast_squares(to);
 
+  // If the explosion would capture an opponent royal or pseudo-royal piece,
+  // treat the move as delivering immediate mate. This prevents the static
+  // evaluation from underestimating winning blast captures.
+  Bitboard enemyRoyal = st->pseudoRoyals & pieces(~us);
+  enemyRoyal |= pieces(~us, king_type());
+  if (blast & enemyRoyal)
+      return -checkmate_value();
+
   Value result = VALUE_ZERO;
 
   // Add the least valuable attacker for quiet moves


### PR DESCRIPTION
## Summary
- account for blast captures that immediately explode the opponent's royal piece
- treat such captures as delivering mate in `blast_see`

## Testing
- `make -C src build ARCH=x86-64-modern`
- `pip install -e .`
- `python3 test.py`

------
https://chatgpt.com/codex/tasks/task_e_683f88c85c408330a3de125ea762ce71