### PR TITLE
Implement friendly-jumping slider modifier

### DIFF
--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -88,6 +88,9 @@ namespace {
           // Initial move
           else if (c == 'i')
               initial = true;
+          // Slider ignores friendly pieces
+          else if (c == 'y')
+              p->friendlyJump = true;
           // Directional modifiers
           else if (verticals.find(c) != std::string::npos || horizontals.find(c) != std::string::npos)
           {

--- a/src/piece.h
+++ b/src/piece.h
@@ -40,6 +40,7 @@ struct PieceInfo {
   std::map<Direction, int> steps[2][MOVE_MODALITY_NB] = {};
   std::map<Direction, int> slider[2][MOVE_MODALITY_NB] = {};
   std::map<Direction, int> hopper[2][MOVE_MODALITY_NB] = {};
+  bool friendlyJump = false;
 };
 
 struct PieceMap : public std::map<PieceType, const PieceInfo*> {

--- a/src/position.h
+++ b/src/position.h
@@ -1487,7 +1487,10 @@ inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s) const {
       return attacks_bb(c, pt, s, byTypeBB[ALL_PIECES]) & board_bb();
 
   PieceType movePt = pt == KING ? king_type() : pt;
-  Bitboard b = attacks_bb(c, movePt, s, byTypeBB[ALL_PIECES]);
+  Bitboard occupancy = byTypeBB[ALL_PIECES];
+  if (pieceMap.find(movePt)->second->friendlyJump)
+      occupancy &= ~pieces(c);
+  Bitboard b = attacks_bb(c, movePt, s, occupancy);
   // Xiangqi soldier
   if (pt == SOLDIER && !(promoted_soldiers(c) & s))
       b &= file_bb(file_of(s));
@@ -1573,10 +1576,13 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
       return (moves_bb(c, pt, s, byTypeBB[ALL_PIECES]) | extraDestinations) & board_bb();
 
   PieceType movePt = pt == KING ? king_type() : pt;
-  Bitboard b = (moves_bb(c, movePt, s, byTypeBB[ALL_PIECES]) | extraDestinations);
+  Bitboard occupancy = byTypeBB[ALL_PIECES];
+  if (pieceMap.find(movePt)->second->friendlyJump)
+      occupancy &= ~pieces(c);
+  Bitboard b = (moves_bb(c, movePt, s, occupancy) | extraDestinations);
   // Add initial moves
   if (double_step_region(c, pt) & s)
-      b |= moves_bb<true>(c, movePt, s, byTypeBB[ALL_PIECES]);
+      b |= moves_bb<true>(c, movePt, s, occupancy);
 
   // Xiangqi soldier
   if (pt == SOLDIER && !(promoted_soldiers(c) & s))

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -105,6 +105,7 @@
 # - limited and unlimited distance sliders/riders for W/R, F/B, and N directions
 # - hoppers and grasshoppers for W/R and F/B directions, i.e., pR, pB, gR, and gB
 # - lame leapers (n) for N, A, Z, and D directions, i.e., nN, nA, nZ, and nD
+# - friendly-jumping sliders (y) which may move over own pieces
 
 ### Piece values
 # The predefined and precalculated piece values can be overridden


### PR DESCRIPTION
## Summary
- add `friendlyJump` field in `PieceInfo`
- parse new Betza modifier `y` for sliders ignoring friendly blockers
- support `friendlyJump` in move and attack generation
- document new modifier in `variants.ini`

## Testing
- `make -j build ARCH=x86-64-modern`
- `./stockfish check ../src/variants.ini`

------
https://chatgpt.com/codex/tasks/task_e_6840c3f1025c83309d723ead33654545