### PR TITLE
Fix Lines of Action dynamic slider

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -44,7 +44,7 @@ namespace {
             b ^= pos.capture_square(to);
 
         if (pos.walling_rule() == ARROW)
-            b &= moves_bb(us, type_of(pos.piece_on(from)), to, pos.pieces() ^ from);
+            b &= moves_bb(us, type_of(pos.piece_on(from)), to, pos.pieces() ^ from, pos.pieces());
 
         //Any current or future wall variant must follow the walling region rule if set:
         b &= pos.variant()->wallingRegion[us];

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1543,7 +1543,7 @@ bool Position::pseudo_legal(const Move m) const {
       if (!(var->wallingRegion[us] & gating_square(m)) || //putting a wall on disallowed square
           wallsquares & gating_square(m)) //or square already with a wall
           return false;
-      if (walling_rule() == ARROW && !(moves_bb(us, type_of(pc), to, pieces() ^ from) & gating_square(m)))
+      if (walling_rule() == ARROW && !(moves_bb(us, type_of(pc), to, pieces() ^ from, pieces()) & gating_square(m)))
           return false;
       if (walling_rule() == PAST && (from != gating_square(m)))
           return false;

--- a/src/position.h
+++ b/src/position.h
@@ -1484,13 +1484,13 @@ inline Square Position::castling_rook_square(CastlingRights cr) const {
 
 inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s) const {
   if (var->fastAttacks || var->fastAttacks2)
-      return attacks_bb(c, pt, s, byTypeBB[ALL_PIECES]) & board_bb();
+      return attacks_bb(c, pt, s, byTypeBB[ALL_PIECES], byTypeBB[ALL_PIECES]) & board_bb();
 
   PieceType movePt = pt == KING ? king_type() : pt;
   Bitboard occupancy = byTypeBB[ALL_PIECES];
   if (pieceMap.find(movePt)->second->friendlyJump)
       occupancy &= ~pieces(c);
-  Bitboard b = attacks_bb(c, movePt, s, occupancy);
+  Bitboard b = attacks_bb(c, movePt, s, occupancy, byTypeBB[ALL_PIECES]);
   // Xiangqi soldier
   if (pt == SOLDIER && !(promoted_soldiers(c) & s))
       b &= file_bb(file_of(s));
@@ -1498,14 +1498,14 @@ inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s) const {
   if (pt == JANGGI_CANNON)
   {
       b &= ~pieces(pt);
-      b &= attacks_bb(c, pt, s, pieces() ^ pieces(pt));
+      b &= attacks_bb(c, pt, s, pieces() ^ pieces(pt), byTypeBB[ALL_PIECES]);
   }
   // Janggi palace moves
   if (diagonal_lines() & s)
   {
       PieceType diagType = movePt == WAZIR ? FERS : movePt == SOLDIER ? PAWN : movePt == ROOK ? BISHOP : NO_PIECE_TYPE;
       if (diagType)
-          b |= attacks_bb(c, diagType, s, pieces()) & diagonal_lines();
+          b |= attacks_bb(c, diagType, s, pieces(), byTypeBB[ALL_PIECES]) & diagonal_lines();
       else if (movePt == JANGGI_CANNON)
           b |=  rider_attacks_bb<RIDER_CANNON_DIAG>(s, pieces())
               & rider_attacks_bb<RIDER_CANNON_DIAG>(s, pieces() ^ pieces(pt))
@@ -1573,16 +1573,16 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
     }
 
   if (var->fastAttacks || var->fastAttacks2)
-      return (moves_bb(c, pt, s, byTypeBB[ALL_PIECES]) | extraDestinations) & board_bb();
+      return (moves_bb(c, pt, s, byTypeBB[ALL_PIECES], byTypeBB[ALL_PIECES]) | extraDestinations) & board_bb();
 
   PieceType movePt = pt == KING ? king_type() : pt;
   Bitboard occupancy = byTypeBB[ALL_PIECES];
   if (pieceMap.find(movePt)->second->friendlyJump)
       occupancy &= ~pieces(c);
-  Bitboard b = (moves_bb(c, movePt, s, occupancy) | extraDestinations);
+  Bitboard b = (moves_bb(c, movePt, s, occupancy, byTypeBB[ALL_PIECES]) | extraDestinations);
   // Add initial moves
   if (double_step_region(c, pt) & s)
-      b |= moves_bb<true>(c, movePt, s, occupancy);
+      b |= moves_bb<true>(c, movePt, s, occupancy, byTypeBB[ALL_PIECES]);
 
   // Xiangqi soldier
   if (pt == SOLDIER && !(promoted_soldiers(c) & s))
@@ -1591,14 +1591,14 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
   if (pt == JANGGI_CANNON)
   {
       b &= ~pieces(pt);
-      b &= attacks_bb(c, pt, s, pieces() ^ pieces(pt));
+      b &= attacks_bb(c, pt, s, pieces() ^ pieces(pt), byTypeBB[ALL_PIECES]);
   }
   // Janggi palace moves
   if (diagonal_lines() & s)
   {
       PieceType diagType = movePt == WAZIR ? FERS : movePt == SOLDIER ? PAWN : movePt == ROOK ? BISHOP : NO_PIECE_TYPE;
       if (diagType)
-          b |= attacks_bb(c, diagType, s, pieces()) & diagonal_lines();
+          b |= attacks_bb(c, diagType, s, pieces(), byTypeBB[ALL_PIECES]) & diagonal_lines();
       else if (movePt == JANGGI_CANNON)
           b |=  rider_attacks_bb<RIDER_CANNON_DIAG>(s, pieces())
               & rider_attacks_bb<RIDER_CANNON_DIAG>(s, pieces() ^ pieces(pt))


### PR DESCRIPTION
## Summary
- handle dynamic slider piece counts correctly
- pass full occupancy to move generation helpers
- allow LOA pieces to jump over own men while counting all pieces

## Testing
- `make -j build ARCH=x86-64-modern`
- `python test.py` *(fails: ModuleNotFoundError: No module named 'pyffish')*


------
https://chatgpt.com/codex/tasks/task_e_6840dcea8fc0833087ba8dacd03f22ff