### PR TITLE
Fix CTF evaluation ratio without truncation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1210,10 +1210,14 @@ namespace {
         {
             int wins = popcount(ctfTargets & ctfPieces);
             if (wins)
+            {
                 //score went overflow in a test of tafl
                 //original code may not be intended for such a mobile flag piece with so many flag squares
                 //this may need to be rethought
-                score += make_score(4000, 4000) * (wins / (wins + dist * dist));
+                int denom = wins + dist * dist;
+                int ctfBonus = (4000 * wins) / denom;
+                score += make_score(ctfBonus, ctfBonus);
+            }
             Bitboard current = ctfPieces & ~ctfTargets;
             processed |= ctfPieces;
             ctfPieces = onHold & ~processed;


### PR DESCRIPTION
## Summary
- compute the capture-the-flag bonus using integer arithmetic before constructing the score so the distance weighting is preserved without overflow

## Testing
- make -j build ARCH=x86-64-modern *(fails: missing dropRegion/promotion_pawn_type declarations in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68ca616cf7d483308c133c52c2948ce4