### PR TITLE
Fix boardKey sync, suppress strong-pawn warnings, and fix alterga test

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -3837,8 +3837,10 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
 
       if (givesCountingCheck)
       {
-          st->key ^= Zobrist::checks[us][st->checksRemaining[us]]
+          Key diff = Zobrist::checks[us][st->checksRemaining[us]]
                   ^  Zobrist::checks[us][st->checksRemaining[us] - 1];
+          st->key ^= diff;
+          st->boardKey ^= diff;
           --st->checksRemaining[us];
       }
   }

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -647,6 +647,7 @@ startFen = rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1
 
 # https://www.chessvariants.com/diffmove.dir/strongpawn.html
 [strong-pawn:chess]
+pieceToCharTable = -
 customPiece1 = t:W
 customPiece2 = s:ffN
 customPiece3 = c:F

--- a/test.py
+++ b/test.py
@@ -733,6 +733,8 @@ customPiece2 = b:mFfWcB
 customPiece3 = r:mWcRfF
 customPiece4 = q:BmRcN
 customPiece5 = k:FmWcNisO2
+castling = false
+startFen = rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1
 """
         )
 


### PR DESCRIPTION
This PR addresses several issues identified during code review:

1. **boardKey synchronization**: Fixed a bug in `do_move` where `boardKey` was not updated when `key` was modified for 3-check like variants. This ensures correct repetition detection in variants using `boardKey` (e.g., Crazyhouse variants).
2. **strong-pawn warnings**: Suppressed "Missing piece type" warnings in `variants.ini` for the `strong-pawn` variant by setting `pieceToCharTable = -`.
3. **altergaproto test fix**: Fixed the FEN validation failure in `test.py` for `altergaproto` by correctly setting `castling = false` and providing an appropriate `startFen` without castling rights.