### PR TITLE
Fix chaturanga-payagunda piece definition and anti-royal logic inversion

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1757,8 +1757,8 @@ Bitboard Position::checked_anti_royals(Color c) const {
   while (antiRoyals)
   {
       Square sr = pop_lsb(antiRoyals);
-      if (!(blastOnCapture && (vulnerableEnemyRoyals & blast_pattern(sr)))
-          && attackers_to(sr, occupied, ~c))
+      if (!(attackers_to(sr, occupied, ~c))
+          || (blastOnCapture && (vulnerableEnemyRoyals & blast_pattern(sr))))
           checked |= sr;
   }
   return checked;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -1902,6 +1902,7 @@ knight = n
 king = k
 bishop = b
 alfil = a
+fers = f
 doubleStep = false
 castling = false
 promotionRegionWhite = *8

--- a/tests/signature.sh
+++ b/tests/signature.sh
@@ -10,8 +10,9 @@ error()
 trap 'error ${LINENO}' ERR
 
 # obtain
+ENGINE=${ENGINE:-./stockfish}
 
-signature=`./stockfish bench 2>&1 | grep "Nodes searched  : " | awk '{print $4}'`
+signature=`${ENGINE} bench 2>&1 | grep "Nodes searched  : " | awk '{print $4}'`
 
 if [ $# -gt 0 ] && [ -n "$1" ]; then
    # compare to given reference


### PR DESCRIPTION
This PR fixes two bugs identified during a bug sweep:
1. Missing fers = f in chaturanga-payagunda which caused FEN validation failure in tests.
2. Logic inversion in Position::checked_anti_royals which caused incorrect checkmate detection for anti-royal pieces.
3. Updated tests/signature.sh to handle the engine path correctly via ENGINE environment variable.