### PR TITLE
Parser: reject incompatible rule combinations

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1329,11 +1329,11 @@ void VariantParser<DoCheck>::check_consistency(Variant* v) {
         std::cerr << "connect3D/connect4D currently require connectN = 3." << std::endl;
 
     // Check for limitations
-    if ((v->pieceDrops || v->freeDrops) && v->wallingRule)
+    if ((v->pieceDrops || v->freeDrops) && v->wallingRule != NO_WALLING)
         std::cerr << "pieceDrops and any walling are incompatible." << std::endl;
-    if (v->wallingRule && v->seirawanGating)
+    if (v->wallingRule != NO_WALLING && v->seirawanGating)
         std::cerr << "wallingRule and seirawanGating are incompatible." << std::endl;
-    if (v->wallingRule && v->potions)
+    if (v->wallingRule != NO_WALLING && v->potions)
         std::cerr << "wallingRule and potions are incompatible." << std::endl;
     if (v->wallingRule == DUCK && v->petrifyOnCaptureTypes)
         std::cerr << "wallingRule=duck and petrifyOnCaptureTypes are incompatible." << std::endl;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1329,8 +1329,14 @@ void VariantParser<DoCheck>::check_consistency(Variant* v) {
         std::cerr << "connect3D/connect4D currently require connectN = 3." << std::endl;
 
     // Check for limitations
-    if (v->pieceDrops && v->wallingRule)
+    if ((v->pieceDrops || v->freeDrops) && v->wallingRule)
         std::cerr << "pieceDrops and any walling are incompatible." << std::endl;
+    if (v->wallingRule && v->seirawanGating)
+        std::cerr << "wallingRule and seirawanGating are incompatible." << std::endl;
+    if (v->wallingRule && v->potions)
+        std::cerr << "wallingRule and potions are incompatible." << std::endl;
+    if (v->wallingRule == DUCK && v->petrifyOnCaptureTypes)
+        std::cerr << "wallingRule=duck and petrifyOnCaptureTypes are incompatible." << std::endl;
 
     // Options incompatible with royal kings
     if (v->pieceTypes & KING)

--- a/tests/parser-regressions.sh
+++ b/tests/parser-regressions.sh
@@ -31,6 +31,22 @@ piecePoints =
 promotionLimit =
 priorityDropTypes =
 virtualDropLimit =
+
+[walling-seirawan:chess]
+wallingRule = duck
+seirawanGating = true
+
+[walling-potions:chess]
+wallingRule = duck
+potions = true
+
+[duck-petrify:chess]
+wallingRule = duck
+petrifyOnCaptureTypes = p
+
+[walling-freedrops:chess]
+wallingRule = duck
+freeDrops = true
 INI
 
 echo "parser regression tests started"
@@ -43,6 +59,26 @@ fi
 
 if printf '%s\n' "${check_output}" | grep -Eq "piecePoints - Invalid piece type: $|promotionLimit - Invalid piece type: $|priorityDropTypes - Invalid piece type: $|virtualDropLimit - Invalid piece type: $"; then
   echo "${check_output}"
+  exit 1
+fi
+
+if ! echo "${check_output}" | grep -q "wallingRule and seirawanGating are incompatible."; then
+  echo "Failed: seirawanGating check"
+  exit 1
+fi
+
+if ! echo "${check_output}" | grep -q "wallingRule and potions are incompatible."; then
+  echo "Failed: potions check"
+  exit 1
+fi
+
+if ! echo "${check_output}" | grep -q "wallingRule=duck and petrifyOnCaptureTypes are incompatible."; then
+  echo "Failed: petrify check"
+  exit 1
+fi
+
+if ! echo "${check_output}" | grep -q "pieceDrops and any walling are incompatible."; then
+  echo "Failed: freeDrops check"
   exit 1
 fi
 

--- a/tests/parser-regressions.sh
+++ b/tests/parser-regressions.sh
@@ -52,35 +52,38 @@ INI
 echo "parser regression tests started"
 
 check_output=$("${ENGINE}" check "${tmp_ini}" 2>&1 || true)
-if echo "${check_output}" | grep -Eq "PieceTypeBitboardGroup declaration|Invalid value.*whitePieceDropRegion|Error parsing|unterminated"; then
-  echo "${check_output}"
+
+# Fail if output contains unexpected internal errors
+if printf '%s\n' "${check_output}" | grep -Eq "PieceTypeBitboardGroup declaration|Invalid value.*whitePieceDropRegion|Error parsing|unterminated"; then
+  echo "Unexpected error in parser output:"
+  printf '%s\n' "${check_output}"
   exit 1
 fi
 
+# Fail if output contains empty field errors (these shouldn't happen for empty fields anymore)
 if printf '%s\n' "${check_output}" | grep -Eq "piecePoints - Invalid piece type: $|promotionLimit - Invalid piece type: $|priorityDropTypes - Invalid piece type: $|virtualDropLimit - Invalid piece type: $"; then
-  echo "${check_output}"
+  echo "Detected empty field error which should be ignored:"
+  printf '%s\n' "${check_output}"
   exit 1
 fi
 
-if ! echo "${check_output}" | grep -q "wallingRule and seirawanGating are incompatible."; then
-  echo "Failed: seirawanGating check"
-  exit 1
-fi
+# Verify new incompatibility warnings
+verify_warning() {
+  local pattern="$1"
+  local label="$2"
+  if ! printf '%s\n' "${check_output}" | grep -qF "${pattern}"; then
+    echo "Failed: ${label}"
+    echo "Expected warning not found: ${pattern}"
+    echo "Full output was:"
+    printf '%s\n' "${check_output}"
+    exit 1
+  fi
+}
 
-if ! echo "${check_output}" | grep -q "wallingRule and potions are incompatible."; then
-  echo "Failed: potions check"
-  exit 1
-fi
-
-if ! echo "${check_output}" | grep -q "wallingRule=duck and petrifyOnCaptureTypes are incompatible."; then
-  echo "Failed: petrify check"
-  exit 1
-fi
-
-if ! echo "${check_output}" | grep -q "pieceDrops and any walling are incompatible."; then
-  echo "Failed: freeDrops check"
-  exit 1
-fi
+verify_warning "wallingRule and seirawanGating are incompatible." "seirawanGating check"
+verify_warning "wallingRule and potions are incompatible." "potions check"
+verify_warning "wallingRule=duck and petrifyOnCaptureTypes are incompatible." "petrify check"
+verify_warning "pieceDrops and any walling are incompatible." "freeDrops check"
 
 tuple_output=$(cat <<CMDS | "${ENGINE}" 2>&1
 uci
@@ -92,8 +95,9 @@ quit
 CMDS
 )
 
-if echo "${tuple_output}" | grep -q "No piece char found for custom piece"; then
-  echo "${tuple_output}"
+if printf '%s\n' "${tuple_output}" | grep -q "No piece char found for custom piece"; then
+  echo "Tuple test failed:"
+  printf '%s\n' "${tuple_output}"
   exit 1
 fi
 
@@ -105,14 +109,16 @@ quit
 CMDS
 )
 
-if ! echo "${terminal_output}" | grep -q "bestmove (none)"; then
-  echo "${terminal_output}"
+if ! printf '%s\n' "${terminal_output}" | grep -q "bestmove (none)"; then
+  echo "Terminal position test failed:"
+  printf '%s\n' "${terminal_output}"
   exit 1
 fi
 
 bench_output=$("${ENGINE}" bench 16 1 1 default nonsense 2>&1 || true)
-if ! echo "${bench_output}" | grep -q "Nodes searched  : "; then
-  echo "${bench_output}"
+if ! printf '%s\n' "${bench_output}" | grep -q "Nodes searched  : "; then
+  echo "Bench test failed:"
+  printf '%s\n' "${bench_output}"
   exit 1
 fi
 


### PR DESCRIPTION
This PR adds checks to the variant parser to reject rule combinations that are incompatible or irreconcilable, such as wallingRule with seirawanGating, potions, or petrifyOnCaptureTypes. These combinations either conflict in move encoding or cause synchronization issues in the board state.