### PR TITLE
Fix interactions between unorthodox rules

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -112,14 +112,14 @@ namespace {
     *moveList++ = make<T>(from, to, pt);
 
     // Gating moves
-    if (pos.seirawan_gating() && (pos.gates(us) & from))
+    if (pos.seirawan_gating() && (pos.gates(us) & from) && !pos.rifle_capture(make<T>(from, to, pt)))
         for (PieceSet ps = pos.piece_types(); ps;)
         {
             PieceType pt_gating = pop_lsb(ps);
             if (pos.can_drop(us, pt_gating) && (pos.drop_region(us, pt_gating) & from))
                 *moveList++ = make_gating<T>(from, to, pt_gating, from);
         }
-    if (pos.seirawan_gating() && T == CASTLING && (pos.gates(us) & to))
+    if (pos.seirawan_gating() && T == CASTLING && (pos.gates(us) & to) && !pos.rifle_capture(make<T>(from, to, pt)))
         for (PieceSet ps = pos.piece_types(); ps;)
         {
             PieceType pt_gating = pop_lsb(ps);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -3691,7 +3691,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   st->capturedPiece = captured;
 
   // Add gating piece
-  if (is_gating(m))
+  if (is_gating(m) && !rifleShot)
   {
       Square gate = gating_square(m);
       Piece gating_piece = make_piece(us, gating_type(m));
@@ -3726,7 +3726,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   }
 
   // Musketeer gating
-  if(commit_gates()){
+  if(commit_gates() && !rifleShot){
       {
           Rank r = rank_of(from);
           if (us == WHITE && r == RANK_1 && has_committed_piece(WHITE, file_of(from))){
@@ -4119,7 +4119,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           givesCheck = bool(attackers_to_king(square<KING>(them), us) & pieces(us));
   }
 
-  if (trigger_matches(var->changingColorTrigger, captured != NO_PIECE)
+  if (trigger_matches(var->changingColorTrigger, captured != NO_PIECE || st->bycatchSquares != 0)
       && !is_pass(m)
       && type_of(m) != DROP
       && piece_on(moverSq) != NO_PIECE

--- a/tests/unorthodox-interactions.sh
+++ b/tests/unorthodox-interactions.sh
@@ -90,6 +90,16 @@ extinctionValue = win
 extinctionPieceTypes = q
 checking = false
 startFen = 4k3/8/8/8/8/8/3Qq3/4S2K w - - 0 1
+
+[rifle-gating:chess]
+rifleCapture = true
+gating = true
+seirawanGating = true
+
+[surround-color:chess]
+surroundCaptureIntervene = true
+changingColorTrigger = capture
+changingColorPieceTypes = *
 EOF
 
 echo "unorthodox interactions tests started"
@@ -177,6 +187,24 @@ out=$(run_cmds "iron-extinction" "${TEMP_INI}" "position fen 4k3/8/8/8/8/8/3Qq3/
 go perft 1")
 if echo "${out}" | grep -q "^e2e1:"; then
   echo "captureForbidden iron-piece suppression for black failed"
+  exit 1
+fi
+
+# 15. Test rifleCapture + gating (ensure piece is NOT overwritten)
+# Move White King from e1 to e2 (rifle capture). It should NOT gate on e1.
+out=$(run_cmds "rifle-gating" "${TEMP_INI}" "position fen r3k2r/8/8/8/8/8/4q3/4K3[B] w KQkq - 0 1
+go perft 1")
+if echo "${out}" | grep -q "e1e2b:"; then
+  echo "rifleCapture + gating bug: gating move was generated"
+  exit 1
+fi
+
+# 16. Test surroundCapture + changingColor (ensure color change triggers on bycatch)
+# White King moves from e2 to e3, between black pawns on d3 and f3.
+out=$(run_cmds "surround-color" "${TEMP_INI}" "position fen 4k3/8/8/8/8/3p1p2/4K3/8 w - - 0 1 moves e2e3
+d")
+if ! echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/4k3/8/8 b"; then
+  echo "surroundCapture + changingColor bug: color change did not trigger"
   exit 1
 fi
 


### PR DESCRIPTION
This PR fixes two significant issues when combining unorthodox rules:

1. **rifleCapture + gating (Musketeer and Seirawan)**: Prevents piece overwriting. Previously, if a piece performed a rifle capture (staying on its original square) from a gating square, the gated piece would overwrite the capturer. Now, gating is skipped for rifle captures since the square was not vacated.
2. **surroundCapture + changingColorTrigger = capture**: Ensures that bycatch captures (surround capture, blast, etc.) correctly trigger the color change. Previously, only direct captures were counted.

New tests have been added to `tests/unorthodox-interactions.sh` to verify these fixes.