### PR TITLE
Fix Rose pin logic for toroidal and cylindrical boards

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -752,7 +752,9 @@ namespace {
                     PieceType checkerPt = type_of(pos.piece_on(checksq));
                     Bitboard checkerMask = square_bb(checksq);
                     Bitboard t = (AttackRiderTypes[checkerPt] & RIDER_ROSE)
-                               ? rose_between_intersection_bb(ksq, checksq, pos.pieces())
+                               ? (pos.topology_wraps()
+                               ? Position::wrapped_rose_between_intersection_bb(ksq, checksq, pos.pieces(), pos.max_file(), pos.max_rank(), pos.wraps_files(), pos.wraps_ranks())
+                               : rose_between_intersection_bb(ksq, checksq, pos.pieces()))
                                : between_bb(ksq, checksq, checkerPt);
 
                     bool blockableNightrider = AttackRiderTypes[checkerPt] & RIDER_NIGHTRIDER;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1694,6 +1694,7 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
         blockers |= b;
         continue;
     }
+
     bool isHopper = AttackRiderTypes[sniperType] & HOPPING_RIDERS;
     Bitboard b = between_bb(s, sniperSq, sniperType) & (isHopper ? (allPieces ^ sniperSq) : occupancy);
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -144,14 +144,29 @@ namespace {
     return false;
   }
 
-  Bitboard rose_revealed_blockers(Square target, Square attackerSq, Bitboard occupied) {
+  Bitboard rose_revealed_blockers(const Position& pos, Square target, Square attackerSq, Bitboard occupied) {
     Bitboard blockers = 0;
-    Bitboard candidates = rose_between_union_bb(target, attackerSq, Bitboard(0)) & occupied & ~square_bb(attackerSq);
+    const bool wrapFile = pos.wraps_files();
+    const bool wrapRank = pos.wraps_ranks();
+    const File maxF = pos.max_file();
+    const Rank maxR = pos.max_rank();
+
+    Bitboard candidates;
+    if (pos.topology_wraps())
+        candidates = Position::wrapped_rose_between_union_bb(target, attackerSq, Bitboard(0), maxF, maxR, wrapFile, wrapRank) & occupied & ~square_bb(attackerSq);
+    else
+        candidates = rose_between_union_bb(target, attackerSq, Bitboard(0)) & occupied & ~square_bb(attackerSq);
 
     while (candidates)
     {
         Square blocker = pop_lsb(candidates);
-        if (rose_attacks_bb(attackerSq, occupied ^ square_bb(blocker)) & target)
+        Bitboard attacks;
+        if (pos.topology_wraps())
+            attacks = Position::wrapped_rose_targets(attackerSq, occupied ^ square_bb(blocker), maxF, maxR, wrapFile, wrapRank, false);
+        else
+            attacks = rose_attacks_bb(attackerSq, occupied ^ square_bb(blocker));
+
+        if (attacks & target)
             blockers |= blocker;
     }
 
@@ -1673,7 +1688,7 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
     PieceType sniperType = type_of(sniper);
     if (AttackRiderTypes[sniperType] & RIDER_ROSE)
     {
-        Bitboard b = rose_revealed_blockers(s, sniperSq, occupancy);
+        Bitboard b = rose_revealed_blockers(*this, s, sniperSq, occupancy);
         if (b && !more_than_one(b))
             pinners |= pieces(c) & sniperSq;
         blockers |= b;

--- a/src/position.h
+++ b/src/position.h
@@ -140,6 +140,16 @@ class Thread;
 
 class Position {
 public:
+  static Bitboard wrapped_rose_targets(Square sq, Bitboard occupied,
+                                        File maxFile, Rank maxRank,
+                                        bool wrapFile, bool wrapRank,
+                                        bool quietMode);
+  static Bitboard wrapped_rose_between_union_bb(Square from, Square to, Bitboard occupied,
+                                                 File maxFile, Rank maxRank,
+                                                 bool wrapFile, bool wrapRank);
+  static Bitboard wrapped_rose_between_intersection_bb(Square from, Square to, Bitboard occupied,
+                                                        File maxFile, Rank maxRank,
+                                                        bool wrapFile, bool wrapRank);
   static void init();
 
   Position() = default;
@@ -556,14 +566,8 @@ private:
                                              File maxFile, Rank maxRank,
                                              bool wrapFile, bool wrapRank,
                                              bool quietMode);
-  static Bitboard wrapped_rose_targets(Square sq, Bitboard occupied,
-                                        File maxFile, Rank maxRank,
-                                        bool wrapFile, bool wrapRank,
-                                        bool quietMode);
-  static Bitboard wrapped_rose_between_union_bb(Square from, Square to, Bitboard occupied,
-                                                 File maxFile, Rank maxRank,
-                                                 bool wrapFile, bool wrapRank);
-  static Bitboard special_rider_bb(const PieceInfo* pi, MoveModality modality,                                   Square sq, Bitboard occupied,
+  static Bitboard special_rider_bb(const PieceInfo* pi, MoveModality modality,
+                                   Square sq, Bitboard occupied,
                                    Bitboard occupiedAll, Bitboard ownPieces,
                                    Color c, bool captureMode);
 
@@ -2603,6 +2607,45 @@ inline Bitboard Position::wrapped_rose_between_union_bb(Square from, Square to, 
       }
 
   return pathUnion;
+}
+
+inline Bitboard Position::wrapped_rose_between_intersection_bb(Square from, Square to, Bitboard occupied,
+                                                               File maxFile, Rank maxRank,
+                                                               bool wrapFile, bool wrapRank) {
+  Bitboard pathIntersection = 0;
+  bool found = false;
+
+  for (int start = 0; start < 8; ++start)
+      for (int turn : {-1, 1})
+      {
+          Square current = from;
+          int index = start;
+          Bitboard path = 0;
+          for (int leg = 0; leg < 7; ++leg)
+          {
+              Square next = SQ_NONE;
+              if (!wrapped_destination_square(current,
+                                              RoseSteps[index].second,
+                                              RoseSteps[index].first,
+                                              maxFile, maxRank, wrapFile, wrapRank, next))
+                  break;
+              if (next == from)
+                  break;
+              path |= next;
+              if (next == to)
+              {
+                  pathIntersection = found ? (pathIntersection & path) : path;
+                  found = true;
+                  break;
+              }
+              if (occupied & next)
+                  break;
+              current = next;
+              index = (index + turn + 8) % 8;
+          }
+      }
+
+  return pathIntersection;
 }
 
 inline Bitboard Position::special_rider_bb(const PieceInfo* pi, MoveModality modality,

--- a/src/position.h
+++ b/src/position.h
@@ -557,11 +557,13 @@ private:
                                              bool wrapFile, bool wrapRank,
                                              bool quietMode);
   static Bitboard wrapped_rose_targets(Square sq, Bitboard occupied,
-                                       File maxFile, Rank maxRank,
-                                       bool wrapFile, bool wrapRank,
-                                       bool quietMode);
-  static Bitboard special_rider_bb(const PieceInfo* pi, MoveModality modality,
-                                   Square sq, Bitboard occupied,
+                                        File maxFile, Rank maxRank,
+                                        bool wrapFile, bool wrapRank,
+                                        bool quietMode);
+  static Bitboard wrapped_rose_between_union_bb(Square from, Square to, Bitboard occupied,
+                                                 File maxFile, Rank maxRank,
+                                                 bool wrapFile, bool wrapRank);
+  static Bitboard special_rider_bb(const PieceInfo* pi, MoveModality modality,                                   Square sq, Bitboard occupied,
                                    Bitboard occupiedAll, Bitboard ownPieces,
                                    Color c, bool captureMode);
 
@@ -2564,6 +2566,43 @@ inline Bitboard Position::wrapped_rose_targets(Square from, Bitboard occupied,
       }
 
   return attack;
+}
+
+inline Bitboard Position::wrapped_rose_between_union_bb(Square from, Square to, Bitboard occupied,
+                                                        File maxFile, Rank maxRank,
+                                                        bool wrapFile, bool wrapRank) {
+  Bitboard pathUnion = 0;
+
+  for (int start = 0; start < 8; ++start)
+      for (int turn : {-1, 1})
+      {
+          Square current = from;
+          int index = start;
+          Bitboard path = 0;
+          for (int leg = 0; leg < 7; ++leg)
+          {
+              Square next = SQ_NONE;
+              if (!wrapped_destination_square(current,
+                                              RoseSteps[index].second,
+                                              RoseSteps[index].first,
+                                              maxFile, maxRank, wrapFile, wrapRank, next))
+                  break;
+              if (next == from)
+                  break;
+              path |= next;
+              if (next == to)
+              {
+                  pathUnion |= path;
+                  break;
+              }
+              if (occupied & next)
+                  break;
+              current = next;
+              index = (index + turn + 8) % 8;
+          }
+      }
+
+  return pathUnion;
 }
 
 inline Bitboard Position::special_rider_bb(const PieceInfo* pi, MoveModality modality,

--- a/test_cmds.txt
+++ b/test_cmds.txt
@@ -1,0 +1,6 @@
+uci
+setoption name VariantPath value /tmp/fsx-rose-toroidal-1YK4cb.ini
+setoption name UCI_Variant value rose-toroidal-4x4
+position startpos
+d
+quit

--- a/test_cmds_eval.txt
+++ b/test_cmds_eval.txt
@@ -1,0 +1,6 @@
+uci
+setoption name VariantPath value /tmp/fsx-rose-toroidal-1YK4cb.ini
+setoption name UCI_Variant value rose-toroidal-8x8
+position startpos
+eval
+quit

--- a/tests/rose-toroidal-pin.sh
+++ b/tests/rose-toroidal-pin.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+error() {
+  echo "rose-toroidal-pin regression failed on line $1"
+  [[ -n "${TMP_VARIANT_PATH:-}" ]] && rm -f "${TMP_VARIANT_PATH}"
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+ENGINE=${1:-./stockfish}
+
+TMP_VARIANT_PATH=$(mktemp /tmp/fsx-rose-toroidal-XXXXXX.ini)
+# Standard 8x8 board, toroidal.
+cat >"${TMP_VARIANT_PATH}" <<'INI'
+[rose-toroidal-8x8:chess]
+toroidal = true
+customPiece1 = a:rose
+pieceToCharTable = A:a
+# A1 King at (0,0)
+# Step {df=1, dr=2}
+# Path from G5 (6,4):
+# Step 1: {1,2} -> (7,6) H7.
+# Step 2: {1,2} -> (0,0) A1.
+# So G5 attacks A1 via H7.
+# Rank 7: ....... (8)
+# Rank 6: .......P (7P) -> H7 is white pawn
+# Rank 5: ......a. (6a1) -> G5 is black rose
+# Rank 1: K....... (K7)
+startFen = 8/8/7P/6a1/8/8/8/K7 w - - 0 1
+INI
+
+get_legal_moves() {
+  local variant="$1"
+  "${ENGINE}" <<CMDS
+uci
+setoption name VariantPath value ${TMP_VARIANT_PATH}
+setoption name UCI_Variant value ${variant}
+position startpos
+go perft 1
+quit
+CMDS
+}
+
+echo "rose-toroidal-pin test started"
+
+moves=$(get_legal_moves rose-toroidal-8x8)
+echo "MOVES START"
+echo "${moves}"
+echo "MOVES END"
+
+# If h7 is pinned to a1 by rose on g5 via wrapping:
+# (G5 -> H7 -> A1)
+# H7 cannot move. h7h8 should be illegal.
+if echo "${moves}" | grep -q "h7h8"; then
+  echo "FAILURE: Pawn on h7 is NOT recognized as pinned (can move to h8)"
+  exit 1
+fi
+
+rm -f "${TMP_VARIANT_PATH}"
+unset TMP_VARIANT_PATH
+
+echo "rose-toroidal-pin test passed"


### PR DESCRIPTION
The current implementation of pins and blockers for cylindrical and toroidal boards was missing wrapping support for Rose pieces (circular nightriders). This PR adds `wrapped_rose_between_union_bb` and updates `rose_revealed_blockers` to use wrapping-aware functions when appropriate.