### PR TITLE
Fix changingColor interaction with passive burners and drops

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -4407,9 +4407,8 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           givesCheck = bool(attackers_to_king(square<KING>(them), us) & pieces(us));
   }
 
-  if (trigger_matches(var->changingColorTrigger, captured != NO_PIECE || st->bycatchSquares != 0)
+  if (trigger_matches(var->changingColorTrigger, captured != NO_PIECE || (st->bycatchSquares & blast_pattern(moverSq)))
       && !is_pass(m)
-      && !dropMove
       && piece_on(moverSq) != NO_PIECE
       && color_of(piece_on(moverSq)) == us
       && (var->changingColorPieceTypes & type_of(piece_on(moverSq))))

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -254,6 +254,8 @@
 # symmetricDropTypes: drop two identical pieces at once onto horizontally paired squares; UCI uses piece@sq1,sq2 [PieceSet] (default: none)
 # captureMorph: capturing piece morphs into captured piece type [bool] (default: false)
 # rexExclusiveMorph: kings do not morph when captureMorph is enabled [bool] (default: false)
+# changingColorTrigger: condition for changing piece color (e.g., for Andernach chess) [capture, non-capture, always, never] (default: never)
+# changingColorPieceTypes: piece types affected by changingColorTrigger [PieceSet] (default: none)
 # captureForbidden: forbidden capture pairs attacker:targets, e.g. q:k b:pn *:i [str] (default: )
 # captureAllowed: remove captureForbidden pairs (applied after captureForbidden), same format [str] (default: )
 # petrifyOnCaptureTypes: defined pieces are turned into wall squares when capturing [PieceSet] (default: -)


### PR DESCRIPTION
This PR fixes two issues with the `changingColor` rule:
1. It now correctly triggers for drop captures (previously it was explicitly disabled for all drop moves).
2. It now only triggers if the moving piece was actually involved in a capture (direct or bycatch). Previously, a remote passive burner blasting an enemy piece would trigger a color change for the moving piece, even if it was unrelated.

Also added documentation for `changingColorTrigger` and `changingColorPieceTypes` in `variants.ini`.