### PR TITLE
Fix walling for igui and rifle captures

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -67,17 +67,25 @@ namespace {
     //if it's "wall or move", and they chose non-null move, skip even generating wall move
     if (pos.walling(us) && !(pos.wall_or_move() && (from!=to)))
     {
-        Bitboard b = pos.board_bb() & ~((pos.pieces() ^ from) | to);
+        bool iguiShot = T == SPECIAL && from != to;
+        bool rifleShot = pos.rifle_capture(make<T>(from, to, pt)) && (T == NORMAL || T == PROMOTION);
+        Square effectiveTo = (rifleShot || iguiShot) ? from : to;
+        Square capSq = T == EN_PASSANT ? pos.capture_square(to)
+                     : pos.is_jump_capture(make<T>(from, to, pt)) ? pos.jump_capture_square(from, to)
+                     : pos.capture(make<T>(from, to, pt)) ? to
+                     : SQ_NONE;
+
+        Bitboard occupancyAfter = pos.pieces();
+        if (from != effectiveTo) occupancyAfter ^= square_bb(from) ^ square_bb(effectiveTo);
+        if (capSq != SQ_NONE) occupancyAfter ^= square_bb(capSq);
+
+        Bitboard b = pos.board_bb() & ~occupancyAfter & ~square_bb(to);
         if (T == CASTLING)
         {
             Square kto = make_square(to > from ? pos.castling_kingside_file() : pos.castling_queenside_file(), pos.castling_rank(us));
             Square rto = kto - (to > from ? EAST : WEST);
-            b ^= square_bb(to) ^ kto ^ rto;
+            b ^= square_bb(to) ^ square_bb(kto) ^ square_bb(rto);
         }
-        Square capsq = T == EN_PASSANT ? pos.capture_square(to)
-                     : pos.jump_capture_square(from, to);
-        if (capsq != SQ_NONE && capsq != to)
-            b ^= capsq;
 
         // Duck is by far the hottest walling mode: avoid extra rule checks.
         if (pos.walling_rule() == DUCK)
@@ -89,7 +97,7 @@ namespace {
         }
 
         if (pos.walling_rule() == ARROW)
-            b &= moves_bb(us, type_of(pos.piece_on(from)), to, pos.pieces() ^ from);
+            b &= moves_bb(us, type_of(pos.piece_on(from)), effectiveTo, occupancyAfter ^ square_bb(effectiveTo));
 
         //Any current or future wall variant must follow the walling region rule if set:
         b &= pos.walling_region(us);
@@ -887,7 +895,7 @@ namespace {
                     Square from = pop_lsb(movers);
                     Bitboard adjacent = pos.attacks_from(Us, KING, from) & captureTarget;
                     while (adjacent)
-                        *moveList++ = make<SPECIAL>(from, pop_lsb(adjacent));
+                        moveList = make_move_and_gating<SPECIAL>(pos, moveList, Us, from, pop_lsb(adjacent));
                 }
             }
         }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2837,15 +2837,18 @@ bool Position::pseudo_legal(const Move m) const {
   if (walling(us) && (!wall_or_move() || (from == to)))
   {
       Bitboard wallsquares = st->wallSquares;
-      Square capSq = capture(m) ? capture_square(m) : to;
+      Square capSq = capture(m) ? capture_square(m) : SQ_NONE;
+      Bitboard occupancyAfter = pieces();
+      if (from != effectiveTo) occupancyAfter ^= square_bb(from) ^ square_bb(effectiveTo);
+      if (capSq != SQ_NONE) occupancyAfter ^= square_bb(capSq);
 
       // Illegal wall square placement
-      if (!((board_bb() & ~(((pieces() ^ from) ^ capSq) | to)) & gating_square(m)))
+      if (!((board_bb() & ~occupancyAfter) & gating_square(m)))
           return false;
       if (!(walling_region(us) & gating_square(m)) || //putting a wall on disallowed square
           wallsquares & gating_square(m)) //or square already with a wall
           return false;
-      if (walling_rule() == ARROW && !(moves_bb(us, type_of(pc), to, pieces() ^ from) & gating_square(m)))
+      if (walling_rule() == ARROW && !(moves_bb(us, type_of(pc), effectiveTo, occupancyAfter ^ square_bb(effectiveTo)) & gating_square(m)))
           return false;
       if (walling_rule() == PAST && (from != gating_square(m)))
           return false;

--- a/src/types.h
+++ b/src/types.h
@@ -1126,11 +1126,12 @@ inline PieceType gating_type(Move m) {
 
 inline Square gating_square(Move m) {
   const uint64_t raw = static_cast<uint64_t>(m);
-  return Square((raw >> (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS)) & SQUARE_BIT_MASK);
+  return Square(((raw >> (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS)) & SQUARE_BIT_MASK) - 1);
 }
 
 inline bool is_gating(Move m) {
-  return gating_type(m) && (type_of(m) == NORMAL || type_of(m) == CASTLING);
+  const MoveType mt = type_of(m);
+  return (mt != DROP && mt != DROP2) && ((m >> (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS)) & SQUARE_BIT_MASK);
 }
 
 inline bool is_drop_move(Move m) {
@@ -1186,7 +1187,7 @@ constexpr Move reverse_move(Move m) {
 
 template<MoveType T>
 constexpr Move make_gating(Square from, Square to, PieceType pt, Square gate) {
-  return Move((static_cast<uint64_t>(gate) << (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS))
+  return Move((static_cast<uint64_t>(gate + 1) << (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS))
             + (static_cast<uint64_t>(pt) << (2 * SQUARE_BITS + MOVE_TYPE_BITS))
             + static_cast<uint64_t>(T)
             + (static_cast<uint64_t>(from) << SQUARE_BITS)

--- a/tests/unorthodox-interactions.sh
+++ b/tests/unorthodox-interactions.sh
@@ -100,6 +100,10 @@ seirawanGating = true
 surroundCaptureIntervene = true
 changingColorTrigger = capture
 changingColorPieceTypes = *
+
+[rifle-amazon:chess]
+rifleCapture = true
+wallingRule = arrow
 EOF
 
 echo "unorthodox interactions tests started"
@@ -205,6 +209,17 @@ out=$(run_cmds "surround-color" "${TEMP_INI}" "position fen 4k3/8/8/8/8/3p1p2/4K
 d")
 if ! echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/4k3/8/8 b"; then
   echo "surroundCapture + changingColor bug: color change did not trigger"
+  exit 1
+fi
+
+# 17. Test rifleCapture + arrow walling (ensure arrow shot from origin)
+# White Queen at e1, Black Pawn at e2. rifle capture e1e2, shoot arrow to e3.
+# h5 is NOT reachable from e1 (origin) but IS from e2 (if it was moved there).
+# e1-h5: 7 files, 4 ranks (NO). e2-h5: 3 files, 3 ranks (YES).
+out=$(run_cmds "rifle-amazon" "${TEMP_INI}" "position fen 4k3/8/8/7p/8/8/4p3/4Q1K1 w - - 0 1
+go perft 1")
+if echo "${out}" | grep -q "e1e2,h5"; then
+  echo "rifleCapture + arrow walling bug: arrow shot from victim square"
   exit 1
 fi
 


### PR DESCRIPTION
This PR fixes several bugs in the interaction between walling rules (like Amazons or Duck Chess) and unorthodox capture types (igui and rifle captures).

1.  **Bug in movegen.cpp**: `igui` captures were skipping the walling phase in move generation.
2.  **Bug in movegen.cpp**: `ARROW` walling occupancy and square were incorrect for `igui` and `rifle` captures (shot from the victim square instead of the actual piece position).
3.  **Bug in position.cpp**: `legal()` walling check was using incorrect occupancy for `igui` and `rifle` captures.
4.  **Bug in types.h**: `is_gating()` was rejecting `SPECIAL` moves (like `igui` captures) even if they had walling bits.
5.  **Bug in types.h**: `SQ_A1` (0) was indistinguishable from "no gate" in `is_gating()`. Fixed by using `gate + 1` encoding.