### PR TITLE
Add Anti-King Chess variants I and II

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -684,8 +684,17 @@ namespace {
 
         Bitboard attacks = pos.attacks_from(Us, Pt, from);
         Bitboard quiets = pos.moves_from(Us, Pt, from);
-        Bitboard captureSquares = (attacks & pos.pieces()) & captureTarget;
+        Bitboard ptCaptureTarget = captureTarget;
+        if (pos.anti_royal_types() & Pt)
+        {
+            ptCaptureTarget = pos.pieces(Us) & ~pos.pieces(Us, pos.king_type());
+            // Also ensure we don't try to move to empty squares using the capture logic
+            // (though attacks & pos.pieces() already handles this).
+        }
+        Bitboard captureSquares = (attacks & pos.pieces()) & ptCaptureTarget;
         Bitboard quietSquares   = (quiets & ~pos.pieces()) & target;
+        if (pos.anti_royal_types() & Pt)
+            quietSquares &= ~pos.pieces(~Us); // Cannot move to enemy occupied squares
         Bitboard b = captureSquares | quietSquares;
         Bitboard epSquares = (pos.en_passant_types(Us) & Pt) ? (attacks & pos.ep_squares() & ~pos.pieces()) : Bitboard(0);
         Bitboard b1 = b & ~epSquares;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2349,6 +2349,25 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard j
   if (b & pieces(SOLDIER) && relative_rank(c, s, max_rank()) < var->soldierPromotionRank)
       b ^= b & pieces(SOLDIER) & ~PseudoAttacks[~c][SHOGI_PAWN][s];
 
+  if (anti_royal_types())
+  {
+      Bitboard akPieces = 0;
+      for (PieceSet ps = anti_royal_types(); ps; )
+          akPieces |= pieces(c, pop_lsb(ps));
+
+      // 1. Anti-King of side c only attacks friendly pieces of side c.
+      if (is_ok(s) && !(pieces(c) & s))
+          b &= ~akPieces;
+
+      Bitboard enemyAkPieces = 0;
+      for (PieceSet ps = anti_royal_types(); ps; )
+          enemyAkPieces |= pieces(~c, pop_lsb(ps));
+
+      // 2. King of side c doesn't attack enemy side ~c's Anti-King at square s.
+      if (is_ok(s) && (enemyAkPieces & s))
+          b &= ~pieces(c, king_type());
+  }
+
   return b;
 }
 
@@ -2498,7 +2517,8 @@ Bitboard Position::checked_anti_royals(Color c) const {
               while (antiRoyals)
               {
                   Square sr = pop_lsb(antiRoyals);
-                  if (!(attackers_to(sr, occupied, ~c))
+                  Bitboard attackers = attackers_to(sr, occupied, ~c);
+                  if (!(attackers & ~pieces(~c, king_type()))
                       || (blastOnCapture && (vulnerableEnemyRoyals & blast_pattern(sr))))
                       checked |= sr;
               }
@@ -3057,9 +3077,10 @@ bool Position::legal(Move m) const {
       while (antiRoyals)
       {
           Square sr = pop_lsb(antiRoyals);
+          Bitboard attackers = attackers_to(sr, occupied, ~us);
           if (!(occupied & sr)
               || (blastOnCapture && (vulnerableEnemyRoyals & blast_pattern(sr)))
-              || !(attackers_to(sr, occupied, ~us) & ~removedAttackers))
+              || !((attackers & ~pieces(~us, king_type())) & ~removedAttackers))
               return false;
       }
   }
@@ -3589,13 +3610,17 @@ bool Position::pseudo_legal(const Move m) const {
   // self-capture is enabled. Friendly kings remain uncapturable.
   if ((pieces(us) & to) && !is_self_destruct(m))
   {
-      if (!pushMove && !(self_capture() && capture(m)))
+      if (!pushMove && !((self_capture() || (anti_royal_types() & type_of(pc))) && capture(m)))
           return false;
-      if (type_of(piece_on(to)) == KING)
+      if (type_of(piece_on(to)) == KING || (anti_royal_types() & type_of(piece_on(to))))
           return false;
   }
 
-  if ((topology_wraps() || pushMove) && !allow_checks() && (pieces(them) & to) && type_of(piece_on(to)) == KING)
+  // Anti-King cannot capture enemy pieces.
+  if ((anti_royal_types() & type_of(pc)) && (pieces(them) & to) && !is_self_destruct(m))
+      return false;
+
+  if ((topology_wraps() || pushMove) && !allow_checks() && (pieces(them) & to) && (type_of(piece_on(to)) == KING || (anti_royal_types() & type_of(piece_on(to)))))
       return false;
 
   // Handle the special case of a pawn move
@@ -4078,8 +4103,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   assert(captured == NO_PIECE
          || (type_of(m) == CASTLING ? color_of(captured) == us
                                     : (color_of(captured) == them
-                                       || (self_capture() && color_of(captured) == us))));
-  assert(type_of(captured) != KING || allow_checks());
+                                       || ((self_capture() || (anti_royal_types() & type_of(pc))) && color_of(captured) == us))));  assert(type_of(captured) != KING || allow_checks());
 
   auto trigger_matches = [](ColorChangeTrigger trigger, bool isCapture) {
       switch (trigger)

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -3786,3 +3786,29 @@ doubleStepRegionBlack = *8 *7
 enPassantTypes = gu
 pseudoRoyalTypes = uacml
 pseudoRoyalValue = loss
+
+
+[anti-king-1]
+variantTemplate = fairy
+maxFile = 8
+maxRank = 8
+startFen = 2prbkqA/2p1nnbr/2pppppp/8/8/PPPPPP2/RBNN1P2/aQKBRP2 w - - 0 1
+pieceSpecificDoubleStepRegion = true
+whitePieceDoubleStepRegion = K(c1);A(h8);
+blackPieceDoubleStepRegion = K(f8);A(a1);
+king = k:K imN
+customPiece1 = a:K imN
+antiRoyalTypes = a
+antiRoyalCount = 1
+pawn = p:fmFcfW
+promotionPieceTypes = nbrq
+castling = false
+
+[anti-king-2]
+variantTemplate = fairy
+maxFile = 8
+maxRank = 8
+startFen = rnbqkbnr/pppppppp/3A4/8/8/3a4/PPPPPPPP/RNBQKBNR w - - 0 1
+customPiece1 = a:K
+antiRoyalTypes = a
+antiRoyalCount = 1


### PR DESCRIPTION
This PR implements the Anti-King Chess variants as described by Peter Aronson. Includes core engine changes for anti-royal pieces and two new variant definitions in variants.ini.