### PR TITLE
Refactor: Unify blast and capturer-dies logic

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1462,10 +1462,8 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
         parse_attribute("selfCaptureBlack", v->selfCaptureByColor[BLACK]);
         v->selfCaptureByColorSet[BLACK] = true;
     }
-    parse_attribute("capturerDiesOnCapture", v->capturerDiesOnCapture);
-    parse_attribute("capturerDiesOnSameTypeCapture", v->capturerDiesOnSameTypeCapture);
-    parse_attribute("capturerDiesExemptTypes", v->capturerDiesExemptTypes, v);
-    parse_attribute("capturerDiesExemptPawns", v->capturerDiesExemptPawns);
+    parse_attribute("blastOrthogonals", v->blastOrthogonals);
+    parse_attribute("blastOnSameTypeCapture", v->blastOnSameTypeCapture);
     parse_attribute("captureMorph", v->captureMorph);
     parse_attribute("rexExclusiveMorph", v->rexExclusiveMorph);
     parse_attribute("mustDrop", v->mustDrop);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2899,7 +2899,7 @@ bool Position::legal(Move m) const {
   // Check for attacks to pseudo-royal pieces
   if (pseudo_royal_types())
   {
-      const bool blastOnCapture = blast_on_capture();
+      const bool blastOnCapture = blast_on_capture(m);
       Square kto = rifleShot ? from : to;
       Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? shotSq : kto;
       Bitboard occupied = rifleShot ? pieces() : (!dropMove ? pieces() ^ from : pieces());
@@ -2999,7 +2999,7 @@ bool Position::legal(Move m) const {
   // Anti-royal pieces must remain under attack.
   if (anti_royal_types())
   {
-      const bool blastOnCapture = blast_on_capture();
+      const bool blastOnCapture = blast_on_capture(m);
       Square kto = rifleShot ? from : to;
       Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? shotSq : kto;
       Square rfrom = SQ_NONE, rto = SQ_NONE;
@@ -3171,7 +3171,7 @@ bool Position::legal(Move m) const {
   Bitboard removedByEffects = 0;
   if (!is_pass(m))
   {
-      if (((capture(m) || rifleShot) && blast_on_capture())
+      if (((capture(m) || rifleShot) && blast_on_capture(m))
           || (blast_on_move() && !capture(m) && !is_self_destruct(m))
           || (blast_on_self_destruct() && is_self_destruct(m)))
       {
@@ -3991,7 +3991,6 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   Square from = from_sq(m);
   Square to = to_sq(m);
   Piece pc = moved_piece(m);
-  PieceType movedType = type_of(pc);
   Piece captured = captured_piece(m);
   PushInfo pushInfo;
   bool pushMove = analyze_push(*this, m, pushInfo);
@@ -5043,7 +5042,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   if (
        (
          ( surround_capture_opposite() || surround_capture_intervene() || surround_capture_edge() ) ||
-         ( captured && (blast_on_capture() || var->petrifyOnCaptureTypes) ) ||
+         ( captured && (blast_on_capture() || var->petrifyOnCaptureTypes || var->deathOnCaptureTypes) ) ||
          ( blast_on_move() && !captured && !is_self_destruct(m) ) ||
          ( blast_on_self_destruct() && is_self_destruct(m) ) ||
          var->blastPassiveTypes ||
@@ -5061,12 +5060,12 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       st->promotedBycatch = st->demotedBycatch = Bitboard(0);
       st->blastPromotedSquares = 0;
 
-      if ( ( captured && (blast_on_capture() || var->petrifyOnCaptureTypes) ) ||
+      if ( ( captured && (blast_on_capture(m) || var->petrifyOnCaptureTypes || var->deathOnCaptureTypes) ) ||
            ( blast_on_move() && !captured && !is_self_destruct(m) ) ||
            ( blast_on_self_destruct() && is_self_destruct(m) ) ) {
 
-          blast_mask = (blast_on_capture() || blast_on_move() || blast_on_self_destruct()) ? blast_squares(captured ? st->captureSquare : to)
-              : (var->petrifyOnCaptureTypes & type_of(pc) ? square_bb(moverSq) : Bitboard(0));
+          blast_mask = (blast_on_capture(m) || blast_on_move() || blast_on_self_destruct()) ? blast_squares(captured ? st->captureSquare : to)
+              : ((var->petrifyOnCaptureTypes | var->deathOnCaptureTypes) & type_of(pc) ? square_bb(moverSq) : Bitboard(0));
           removal_mask |= blast_mask;
       };
 
@@ -5325,6 +5324,13 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
               byTypeBB[ALL_PIECES] |= bsq;
               k ^= Zobrist::wall[bsq];
           }
+
+          if (bsq == to && bool(var->deathOnCaptureTypes & type_of(bpc)))
+          {
+              st->deadSquares |= bsq;
+              byTypeBB[ALL_PIECES] |= bsq;
+              k ^= Zobrist::dead[bsq];
+          }
       };
   };
 
@@ -5344,55 +5350,6 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       st->wallSquares |= gating_square(m);
       byTypeBB[ALL_PIECES] |= gating_square(m);
       k ^= Zobrist::wall[gating_square(m)];
-  }
-
-  // Shared helper for "piece removed from its destination square" effects that
-  // are not normal captures (e.g. capturer-dies or death-on-capture).
-  auto remove_destination_piece_no_capture_effects = [&](Square sq, bool makeDeadSquare) {
-      Piece deadPiece = piece_on(sq);
-      Color dc = color_of(deadPiece);
-
-      st->deadPiece = deadPiece;
-      st->deadPiecePromoted = is_promoted(sq);
-      st->deadUnpromotedPiece = st->deadPiecePromoted ? unpromoted_piece_on(sq) : NO_PIECE;
-
-      if (Eval::useNNUE)
-          append_dirty(st, deadPiece, sq, SQ_NONE);
-
-      remove_piece(sq);
-      board[sq] = NO_PIECE;
-
-      k ^= Zobrist::psq[deadPiece][sq];
-      st->materialKey ^= Zobrist::psq[deadPiece][pieceCount[deadPiece]];
-      if (type_of(deadPiece) == PAWN)
-          st->pawnKey ^= Zobrist::psq[deadPiece][sq];
-      else
-          st->nonPawnMaterial[dc] -= PieceValue[MG][deadPiece];
-
-      if (makeDeadSquare)
-      {
-          st->deadSquares |= sq;
-          byTypeBB[ALL_PIECES] |= sq;
-          k ^= Zobrist::dead[sq];
-      }
-  };
-
-  bool diesOnSameTypeCapture = var->capturerDiesOnSameTypeCapture
-                            && captured != NO_PIECE
-                            && type_of(captured) == movedType;
-  bool exemptFromCapturerDeath = (var->capturerDiesExemptTypes & piece_set(movedType))
-                              || (var->capturerDiesExemptPawns && movedType == PAWN);
-  bool diesOnCapture = (death_on_capture_types() & piece_set(movedType))
-                    || (var->capturerDiesOnCapture && !exemptFromCapturerDeath)
-                    || diesOnSameTypeCapture;
-  if (!capturedDeadSquare && captured != NO_PIECE && !dropMove && diesOnCapture
-      && piece_on(moverSq) != NO_PIECE)
-  {
-      bool makeDeadSquare = bool(death_on_capture_types() & piece_set(movedType));
-      remove_destination_piece_no_capture_effects(moverSq, makeDeadSquare);
-
-      if (!allow_checks() && givesCheck && count<KING>(them))
-          givesCheck = bool(attackers_to_king(square<KING>(them), us) & pieces(us));
   }
 
   Bitboard localBycatch = st->bycatchSquares & (blast_pattern(moverSq) | square_bb(moverSq));
@@ -5645,7 +5602,7 @@ void Position::undo_move(Move m) {
   // Add the blast pieces
   if (
        ( surround_capture_opposite() || surround_capture_intervene() || surround_capture_edge() ) ||
-       ( st->capturedPiece && (blast_on_capture() || var->petrifyOnCaptureTypes) ) ||
+       ( st->capturedPiece && (blast_on_capture(st->move) || var->petrifyOnCaptureTypes || var->deathOnCaptureTypes) ) ||
        ( blast_on_move() && !st->capturedPiece && !is_self_destruct(st->move) ) ||
        ( blast_on_self_destruct() && is_self_destruct(st->move) ) ||
        ( remove_connect_n() > 0 )
@@ -6215,7 +6172,7 @@ bool Position::see_ge(Move m, Value threshold) const {
       return true;
 
   // Atomic explosion SEE
-  if (blast_on_capture() || blast_on_move() || (blast_on_self_destruct() && is_self_destruct(m)))
+  if (blast_on_capture(m) || blast_on_move() || (blast_on_self_destruct() && is_self_destruct(m)))
       return blast_see(m) >= threshold;
 
   Piece victim = captured_piece(m);

--- a/src/position.h
+++ b/src/position.h
@@ -206,10 +206,12 @@ public:
   bool mandatory_piece_promotion() const;
   bool piece_demotion() const;
   bool blast_on_capture() const;
+  bool blast_on_capture(Move m) const;
   bool blast_on_move() const;
   bool blast_on_self_destruct() const;
   bool blast_promotion() const;
   bool blast_diagonals() const;
+  bool blast_orthogonals() const;
   bool blast_center() const;
   PieceSet blast_immune_types() const;
   PieceSet death_on_capture_types() const;
@@ -906,6 +908,14 @@ inline bool Position::blast_on_capture() const {
   return var->blastOnCapture;
 }
 
+inline bool Position::blast_on_capture(Move m) const {
+  assert(var != nullptr);
+  if (blast_on_capture()) return true;
+  if (!var->blastOnSameTypeCapture || !capture(m)) return false;
+  Piece captured = captured_piece(m);
+  return captured != NO_PIECE && type_of(captured) == type_of(moved_piece(m));
+}
+
 inline bool Position::blast_on_move() const {
   assert(var != nullptr);
   return var->blastOnMove;
@@ -924,6 +934,11 @@ inline bool Position::blast_promotion() const {
 inline bool Position::blast_diagonals() const {
   assert(var != nullptr);
   return var->blastDiagonals;
+}
+
+inline bool Position::blast_orthogonals() const {
+  assert(var != nullptr);
+  return var->blastOrthogonals;
 }
 
 inline bool Position::blast_center() const {
@@ -951,7 +966,9 @@ inline Bitboard Position::blast_immune_bb() const {
 }
 
 inline Bitboard Position::blast_pattern(Square to) const {
-    Bitboard blastPattern = blast_diagonals() ?  attacks_bb<KING>(to) : attacks_bb<WAZIR>(to);
+    Bitboard blastPattern = 0;
+    if (blast_diagonals()) blastPattern |= attacks_bb<KING>(to) & ~attacks_bb<WAZIR>(to);
+    if (blast_orthogonals()) blastPattern |= attacks_bb<WAZIR>(to);
     return blastPattern;
 }
 

--- a/src/variant.h
+++ b/src/variant.h
@@ -182,10 +182,8 @@ struct Variant {
   bool selfCapture = false;
   bool selfCaptureByColor[COLOR_NB] = {false, false};
   bool selfCaptureByColorSet[COLOR_NB] = {false, false};
-  bool capturerDiesOnCapture = false;
-  bool capturerDiesOnSameTypeCapture = false;
-  bool capturerDiesExemptPawns = false;
-  PieceSet capturerDiesExemptTypes = NO_PIECE_SET;
+  bool blastOnSameTypeCapture = false;
+  bool blastOrthogonals = true;
   bool mustDrop = false;
   bool mustDropByColor[COLOR_NB] = {false, false};
   PieceType mustDropType = ALL_PIECES;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -248,7 +248,9 @@
 # selfDestructTypes: same-square `SPECIAL` moves like a2a2x that trigger blastOnMove without relocating [PieceSet] (default: none)
 # blastPromotion: blast promotes pieces instead of destroying them [bool] (default: false)
 # blastDiagonals: are diagonals included in blast [bool] (default: true)
+# blastOrthogonals: are orthogonals included in blast [bool] (default: true)
 # blastCenter: is the center square included in blast [bool] (default: true)
+# blastOnSameTypeCapture: if capture target has same piece type, triggers a zero-range blast removing the capturing piece [bool] (default: false)
 # blastPassiveTypes: pieces of these types passively blast adjacent enemy pieces after moves [PieceSet] (default: none)
 # blastImmuneTypes: pieces completely immune to explosions (even at ground zero) [PieceSet] (default: none)
 # mutuallyImmuneTypes: pieces that can't capture another piece of same types (e.g., kings (commoners) in atomar) [PieceSet] (default: none)
@@ -330,10 +332,6 @@
 # mustCaptureWhite: captures mandatory for white side only [bool] (default: false)
 # mustCaptureBlack: captures mandatory for black side only [bool] (default: false)
 # rifleCapture: convenience alias enabling stationary capture for all capturing pieces; explicit ^ piece definitions are preferred [bool] (default: false)
-# capturerDiesOnCapture: after any capture, the capturing piece is removed from board [bool] (default: false)
-# capturerDiesOnSameTypeCapture: if capture target has same piece type, capturing piece is removed [bool] (default: false)
-# capturerDiesExemptPawns: when capturerDiesOnCapture is enabled, pawns are exempt [bool] (default: false)
-# capturerDiesExemptTypes: piece types exempt from capturer self-destruction [PieceSet] (default: -)
 # Drops, reserves, and setup phases
 # mustDrop: drops are mandatory (e.g., for Sittuyin setup phase) [bool] (default: false)
 # mustDropWhite: drops mandatory for white side only [bool] (default: false)
@@ -2738,7 +2736,7 @@ castling = false
 captureForbidden = p:p n:n r:r q:q b:b
 
 [antimatter:chess]
-capturerDiesOnSameTypeCapture = true
+blastOnSameTypeCapture = true
 
 [benedict:benedictmorph]
 # User-facing alias for the built-in benedictmorph ruleset.
@@ -3413,11 +3411,15 @@ passOnStalemate = true
 deathOnCaptureTypes = nbrqk
 
 [kamikaze-giveaway:giveaway]
-capturerDiesOnCapture = true
+blastOnCapture = true
+blastOrthogonals = false
+blastDiagonals = false
 
 [kamikaze:chess]
-capturerDiesOnCapture = true
-capturerDiesExemptTypes = k
+blastOnCapture = true
+blastOrthogonals = false
+blastDiagonals = false
+blastImmuneTypes = k
 
 # A 10x10 drop variant consisting of only Leapers, Shogi pawns, and Kings.
 [leaperhouse]

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -2737,6 +2737,8 @@ captureForbidden = p:p n:n r:r q:q b:b
 
 [antimatter:chess]
 blastOnSameTypeCapture = true
+blastOrthogonals = false
+blastDiagonals = false
 
 [benedict:benedictmorph]
 # User-facing alias for the built-in benedictmorph ruleset.


### PR DESCRIPTION
This PR unifies the `blast` and `capturer-dies` functionalities by treating capturer-dies as a zero-range blast.

- Introduces `blastOrthogonals` to allow 0-range blasts to replicate `capturerDiesOnCapture` mechanics.
- Renames `capturerDiesOnSameTypeCapture` to `blastOnSameTypeCapture`.
- Removes redundant configuration options (`capturerDiesOnCapture`, `capturerDiesExemptPawns`, `capturerDiesExemptTypes`).
- Simplifies the core spatial logic loop in `position.cpp` by eliminating disjointed `diesOnCapture` blocks.
- Updates kamikaze and antimatter variants to use the new blast terminology.