### PR TITLE
Fix incorrect capturer death in jump/rifle captures with zero-range blast

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -3409,8 +3409,7 @@ bool Position::legal(Move m) const {
       {
           if ((capture(m) || rifleShot) && blast_on_capture(m))
           {
-              moverRemovedByBlast = zero_range_blast_on_capture(m)
-                                 || (blast_center() && effectiveTo == shotSq);
+              moverRemovedByBlast = (blast_center() && effectiveTo == shotSq);
           }
           else if ((blast_on_move() && !capture(m) && !is_self_destruct(m))
                 || (blast_on_self_destruct() && is_self_destruct(m)))
@@ -3452,7 +3451,6 @@ bool Position::legal(Move m) const {
   if (pseudo_royal_types())
   {
       const bool blastOnCapture = blast_on_capture(m);
-      const bool zeroRangeBlastOnCapture = zero_range_blast_on_capture(m);
       Square kto = rifleShot ? from : to;
       Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? shotSq : kto;
       Bitboard occupied = rifleShot ? pieces() : (!dropMove && !cloneMove ? pieces() ^ from : pieces());
@@ -3490,8 +3488,6 @@ bool Position::legal(Move m) const {
           occupied &= ~blast_squares(blastCenter);
           if (blast_immune_types() & movePt)
               occupied |= square_bb(kto);
-          else if (zeroRangeBlastOnCapture)
-              occupied &= ~square_bb(kto);
       }
       // Petrifying a pseudo-royal piece is illegal
       if (capture(m) && (var->petrifyOnCaptureTypes & type_of(moved_piece(m))) && (st->pseudoRoyals & from))
@@ -3563,7 +3559,6 @@ bool Position::legal(Move m) const {
   if (anti_royal_types())
   {
       const bool blastOnCapture = blast_on_capture(m);
-      const bool zeroRangeBlastOnCapture = zero_range_blast_on_capture(m);
       Square kto = rifleShot ? from : to;
       Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? shotSq : kto;
       Square rfrom = SQ_NONE, rto = SQ_NONE;
@@ -3589,10 +3584,7 @@ bool Position::legal(Move m) const {
           occupied &= ~blast_squares(blastCenter);
           if (blast_immune_types() & movePt)
               occupied |= square_bb(kto);
-          else if (zeroRangeBlastOnCapture)
-              occupied &= ~square_bb(kto);
       }
-
       Bitboard antiRoyals = 0;
       for (PieceSet ps = anti_royal_types(); ps; )
       {
@@ -3752,8 +3744,6 @@ bool Position::legal(Move m) const {
               removedByEffects |= square_bb(blastCenter) & blastRelevant;
           if (blast_on_capture(m) && (blast_immune_types() & movePt))
               removedByEffects &= ~square_bb(effectiveTo);
-          else if (zero_range_blast_on_capture(m))
-              removedByEffects |= square_bb(effectiveTo);
       }
 
       if ((capture(m) || rifleShot) && (var->petrifyOnCaptureTypes & movePt))
@@ -4732,7 +4722,6 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
       captured = (!stepwisePush && pushInfo.captures) ? piece_on(pushInfo.tail) : NO_PIECE;
 
   const bool blastOnCaptureMove = blast_on_capture(pc, captured);
-  const bool zeroRangeBlastOnCaptureMove = zero_range_blast_on_capture(pc, captured);
   int pushRightsMask = 0;
   int pullRightsMask = 0;
   bool rifleShot = rifle_capture(m) && captured != NO_PIECE && type_of(m) != CASTLING;
@@ -6400,8 +6389,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
       }
   };
 
-  bool diesOnCapture = (death_on_capture_types() & piece_set(movedType))
-                    || (captured != NO_PIECE && zeroRangeBlastOnCaptureMove && !(blast_immune_types() & movedType));
+  bool diesOnCapture = (death_on_capture_types() & piece_set(movedType));
   if (!capturedDeadSquare && captured != NO_PIECE && !dropMove && diesOnCapture
       && piece_on(moverSq) != NO_PIECE)
   {
@@ -7178,12 +7166,9 @@ Value Position::blast_see(Move m) const {
   Square from = from_sq(m);
   Square to = to_sq(m);
   Piece mover = moved_piece(m);
-  Piece victim = captured_piece(m);
   Color us = color_of(mover);
   Bitboard fromto = is_drop_move(m) ? square_bb(to) | (paired_drop(m) ? square_bb(secondary_drop_square(m)) : Bitboard(0)) : from | to;
   Bitboard blast = blast_squares(capture(m) ? capture_square(m) : to);
-  if (capture(m) && zero_range_blast_on_capture(mover, victim) && !(blast_immune_types() & type_of(mover)))
-      blast |= square_bb(is_drop_move(m) ? to : from);
 
   // If the explosion would capture an opponent royal or pseudo-royal piece,
   // treat the move as delivering immediate mate. This prevents the static

--- a/tests/unorthodox-interactions.sh
+++ b/tests/unorthodox-interactions.sh
@@ -51,6 +51,17 @@ rifleCapture = true
 changingColorTrigger = capture
 changingColorPieceTypes = *
 
+[jump-blast:chess]
+customPiece1 = m:c{hurdles: 1,1; pre: 1,1; post: 1,1; capture: locust_first; hurdle_types: enemy}W
+blastOnSameTypeCapture = true
+blastCenter = true
+blastOrthogonals = false
+blastDiagonals = false
+
+[jump-blast-color:jump-blast]
+changingColorTrigger = capture
+changingColorPieceTypes = *
+
 [rifle-jump:chess]
 customPiece1 = m:c{hurdles: 1,1; pre: 1,1; post: 1,1; capture: locust_first; hurdle_types: enemy}W
 rifleCapture = true
@@ -189,10 +200,10 @@ out=$(run_cmds "rifle-morph" "${TEMP_INI}" "position fen 4k3/8/8/8/8/8/4r3/3QK3 
 d")
 echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/8/8/3RK3 b"
 
-# 3. Test rifleCapture + zero-range blast-on-capture
+# 3. Test rifleCapture + zero-range blast-on-capture (shooter should survive)
 out=$(run_cmds "rifle-atomic" "${TEMP_INI}" "position fen r3k3/8/8/8/8/8/8/R3K3 w - - 0 1 moves a1a8
 d")
-echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/8/8/4K3 b"
+echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/8/8/R3K3 b"
 
 # 4. Test rifleCapture + changingColorTrigger
 out=$(run_cmds "rifle-color" "${TEMP_INI}" "position fen r3k3/8/8/8/8/8/8/R3K3 w - - 0 1 moves a1a8
@@ -366,6 +377,15 @@ if echo "${out}" | grep -q "a1c1:"; then
   echo "cylindrical + ski-slip bug: leaped over blocked square"
   exit 1
 fi
+# 26. Test jumpCapture + zero-range blast-on-capture (survives)
+out=$(run_cmds "jump-blast" "${TEMP_INI}" "position fen 4k3/8/8/8/8/8/m7/M3K3 w - - 0 1 moves a1a3
+d")
+echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/M7/8/4K3 b"
+
+# 27. Test jumpCapture + blast + changingColor (survives and changes color)
+out=$(run_cmds "jump-blast-color" "${TEMP_INI}" "position fen 4k3/8/8/8/8/8/m7/M3K3 w - - 0 1 moves a1a3
+d")
+echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/m7/8/4K3 b"
 
 rm "${TEMP_INI}"
 


### PR DESCRIPTION
This PR fixes a bug where the capturer would incorrectly die when performing a jump or rifle capture that triggered a zero-range blast (e.g. via `blastOnSameTypeCapture`). The zero-range blast should only affect the capture square, but the engine was unconditionally removing the mover even if it was not at the blast site.

Changes:
- Removed redundant and incorrect `zeroRangeBlastOnCapture` checks in `Position::legal` and `Position::do_move`.
- Removed similar incorrect check in `Position::blast_see`.
- Updated `tests/unorthodox-interactions.sh` with regression tests for jump-capture blast interactions and corrected the existing rifle-atomic test.

Verified with newly added tests in `tests/unorthodox-interactions.sh`.