### PR TITLE
Validate and reject incompatible unorthodox rules with royal kings

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1792,9 +1792,50 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
 }
 
 template <bool DoCheck>
-void VariantParser<DoCheck>::check_consistency(Variant* v) {
+bool VariantParser<DoCheck>::check_consistency(Variant* v) {
+    bool valid = true;
+    // Options incompatible with royal kings
+    if (v->pieceTypes & KING)
+    {
+        if (v->blastOnCapture) {
+            std::cerr << "Can not use kings with blastOnCapture." << std::endl;
+            valid = false;
+        }
+        if (v->blastPassiveTypes) {
+            std::cerr << "Can not use kings with blastPassiveTypes." << std::endl;
+            valid = false;
+        }
+        if (v->flipEnclosedPieces) {
+            std::cerr << "Can not use kings with flipEnclosedPieces." << std::endl;
+            valid = false;
+        }
+        if (v->removeConnectN) {
+            std::cerr << "Can not use kings with removeConnectN." << std::endl;
+            valid = false;
+        }
+        if (v->wallingRule==DUCK) {
+            std::cerr << "Can not use kings with wallingRule = duck." << std::endl;
+            valid = false;
+        }
+        // We can not fully check support for custom king movements at this point,
+        // since custom pieces are only initialized on loading of the variant.
+        // We will assume this is valid, but it might cause problems later if it's not.
+        if (!is_custom(v->kingType))
+        {
+            const PieceInfo* pi = pieceMap.find(v->kingType)->second;
+            if (   pi->hopper[0][MODALITY_QUIET].size()
+                || pi->hopper[0][MODALITY_CAPTURE].size()
+                || std::any_of(pi->steps[0][MODALITY_CAPTURE].begin(),
+                               pi->steps[0][MODALITY_CAPTURE].end(),
+                               [](const std::pair<const Direction, int>& d) { return d.second; })) {
+                std::cerr << piece_name(v->kingType) << " is not supported as kingType." << std::endl;
+                valid = false;
+            }
+        }
+    }
+
     if (!DoCheck)
-        return;
+        return valid;
 
     const bool wrapsTopology = v->cylindrical || v->toroidal;
     v->rebuild_piece_symbol_maps();
@@ -1896,31 +1937,6 @@ void VariantParser<DoCheck>::check_consistency(Variant* v) {
     if (v->wallingRule == DUCK && v->petrifyOnCaptureTypes)
         std::cerr << "wallingRule=duck and petrifyOnCaptureTypes are incompatible." << std::endl;
 
-    // Options incompatible with royal kings
-    if (v->pieceTypes & KING)
-    {
-        if (v->blastOnCapture)
-            std::cerr << "Can not use kings with blastOnCapture." << std::endl;
-        if (v->flipEnclosedPieces)
-            std::cerr << "Can not use kings with flipEnclosedPieces." << std::endl;
-        if (v->removeConnectN)
-            std::cerr << "Can not use kings with removeConnectN." << std::endl;
-        if (v->wallingRule==DUCK)
-            std::cerr << "Can not use kings with wallingRule = duck." << std::endl;
-        // We can not fully check support for custom king movements at this point,
-        // since custom pieces are only initialized on loading of the variant.
-        // We will assume this is valid, but it might cause problems later if it's not.
-        if (!is_custom(v->kingType))
-        {
-            const PieceInfo* pi = pieceMap.find(v->kingType)->second;
-            if (   pi->hopper[0][MODALITY_QUIET].size()
-                || pi->hopper[0][MODALITY_CAPTURE].size()
-                || std::any_of(pi->steps[0][MODALITY_CAPTURE].begin(),
-                               pi->steps[0][MODALITY_CAPTURE].end(),
-                               [](const std::pair<const Direction, int>& d) { return d.second; }))
-                std::cerr << piece_name(v->kingType) << " is not supported as kingType." << std::endl;
-        }
-    }
     // Options incompatible with royal kings OR pseudo-royal kings. Possible in theory though:
     // 1. In blast variants, moving a (pseudo-)royal blastImmuneType into another piece is legal.
     // 2. In blast variants, capturing a piece next to a (pseudo-)royal blastImmuneType is legal.
@@ -1943,6 +1959,7 @@ void VariantParser<DoCheck>::check_consistency(Variant* v) {
         if ((v->antiRoyalTypes & v->flagPiece[WHITE]) || (v->antiRoyalTypes & v->flagPiece[BLACK]))
             std::cerr << "Flag piece can not be anti-royal when flagPieceSafe is enabled." << std::endl;
     }
+    return valid;
 }
 
 template <bool DoCheck>
@@ -1977,7 +1994,8 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
         !parse_official_options(v))
         return nullptr;
 
-    check_consistency(v);
+    if (!check_consistency(v))
+        return nullptr;
 
     return v;
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -76,7 +76,7 @@ private:
     bool parse_piece_values(Variant* v);
     bool parse_legacy_attributes(Variant* v);
     bool parse_official_options(Variant* v);
-    void check_consistency(Variant* v);
+    bool check_consistency(Variant* v);
 
     template <typename T> bool require_attribute(bool enabled, const std::string& key, T& target);
     template <typename T, typename U> bool require_attributes(bool enabled,

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -251,7 +251,8 @@
 # blastOrthogonals: are orthogonals included in blast [bool] (default: true)
 # blastCenter: is the center square included in blast [bool] (default: true)
 # blastOnSameTypeCapture: if capture target has same piece type, trigger a zero-range blast on the capture square [bool] (default: false)
-# blastPassiveTypes: pieces of these types passively blast adjacent enemy pieces after moves [PieceSet] (default: none)
+# blastPassiveTypes: pieces of defined types passively blast adjacent enemy pieces after moves (incompatible with royal kings) [PieceSet] (default: -)
+
 # blastImmuneTypes: pieces completely immune to explosions (even at ground zero) [PieceSet] (default: none)
 # mutuallyImmuneTypes: pieces that can't capture another piece of same types (e.g., kings (commoners) in atomar) [PieceSet] (default: none)
 # deathOnCaptureTypes: capturing pieces of these types become neutral dead squares '^' [PieceSet] (default: none)
@@ -279,7 +280,7 @@
 # petrifyOnCaptureTypes: defined pieces are turned into wall squares when capturing [PieceSet] (default: -)
 # petrifyOnCaptureSuppressTransfer: petrifying captures do not also transfer captured material to hand/prison [bool] (default: false)
 # petrifyBlastPieces: if petrify and blast combined, should pieces destroyed in the blast be petrified? [bool] (default: false)
-# removeConnectN: remove n-in-a-row from board [int] (default: 0)
+# removeConnectN: remove n-in-a-row from board (incompatible with royal kings) [int] (default: 0)
 # removeConnectNByType: remove n-in-a-row by piece type, not by color [bool] (default: false)
 # surroundCaptureOpposite: enemy piece can be captured by having another of your pieces opposite it [bool] (default: false)
 # surroundCaptureIntervene: enemy piece can be captured by moving between two enemy pieces [bool] (default: false)

--- a/tests/unorthodox-interactions.sh
+++ b/tests/unorthodox-interactions.sh
@@ -15,7 +15,7 @@ run_cmds() {
   local variant="$1"
   local vpath="$2"
   local cmds="$3"
-  cat <<CMDS | "${ENGINE}"
+  cat <<CMDS | "${ENGINE}" 2>&1
 uci
 setoption name VariantPath value ${vpath}
 setoption name UCI_Variant value ${variant}
@@ -40,6 +40,10 @@ blastOnCapture = true
 blastOrthogonals = false
 blastDiagonals = false
 rifleCapture = true
+king = -
+customPiece1 = k:K
+extinctionValue = -VALUE_MATE
+extinctionPieceTypes = k
 
 [rifle-color:chess]
 rifleCapture = true
@@ -105,6 +109,12 @@ changingColorPieceTypes = *
 [rifle-amazon:chess]
 rifleCapture = true
 wallingRule = arrow
+
+[passive-king-repro:chess]
+blastPassiveTypes = n
+
+[remove-king-repro:chess]
+removeConnectN = 3
 EOF
 
 echo "unorthodox interactions tests started"
@@ -221,6 +231,28 @@ out=$(run_cmds "rifle-amazon" "${TEMP_INI}" "position fen 4k3/8/8/7p/8/8/4p3/4Q1
 go perft 1")
 if echo "${out}" | grep -q "e1e2,h5"; then
   echo "rifleCapture + arrow walling bug: arrow shot from victim square"
+  exit 1
+fi
+
+# 18. Test blastPassiveTypes + royal kings REJECTS
+out=$(run_cmds "passive-king-repro" "${TEMP_INI}" "d")
+if ! echo "${out}" | grep -q "Can not use kings with blastPassiveTypes."; then
+  echo "blastPassiveTypes + KING warning missing"
+  exit 1
+fi
+if echo "${out}" | grep -q "info string variant passive-king-repro"; then
+  echo "blastPassiveTypes + KING variant should have been rejected"
+  exit 1
+fi
+
+# 19. Test removeConnectN + royal kings REJECTS
+out=$(run_cmds "remove-king-repro" "${TEMP_INI}" "d")
+if ! echo "${out}" | grep -q "Can not use kings with removeConnectN."; then
+  echo "removeConnectN + KING warning missing"
+  exit 1
+fi
+if echo "${out}" | grep -q "info string variant remove-king-repro"; then
+  echo "removeConnectN + KING variant should have been rejected"
   exit 1
 fi
 


### PR DESCRIPTION
This PR addresses potential undefined behavior and engine crashes by validating and rejecting variant configurations that combine royal kings with incompatible unorthodox rules.

Changes:
- Prevent combining royal kings with `blastOnCapture`, `blastPassiveTypes`, `flipEnclosedPieces`, `removeConnectN`, or `wallingRule=duck`.
- Improve `VariantParser::check_consistency` to always print warnings/errors and return a boolean status.
- Update `VariantParser::parse` to return `nullptr` if consistency checks fail, effectively rejecting invalid variants.
- Update `variants.ini` documentation to mention these incompatibilities.
- Fix existing tests in `tests/unorthodox-interactions.sh` to use consistent rules (e.g., using commoner kings for Atomic-like effects).
- Add new regression tests to `tests/unorthodox-interactions.sh` to verify that invalid configurations are correctly rejected.