### PR TITLE
Fix inheritance for file-specific promotion maps

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -740,7 +740,7 @@ namespace {
                                   bool doCheck,
                                   const std::string& key) {
         std::stringstream ss(value);
-        std::array<PieceSet, FILE_NB> parsed = {};
+        std::array<PieceSet, FILE_NB> parsed = target;
         bool sawToken = false;
 
         while (true) {


### PR DESCRIPTION
Fixed a bug in `parse_file_piece_set_map` where file-specific promotion overrides (e.g., `promotionPieceTypesByFileWhite`) would overwrite the entire inherited map instead of just the specified files. The parser now initializes with the existing map, making overrides additive for the specified files only.