### PR TITLE
Fix unorthodox rules interactions and max-distance slider check detection

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -702,7 +702,7 @@ void Bitboards::init_pieces() {
                       if (limit == SKI_SLIDER_LIMIT)
                           skiDirs[d] = 0;
                       else if (limit == MAX_SLIDER_LIMIT)
-                          continue;
+                          riderDirs[d] = 0;
                       else if (limit >= 0 || is_slider_range(limit))
                           riderDirs[d] = limit;
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2011,11 +2011,16 @@ bool VariantParser<DoCheck>::check_consistency(Variant* v) {
                 break;
             }
 
-    // Check for limitations
     if (DoCheck && (v->pieceDrops || v->freeDrops) && v->wallingRule != NO_WALLING)
+    {
         std::cerr << "pieceDrops and any walling are incompatible." << std::endl;
+        valid = false;
+    }
     if (DoCheck && v->edgeInsertTypes && !v->pieceDrops)
+    {
         std::cerr << "edgeInsertTypes requires pieceDrops=true." << std::endl;
+        valid = false;
+    }
     if (DoCheck && v->openingSwapDrop
         && (!v->pieceDrops
             || !v->mustDrop
@@ -2026,13 +2031,43 @@ bool VariantParser<DoCheck>::check_consistency(Variant* v) {
             || v->twoBoards
             || v->freeDrops
             || v->edgeInsertTypes))
+    {
         std::cerr << "openingSwapDrop is only supported for simple move-out mandatory drop variants without capture drops, paired drops, self capture, free drops, edge inserts, or two-board reserves." << std::endl;
-    if (DoCheck && v->wallingRule != NO_WALLING && v->seirawanGating)
-        std::cerr << "wallingRule and seirawanGating are incompatible." << std::endl;
-    if (DoCheck && v->wallingRule != NO_WALLING && v->potions)
-        std::cerr << "wallingRule and potions are incompatible." << std::endl;
+        valid = false;
+    }
+
+    bool hasGatingPieceAfter = false;
+    for (Color c : {WHITE, BLACK})
+        for (int i = 0; i < PIECE_TYPE_NB; ++i)
+            if (v->gatingPieceAfter[c][i] != NO_PIECE_TYPE)
+                hasGatingPieceAfter = true;
+
+    if (DoCheck && v->wallingRule != NO_WALLING && (v->seirawanGating || v->potions || v->gating || hasGatingPieceAfter))
+    {
+        std::cerr << "wallingRule and gating features (seirawanGating, potions, gating, gatingPieceAfter) are incompatible." << std::endl;
+        valid = false;
+    }
     if (DoCheck && v->wallingRule == DUCK && v->petrifyOnCaptureTypes)
+    {
         std::cerr << "wallingRule=duck and petrifyOnCaptureTypes are incompatible." << std::endl;
+        valid = false;
+    }
+
+    if (DoCheck && hasGatingPieceAfter && (v->seirawanGating || v->potions || v->gating))
+    {
+        std::cerr << "gatingPieceAfter and other gating features (seirawanGating, potions, gating) are incompatible." << std::endl;
+        valid = false;
+    }
+    if (DoCheck && v->seirawanGating && (v->potions || v->gating))
+    {
+        std::cerr << "seirawanGating and other gating features (potions, gating) are incompatible." << std::endl;
+        valid = false;
+    }
+    if (DoCheck && v->potions && v->gating)
+    {
+        std::cerr << "potions and gating are incompatible." << std::endl;
+        valid = false;
+    }
 
     // Options incompatible with royal kings
     if (hasRoyalKing)
@@ -2086,13 +2121,25 @@ bool VariantParser<DoCheck>::check_consistency(Variant* v) {
     if (DoCheck && (v->pseudoRoyalTypes || v->antiRoyalTypes || hasRoyalKing))
     {
         if (v->blastImmuneTypes) //I may have this solved now.
+        {
             std::cerr << "Can not use kings, pseudo-royal, or anti-royal with blastImmuneTypes." << std::endl;
+            valid = false;
+        }
         if (v->mutuallyImmuneTypes)
+        {
             std::cerr << "Can not use kings, pseudo-royal, or anti-royal with mutuallyImmuneTypes." << std::endl;
+            valid = false;
+        }
         if (v->antiRoyalTypes & v->pseudoRoyalTypes)
+        {
             std::cerr << "Piece can not be both pseudo-royal and anti-royal." << std::endl;
+            valid = false;
+        }
         if (v->antiRoyalTypes & KING)
+        {
             std::cerr << "Piece can not be both royal king and anti-royal." << std::endl;
+            valid = false;
+        }
     }
     if (v->flagPieceSafe)
     {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2290,14 +2290,14 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard j
               while (asymmetricals)
               {
                   Square s2 = pop_lsb(asymmetricals);
-                  if (attacks_bb(c, move_pt, s2, occupied) & s)
+                  if (attacks_from(c, move_pt, s2, occupied) & s)
                       b |= s2;
               }
           }
           else if (pt == JANGGI_CANNON)
-              b |= attacks_bb(~c, move_pt, s, occupied) & attacks_bb(~c, move_pt, s, occupied & ~janggiCannons) & pieces(c, JANGGI_CANNON);
+              b |= attacks_from(~c, move_pt, s, occupied) & attacks_from(~c, move_pt, s, occupied & ~janggiCannons) & pieces(c, JANGGI_CANNON);
           else
-              b |= attacks_bb(~c, move_pt, s, occupied) & pieces(c, pt);
+              b |= attacks_from(~c, move_pt, s, occupied) & pieces(c, pt);
       }
   }
 

--- a/src/position.h
+++ b/src/position.h
@@ -3188,7 +3188,7 @@ inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s, Bitboard
 
   Bitboard b = attacks_bb(c, movePt, s, occupancy);
 
-  b |= Position::special_rider_bb(pi, MODALITY_CAPTURE, s, occupancy, byTypeBB[ALL_PIECES], pieces(c), c, true, true);
+  b |= Position::special_rider_bb(pi, MODALITY_CAPTURE, s, occupancy, occupancy, pieces(c), c, true, true);
 
   if (pi->friendlyJump)
       b &= ~pieces(c);          // never hit our own men


### PR DESCRIPTION
This PR addresses several issues with unorthodox rule interactions in Fairy-Stockfish:

1. **Walling + Gating Incompatibility**: The parser now rejects variants that combine `wallingRule` with other gating features (`seirawanGating`, `gatingPieceAfter`, `potions`, `gating`), as they conflict in the `Move` encoding and behave incorrectly in `do_move`.
2. **Max-distance Slider Check Detection**: Fixed a bug where max-distance sliders (`z` modifier) were not correctly detected as checkers. This involved filling `PseudoAttacks` bitboards for these pieces and ensuring `attackers_to` uses `attacks_from` which handles special riders.
3. **Parser Correctness**: Ensured that several existing incompatibility checks actually set `valid = false`, preventing invalid variants from being loaded.
4. **Occupancy in special riders**: Updated `Position::attacks_from` to use the provided occupancy for special rider calculations.

Verified with regression tests.