### PR TITLE
Fix pushingStrength with gating, add tests

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -211,7 +211,7 @@ namespace {
                              PushTempPiece* outTransfers = nullptr,
                              int* outTransferCount = nullptr) {
     const MoveType mt = type_of(m);
-    if (mt != NORMAL || is_gating(m) || pos.topology_wraps())
+    if (mt != NORMAL || pos.topology_wraps())
         return false;
 
     Square from = from_sq(m);
@@ -367,7 +367,7 @@ namespace {
 
   bool analyze_push_direct(const Position& pos, Move m, PushInfo& info) {
     const MoveType mt = type_of(m);
-    if ((mt != NORMAL && mt != INSERT) || is_gating(m))
+    if ((mt != NORMAL && mt != INSERT))
         return false;
     if (pos.topology_wraps())
         return false;

--- a/tests/unorthodox-interactions.sh
+++ b/tests/unorthodox-interactions.sh
@@ -329,7 +329,7 @@ fi
 # 22. Test pushingStrength + gating (ensure gating correctly pushes)
 out=$(run_cmds "push-gating" "${TEMP_INI}" "position fen n3k2n/8/8/8/8/8/8/R2p3K[N] w Qkq - 0 1 moves a1e1n
 d")
-if ! echo "${out}" | grep -q "Fen: n3k2n/8/8/8/8/8/8/N2pR2K"; then
+if ! echo "${out}" | grep -q "Fen: n3k2n/8/8/8/8/8/8/N3Rp1K"; then
   echo "pushingStrength + gating bug: piece was not correctly pushed"
   exit 1
 fi


### PR DESCRIPTION
Fixes a bug where pushing moves combined with gating moves would fail to apply the push correctly. Added regression tests for pushingStrength + gating and pushingStrength + petrifyOnCapture.