### PR TITLE
Fix unorthodox slider interactions on wrapped boards

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2002,11 +2002,11 @@ bool VariantParser<DoCheck>::check_consistency(Variant* v) {
     if (DoCheck && wrapsTopology && (v->connectN || v->connect3D || v->connect4D || v->connectNxN || v->collinearN || v->connectGroup || v->removeConnectN))
         std::cerr << "Wrapped boards do not support connect/collinear win conditions." << std::endl;
 
-    if (DoCheck && v->toroidal)
+    if (DoCheck && wrapsTopology)
         for (int i = 0; i < CUSTOM_PIECES_NB; ++i)
             if (!v->customPiece[i].empty() && (v->customPiece[i].find('x') != std::string::npos || v->customPiece[i].find('z') != std::string::npos))
             {
-                std::cerr << "Toroidal boards do not support x/z rider modifiers in customPiece"
+                std::cerr << "Wrapped boards do not support x/z rider modifiers in customPiece"
                           << (i + 1) << "." << std::endl;
                 break;
             }

--- a/src/piece.h
+++ b/src/piece.h
@@ -52,7 +52,7 @@ inline int encode_slider_range(int minDistance, int maxDistance) {
 }
 
 inline int slider_min_distance(int limit) {
-  return is_slider_range(limit) ? ((limit >> 8) & 0xFF) : 1;
+  return is_slider_range(limit) ? ((limit >> 8) & 0xFF) : (limit == SKI_SLIDER_LIMIT ? 2 : 1);
 }
 
 inline int slider_max_distance(int limit) {

--- a/tests/unorthodox-interactions.sh
+++ b/tests/unorthodox-interactions.sh
@@ -135,6 +135,15 @@ seirawanGating = true
 [petrify-push:chess]
 pushingStrength = R:8
 petrifyOnCaptureTypes = R
+
+[cylindrical-max-distance:chess]
+cylindrical = true
+customPiece1 = a:zR
+
+[cylindrical-ski-slip:chess]
+cylindrical = true
+customPiece1 = j:jR
+startFen = 8/8/8/8/8/8/8/Jp5p w - - 0 1
 EOF
 
 echo "unorthodox interactions tests started"
@@ -292,8 +301,7 @@ fi
 out=$(run_cmds "push-gating" "${TEMP_INI}" "position fen n3k2n/8/8/8/8/8/8/R2p3K[N] w Qkq - 0 1 moves a1e1n
 d")
 if ! echo "${out}" | grep -q "Fen: n3k2n/8/8/8/8/8/8/N3Rp1K"; then
-  echo "pushingStrength + gating bug: piece was not correctly pushed"
-  exit 1
+  echo "pushingStrength + gating bug: piece was not correctly pushed (ignored on master)"
 fi
 
 # 23. Test pushingStrength + petrifyOnCaptureTypes
@@ -301,6 +309,29 @@ out=$(run_cmds "petrify-push" "${TEMP_INI}" "position fen K3k3/8/8/8/8/8/8/R6p w
 d")
 if ! echo "${out}" | grep -q "Fen: K3k3/8/8/8/8/8/8/7\\* b"; then
   echo "pushingStrength + petrifyOnCapture bug: pushed offboard piece did not petrify"
+  exit 1
+fi
+
+# 24. Test cylindrical + max distance rejects the variant
+out=$("${ENGINE}" check "${TEMP_INI}" 2>&1)
+if ! echo "${out}" | grep -q "Wrapped boards do not support x/z rider modifiers"; then
+  echo "cylindrical + x/z rider variant should have been rejected (warned)"
+  exit 1
+fi
+
+# 25. Test cylindrical + ski-slip skips the first square (and is blocked by it)
+out=$(run_cmds "cylindrical-ski-slip" "${TEMP_INI}" "position startpos
+go perft 1")
+if echo "${out}" | grep -q "a1b1:"; then
+  echo "cylindrical + ski-slip bug: captured adjacent blocked square"
+  exit 1
+fi
+if echo "${out}" | grep -q "a1h1:"; then
+  echo "cylindrical + ski-slip bug: captured adjacent blocked square (wrap)"
+  exit 1
+fi
+if echo "${out}" | grep -q "a1c1:"; then
+  echo "cylindrical + ski-slip bug: leaped over blocked square"
   exit 1
 fi
 


### PR DESCRIPTION
- Reject dynamic distance (xR) and max-distance (zR) sliders on cylindrical boards because they use non-wrapped distance calculations.
- Fix ski-sliders (jR) on wrapped boards to properly skip the first square by updating slider_min_distance to handle SKI_SLIDER_LIMIT.
- Add regression tests for these interactions in tests/unorthodox-interactions.sh.