### PR TITLE
Fix Anti-King Chess I and II rules

### DIFF
--- a/src/variants.ini
+++ b/src/variants.ini
@@ -2798,7 +2798,7 @@ customPiece1 = s:KN
 # Peter Aronson's Anti-King Chess I.
 # Best-effort model: Anti-King I's once-only king/anti-king knight leap is not yet encoded.
 customPiece1 = a:K
-customPiece2 = p:mfWcfF
+customPiece2 = p:mfFcfW
 king = k
 pawn = p
 doubleStep = false
@@ -2815,7 +2815,7 @@ captureForbidden = *:a
 [anti-king-2:chess]
 # Peter Aronson's Anti-King Chess II.
 customPiece1 = a:K
-startFen = rnbqkbnr/pppppppp/3A4/8/8/3a4/PPPPPPPP/RNBQKBNR w - - 0 1
+startFen = rnbqkbnr/pppppppp/3A4/8/8/3a4/PPPPPPPP/RNBQKBNR w KQkq - 0 1
 antiRoyalTypes = a
 antiRoyalCount = 1
 antiRoyalSelfCaptureOnly = true

--- a/tests/anti-king.sh
+++ b/tests/anti-king.sh
@@ -28,7 +28,7 @@ echo "anti-king tests started"
 
 out=$(run_engine anti-king-1 "position startpos")
 echo "${out}" | grep -q "^info string variant anti-king-1 "
-echo "${out}" | grep -q "^Nodes searched: 12$"
+echo "${out}" | grep -q "^Nodes searched: 20$"
 
 out=$(run_engine anti-king-2 "position startpos")
 echo "${out}" | grep -q "^info string variant anti-king-2 "


### PR DESCRIPTION
Fixes Berolina pawn movement for Anti-King Chess I and adds castling rights to start FEN for Anti-King Chess II, matching documentation.