### PR TITLE
Fix file piece set map parsing with spaces around colon

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -783,6 +783,12 @@ namespace {
                         std::cerr << key << " - Missing piece set for file " << fileToken << std::endl;
                     return false;
                 }
+            } else if (pieceToken.empty()) {
+                if (!(ss >> pieceToken)) {
+                    if (doCheck)
+                        std::cerr << key << " - Missing piece set for file " << fileToken << std::endl;
+                    return false;
+                }
             }
 
             PieceSet pieces = NO_PIECE_SET;

--- a/tests/parser-regressions.sh
+++ b/tests/parser-regressions.sh
@@ -76,6 +76,10 @@ startFen = rbnkbr/pppppp/6/6/PPPPPP/RBNKBR w KQkq - 0 1
 promotionPieceTypesByFile = a:q b:r
 promotionPieceTypesByFileWhite = a:n
 startFen = 8/1P6/8/8/8/8/8/4k2K w - - 0 1
+
+[promotion-by-file-spaces:chess]
+promotionPieceTypesByFile = a: q b: r c : b d :n e:- f: -
+startFen = 8/1P6/8/8/8/8/8/4k2K w - - 0 1
 INI
 
 echo "parser regression tests started"
@@ -108,7 +112,7 @@ verify_warning "wallingRule=duck and petrifyOnCaptureTypes are incompatible." "p
 verify_warning "pieceDrops and any walling are incompatible." "freeDrops check"
 verify_warning "falcon looks like a custom piece definition. Use customPieceN = a:W for new custom pieces." "named custom piece hint"
 verify_warning "Wrapped boards do not support connect/collinear win conditions." "wrapped connect rejection"
-verify_warning "Toroidal boards do not support x/z rider modifiers in customPiece1." "toroidal x/z rejection"
+verify_warning "Wrapped boards do not support x/z rider modifiers in customPiece1." "toroidal x/z rejection"
 verify_warning "Castling destination is adjacent to castlingKingFile; some GUIs/protocols may not distinguish castling from a normal king move." "adjacent castling warning"
 
 nonking_ini=$(mktemp)
@@ -162,6 +166,21 @@ fi
 
 if echo "${promotion_file_output}" | grep -q "b7b8n:"; then
   echo "${promotion_file_output}"
+  exit 1
+fi
+
+promotion_spaces_output=$(cat <<CMDS | "${ENGINE}" 2>&1
+uci
+setoption name VariantPath value ${tmp_ini}
+setoption name UCI_Variant value promotion-by-file-spaces
+position startpos
+go perft 1
+quit
+CMDS
+)
+
+if ! echo "${promotion_spaces_output}" | grep -q "b7b8r:"; then
+  echo "${promotion_spaces_output}"
   exit 1
 fi
 


### PR DESCRIPTION
Fixes a bug where parsing of file piece set maps (e.g. `promotionPieceTypesByFile`) would fail if there was a space between the colon and the piece set (like `a: RNB`). This PR ensures that empty tokens immediately following a colon correctly read the next token from the stream as the piece list. Also adds a regression test and fixes an outdated warning expected in the test script.