### PR TITLE
Reject incompatible removeConnectN rule combinations

### DIFF
--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -108,6 +108,10 @@ jobs:
         run: |
           ../tests/new-variants-smoke.sh
 
+      - name: Test connect region 3
+        run: |
+          ../tests/connect-region3.sh
+
       - name: Test incomplete baselines
         run: |
           ../tests/incomplete-baselines.sh ./stockfish variants-incomplete.ini

--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -112,6 +112,10 @@ jobs:
         run: |
           ../tests/connect-region3.sh
 
+      - name: Test kopano
+        run: |
+          ../tests/kopano.sh
+
       - name: Test incomplete baselines
         run: |
           ../tests/incomplete-baselines.sh ./stockfish variants-incomplete.ini

--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -108,6 +108,14 @@ jobs:
         run: |
           ../tests/new-variants-smoke.sh
 
+      - name: Test hex board display
+        run: |
+          ../tests/hex-board-display.sh
+
+      - name: Test hex piece movement
+        run: |
+          ../tests/hex-piece-movement.sh
+
       - name: Test connect region 3
         run: |
           ../tests/connect-region3.sh

--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -116,6 +116,10 @@ jobs:
         run: |
           ../tests/kopano.sh
 
+      - name: Test konobi
+        run: |
+          ../tests/konobi.sh
+
       - name: Test incomplete baselines
         run: |
           ../tests/incomplete-baselines.sh ./stockfish variants-incomplete.ini

--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -148,6 +148,10 @@ jobs:
         run: |
           ../tests/sacrifice.sh
 
+      - name: Test borrowed opponent drops
+        run: |
+          ../tests/borrow-opponent-drops.sh
+
       - name: Test asym rider checkers
         run: |
           ../tests/asym-rider-checkers.sh

--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -168,6 +168,10 @@ jobs:
         run: |
           ../tests/sacrifice.sh
 
+      - name: Test Kings or Lemmings
+        run: |
+          ../tests/kings-or-lemmings.sh
+
       - name: Test borrowed opponent drops
         run: |
           ../tests/borrow-opponent-drops.sh

--- a/src/Makefile
+++ b/src/Makefile
@@ -373,7 +373,7 @@ endif
 ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
-	CXXFLAGS += -Wextra -Wshadow
+	CXXFLAGS += -Wextra -Wshadow -fno-ipa-cp-clone
 	ifeq ($(largeboards),no)
 		CXXFLAGS += -pedantic
 	endif

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -512,6 +512,34 @@ inline Bitboard safe_destination_tuple(Square s, int dr, int df) {
     return square_bb(make_square(File(f), Rank(r)));
 }
 
+Bitboard tuple_rider_attacks(const std::vector<PieceInfo::TupleRay>& rays, Square s, Bitboard occupied, Color c) {
+    Bitboard attack = 0;
+
+    for (const auto& ray : rays)
+    {
+        const int stepR = c == WHITE ? ray.dr : -ray.dr;
+        const int stepF = c == WHITE ? ray.df : -ray.df;
+        Square current = s;
+        int count = 0;
+        for (;;)
+        {
+            Bitboard next = safe_destination_tuple(current, stepR, stepF);
+            if (!next)
+                break;
+
+            Square to = lsb(next);
+            attack |= next;
+            current = to;
+            if (ray.limit > 0 && ++count >= ray.limit)
+                break;
+            if (occupied & next)
+                break;
+        }
+    }
+
+    return attack;
+}
+
 Bitboard rider_terminal_squares(const std::map<Direction, int>& directions, Square sq) {
     Bitboard terminal = 0;
 
@@ -622,6 +650,21 @@ Bitboard leap_rider_moves_bb(PieceType pt, bool initial, Color c, Square s, Bitb
   return leap_rider_attacks(pieceMap.get(pt)->leapRider[initial][MODALITY_QUIET], s, occupied, c);
 }
 
+Bitboard tuple_rider_attacks_bb(PieceType pt, Color c, Square s, Bitboard occupied) {
+  return tuple_rider_attacks(pieceMap.get(pt)->tupleSlider[0][MODALITY_CAPTURE], s, occupied, c);
+}
+
+Bitboard tuple_rider_moves_bb(PieceType pt, bool initial, Color c, Square s, Bitboard occupied) {
+  return tuple_rider_attacks(pieceMap.get(pt)->tupleSlider[initial][MODALITY_QUIET], s, occupied, c);
+}
+
+Bitboard tuple_rider_between_bb(PieceType pt, Square s1, Square s2) {
+  for (const auto& ray : pieceMap.get(pt)->tupleSlider[0][MODALITY_CAPTURE])
+      if (Bitboard path = fixed_step_between_bb(s1, s2, ray.df, ray.dr))
+          return path;
+  return Bitboard(0);
+}
+
 
 /// Bitboards::pretty() returns an ASCII representation of a bitboard suitable
 /// to be printed to standard output. Useful for debugging.
@@ -727,6 +770,23 @@ void Bitboards::init_pieces() {
                           Bitboard dst = safe_destination_tuple(s, tdr, tdf);
                           pseudo |= dst;
                           leaper |= dst;
+                      }
+                      for (const auto& ray : pi->tupleSlider[initial][modality])
+                      {
+                          int tdr = c == WHITE ? ray.dr : -ray.dr;
+                          int tdf = c == WHITE ? ray.df : -ray.df;
+                          Square current = s;
+                          int count = 0;
+                          for (;;)
+                          {
+                              Bitboard dst = safe_destination_tuple(current, tdr, tdf);
+                              if (!dst)
+                                  break;
+                              pseudo |= dst;
+                              current = lsb(dst);
+                              if (ray.limit > 0 && ++count >= ray.limit)
+                                  break;
+                          }
                       }
                       pseudo |= special_pseudo_bb(pi, initial, modality, s, c, riderDirs, skiDirs);
                       leaper |= special_leaper_bb(pi, initial, modality, s, c);

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -263,8 +263,10 @@ namespace {
 
   void add_step_like_rider_types(RiderType& riderTypes, Direction d) {
     const int ad = std::abs(int(d));
-    if ((ad % FILE_NB) == 0 || ad < FILE_NB)
-        riderTypes |= RIDER_ROOK_H | RIDER_ROOK_V;
+    if ((ad % FILE_NB) == 0)
+        riderTypes |= RIDER_ROOK_V;
+    if (ad < FILE_NB)
+        riderTypes |= RIDER_ROOK_H;
     if ((FILE_NB > 1 && (ad % (FILE_NB - 1)) == 0) || (ad % (FILE_NB + 1)) == 0)
         riderTypes |= RIDER_BISHOP;
     if (LameDabbabaDirections.find(d) != LameDabbabaDirections.end())

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -131,6 +131,9 @@ extern RiderType AttackRiderTypes[PIECE_TYPE_NB];
 extern RiderType MoveRiderTypes[2][PIECE_TYPE_NB];
 Bitboard leap_rider_attacks_bb(PieceType pt, Color c, Square s, Bitboard occupied);
 Bitboard leap_rider_moves_bb(PieceType pt, bool initial, Color c, Square s, Bitboard occupied);
+Bitboard tuple_rider_attacks_bb(PieceType pt, Color c, Square s, Bitboard occupied);
+Bitboard tuple_rider_moves_bb(PieceType pt, bool initial, Color c, Square s, Bitboard occupied);
+Bitboard tuple_rider_between_bb(PieceType pt, Square s1, Square s2);
 inline Square lsb(Bitboard b);
 
 constexpr std::array<std::pair<int, int>, 8> RoseSteps = {{
@@ -672,6 +675,8 @@ inline Bitboard between_bb(Square s1, Square s2, PieceType pt) {
   auto remap_reverse_path = [&](Bitboard reversePath) {
       return (reversePath & ~square_bb(s1)) | square_bb(s2);
   };
+  if ((path = tuple_rider_between_bb(pt, s1, s2)))
+      return path;
 
   if ((r & RIDER_HORSE) && (path = PseudoAttacks[WHITE][WAZIR][s2] & PseudoAttacks[WHITE][FERS][s1]))
       return path;
@@ -1095,6 +1100,7 @@ inline Bitboard attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
   while (r)
       b |= rider_attacks_bb(pop_rider(r), s, occupied);
   b |= leap_rider_attacks_bb(pt, c, s, occupied);
+  b |= tuple_rider_attacks_bb(pt, c, s, occupied);
   return b & PseudoAttacks[c][pt][s];
 }
 
@@ -1107,6 +1113,7 @@ inline Bitboard moves_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
   while (r)
       b |= rider_attacks_bb(pop_rider(r), s, occupied);
   b |= leap_rider_moves_bb(pt, Initial, c, s, occupied);
+  b |= tuple_rider_moves_bb(pt, Initial, c, s, occupied);
   return b & PseudoMoves[Initial][c][pt][s];
 }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -772,7 +772,8 @@ namespace {
                 // pawn diagonally in front of it is a very serious problem, especially
                 // when that pawn is also blocked.
                 if (   pos.is_chess960()
-                    && (s == relative_square(Us, SQ_A1) || s == relative_square(Us, SQ_H1)))
+                    && (   s == relative_square(Us, make_square(FILE_A, RANK_1), pos.max_rank())
+                        || s == relative_square(Us, make_square(pos.max_file(), RANK_1), pos.max_rank())))
                 {
                     Direction d = pawn_push(Us) + (file_of(s) == FILE_A ? EAST : WEST);
                     if (pos.piece_on(s + d) == make_piece(Us, PAWN))

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -1039,9 +1039,7 @@ namespace {
                 while (froms)
                 {
                     Square from = pop_lsb(froms);
-                    Bitboard b = ((pos.moves_from(Us, pt, from) & ~pos.pieces())
-                                | (pos.attacks_from(Us, pt, from) & pos.pieces(~Us)))
-                               & cloneTargets;
+                    Bitboard b = pos.clone_targets_from(Us, from) & cloneTargets;
                     while (b)
                         *moveList++ = make<SPECIAL>(from, pop_lsb(b));
                 }

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -1025,6 +1025,29 @@ namespace {
             }
         }
 
+        if (!restrictToForcedJumper && pos.clone_move_types())
+        {
+            Bitboard cloneTargets = Type == CAPTURES   ? captureTarget & pos.pieces(~Us)
+                                 : Type == QUIETS     ? target & ~pos.pieces()
+                                 : Type == QUIET_CHECKS ? target & ~pos.pieces()
+                                 : target & ~pos.pieces(Us);
+
+            for (PieceSet ps = pos.clone_move_types(); ps;)
+            {
+                PieceType pt = pop_lsb(ps);
+                Bitboard froms = pos.pieces(Us, pt);
+                while (froms)
+                {
+                    Square from = pop_lsb(froms);
+                    Bitboard b = ((pos.moves_from(Us, pt, from) & ~pos.pieces())
+                                | (pos.attacks_from(Us, pt, from) & pos.pieces(~Us)))
+                               & cloneTargets;
+                    while (b)
+                        *moveList++ = make<SPECIAL>(from, pop_lsb(b));
+                }
+            }
+        }
+
         // Workaround for passing: Execute a non-move with any piece
         if (!restrictToForcedJumper && pos.pass(Us) && !pos.count<KING>(Us))
         {

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -183,7 +183,7 @@ namespace {
         // Restrict to valid target
         b &= pos.drop_region(Us, pt) & (~pos.pieces() | pos.opening_swap_drop_targets(Us, pt));
 
-        if ((pos.symmetric_drop_types() & pt) && pos.count_in_hand(Us, pt) >= 2)
+        if ((pos.symmetric_drop_types() & pt) && pos.count_in_hand(pos.drop_hand_color(Us, pt), pt) >= 2)
         {
             while (b)
             {

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -121,16 +121,15 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
   assert(d > 0);
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-  baseMoveList = std::make_unique<ExtMove[]>(MAX_MOVES);
-  moveList = baseMoveList.get();
+  if (pos.potions_enabled() || pos.capture_type() == PRISON)
+      overflowMoveList = std::make_unique<ExtMove[]>(MOVE_PICK_OVERFLOW_CAPACITY);
+  else
+      baseMoveList = std::make_unique<ExtMove[]>(MAX_MOVES);
+
+  moveList = overflowMoveList ? overflowMoveList.get() : baseMoveList.get();
 #else
   moveList = moves;
 #endif
-  if (pos.potions_enabled() || pos.capture_type() == PRISON)
-  {
-      overflowMoveList = std::make_unique<ExtMove[]>(MOVE_PICK_OVERFLOW_CAPACITY);
-      moveList = overflowMoveList.get();
-  }
 
   stage = (pos.evasion_checkers() ? EVASION_TT : MAIN_TT) +
           !(ttm && pos.pseudo_legal(ttm));
@@ -143,16 +142,15 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
   assert(d <= 0);
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-  baseMoveList = std::make_unique<ExtMove[]>(MAX_MOVES);
-  moveList = baseMoveList.get();
+  if (pos.potions_enabled() || pos.capture_type() == PRISON)
+      overflowMoveList = std::make_unique<ExtMove[]>(MOVE_PICK_OVERFLOW_CAPACITY);
+  else
+      baseMoveList = std::make_unique<ExtMove[]>(MAX_MOVES);
+
+  moveList = overflowMoveList ? overflowMoveList.get() : baseMoveList.get();
 #else
   moveList = moves;
 #endif
-  if (pos.potions_enabled() || pos.capture_type() == PRISON)
-  {
-      overflowMoveList = std::make_unique<ExtMove[]>(MOVE_PICK_OVERFLOW_CAPACITY);
-      moveList = overflowMoveList.get();
-  }
 
   stage = (pos.evasion_checkers() ? EVASION_TT : QSEARCH_TT) +
           !(   ttm
@@ -167,16 +165,15 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const GateHistory*
 
   assert(!pos.evasion_checkers());
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-  baseMoveList = std::make_unique<ExtMove[]>(MAX_MOVES);
-  moveList = baseMoveList.get();
+  if (pos.potions_enabled() || pos.capture_type() == PRISON)
+      overflowMoveList = std::make_unique<ExtMove[]>(MOVE_PICK_OVERFLOW_CAPACITY);
+  else
+      baseMoveList = std::make_unique<ExtMove[]>(MAX_MOVES);
+
+  moveList = overflowMoveList ? overflowMoveList.get() : baseMoveList.get();
 #else
   moveList = moves;
 #endif
-  if (pos.potions_enabled() || pos.capture_type() == PRISON)
-  {
-      overflowMoveList = std::make_unique<ExtMove[]>(MOVE_PICK_OVERFLOW_CAPACITY);
-      moveList = overflowMoveList.get();
-  }
 
   stage = PROBCUT_TT + !(ttm && pos.capture(ttm)
                              && pos.pseudo_legal(ttm)

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -178,7 +178,7 @@ private:
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
   std::unique_ptr<ExtMove[]> baseMoveList;
 #else
-  ExtMove moves[MAX_MOVES];
+  ExtMove moves[MOVE_PICK_OVERFLOW_CAPACITY];
 #endif
   std::unique_ptr<ExtMove[]> overflowMoveList;
 };

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1781,6 +1781,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("weakDiagonalConnect", v->weakDiagonalConnect);
     parse_attribute("reciprocalWeakConnectionDrop", v->reciprocalWeakConnectionDrop);
     parse_attribute("weakCrosscutDropIllegal", v->weakCrosscutDropIllegal);
+    parse_attribute("weakConnectionNobiImpossible", v->weakConnectionNobiImpossible);
     parse_attribute("chasingRule", v->chasingRule);
     parse_attribute("stalemateValue", v->stalemateValue);
     parse_attribute("stalematePieceCount", v->stalematePieceCount);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2112,11 +2112,6 @@ bool VariantParser<DoCheck>::check_consistency(Variant* v) {
             std::cerr << "Can not use kings with flipEnclosedPieces." << std::endl;
             valid = false;
         }
-        if (v->removeConnectN)
-        {
-            std::cerr << "Can not use kings with removeConnectN." << std::endl;
-            valid = false;
-        }
         if (v->wallingRule==DUCK)
         {
             std::cerr << "Can not use kings with wallingRule = duck." << std::endl;
@@ -2139,6 +2134,25 @@ bool VariantParser<DoCheck>::check_consistency(Variant* v) {
             }
         }
     }
+
+    if (v->removeConnectN)
+    {
+        if (hasRoyalKing || v->pseudoRoyalTypes || v->antiRoyalTypes)
+        {
+            if (DoCheck)
+                std::cerr << "removeConnectN is incompatible with (pseudo/anti-)royal pieces." << std::endl;
+            valid = false;
+        }
+        if (v->connectN || v->connect3D || v->connect4D || v->connectNxN || v->collinearN || v->connectGroup
+            || v->connectRegion1[WHITE] || v->connectRegion1[BLACK]
+            || !v->connectPieceGoal[WHITE].empty() || !v->connectPieceGoal[BLACK].empty())
+        {
+            if (DoCheck)
+                std::cerr << "removeConnectN is incompatible with connection win conditions." << std::endl;
+            valid = false;
+        }
+    }
+
     // Options incompatible with royal kings OR pseudo-royal kings. Possible in theory though:
     // 1. In blast variants, moving a (pseudo-)royal blastImmuneType into another piece is legal.
     // 2. In blast variants, capturing a piece next to a (pseudo-)royal blastImmuneType is legal.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1889,12 +1889,16 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("connectHorizontal", v->connectHorizontal);
     parse_attribute("connectVertical", v->connectVertical);
     parse_attribute("connectDiagonal", v->connectDiagonal);
+    parse_attribute("connectNorthEast", v->connectNorthEast);
+    parse_attribute("connectSouthEast", v->connectSouthEast);
     parse_attribute("connect3D", v->connect3D);
     parse_attribute("connect4D", v->connect4D);
     parse_attribute("connectRegion1White", v->connectRegion1[WHITE]);
     parse_attribute("connectRegion2White", v->connectRegion2[WHITE]);
+    parse_attribute("connectRegion3White", v->connectRegion3[WHITE]);
     parse_attribute("connectRegion1Black", v->connectRegion1[BLACK]);
     parse_attribute("connectRegion2Black", v->connectRegion2[BLACK]);
+    parse_attribute("connectRegion3Black", v->connectRegion3[BLACK]);
     parse_attribute("connectNxN", v->connectNxN);
     parse_attribute("collinearN", v->collinearN);
     parse_attribute("connectGroup", v->connectGroup);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1142,6 +1142,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("pocketSize", v->pocketSize);
     parse_attribute("chess960", v->chess960);
     parse_attribute("twoBoards", v->twoBoards);
+    parse_attribute("hexBoard", v->hexBoard);
     parse_attribute("cylindrical", v->cylindrical);
     parse_attribute("toroidal", v->toroidal);
     parse_attribute("startFen", v->startFen);
@@ -1972,6 +1973,13 @@ bool VariantParser<DoCheck>::check_consistency(Variant* v) {
     // startFen
     if (DoCheck && FEN::validate_fen(v->startFen, v, v->chess960) != FEN::FEN_OK)
         std::cerr << "startFen - Invalid starting position: " << v->startFen << std::endl;
+
+    if (v->hexBoard && wrapsTopology)
+    {
+        if (DoCheck)
+            std::cerr << "hexBoard is not supported together with cylindrical or toroidal topology." << std::endl;
+        valid = false;
+    }
 
     // pieceToCharTable
     if (DoCheck && v->pieceToCharTable != "-")

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1617,6 +1617,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("mustDropTypeWhite", v->mustDropTypeByColor[WHITE], v);
     parse_attribute("mustDropTypeBlack", v->mustDropTypeByColor[BLACK], v);
     parse_attribute("openingSwapDrop", v->openingSwapDrop);
+    parse_attribute("openingSwapMirrorMainDiagonal", v->openingSwapMirrorMainDiagonal);
     parse_attribute("dropKingLast", v->dropKingLast);
     parse_attribute("openingSelfRemoval", v->openingSelfRemoval);
     parse_attribute("openingSelfRemovalAdjacentToLast", v->openingSelfRemovalAdjacentToLast);
@@ -1777,6 +1778,9 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("samePlayerBoardRepetitionIllegal", v->samePlayerBoardRepetitionIllegal);
     parse_attribute("alternating2x2DropIllegal", v->alternating2x2DropIllegal);
     parse_attribute("pathwayDropRule", v->pathwayDropRule);
+    parse_attribute("weakDiagonalConnect", v->weakDiagonalConnect);
+    parse_attribute("reciprocalWeakConnectionDrop", v->reciprocalWeakConnectionDrop);
+    parse_attribute("weakCrosscutDropIllegal", v->weakCrosscutDropIllegal);
     parse_attribute("chasingRule", v->chasingRule);
     parse_attribute("stalemateValue", v->stalemateValue);
     parse_attribute("stalematePieceCount", v->stalematePieceCount);
@@ -2063,6 +2067,10 @@ bool VariantParser<DoCheck>::check_consistency(Variant* v) {
             || v->freeDrops
             || v->edgeInsertTypes))
         std::cerr << "openingSwapDrop is only supported for simple move-out mandatory drop variants without capture drops, paired drops, self capture, free drops, edge inserts, or two-board reserves." << std::endl;
+    if (DoCheck && v->openingSwapMirrorMainDiagonal
+        && (!v->openingSwapDrop
+            || int(v->maxFile) != int(v->maxRank)))
+        std::cerr << "openingSwapMirrorMainDiagonal requires openingSwapDrop on a square board." << std::endl;
     if (DoCheck && v->wallingRule != NO_WALLING && v->seirawanGating)
         std::cerr << "wallingRule and seirawanGating are incompatible." << std::endl;
     if (DoCheck && v->wallingRule != NO_WALLING && v->potions)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1725,6 +1725,13 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("gatingFromHand", v->gatingFromHand);
     parse_attribute("seirawanGating", v->seirawanGating);
     parse_attribute("commitGates", v->commitGates);
+    parse_attribute("cloneMoveTypes", v->cloneMoveTypes, v);
+    if (v->cloneMoveTypes & PAWN)
+    {
+        if (DoCheck)
+            std::cerr << "cloneMoveTypes - PAWN is not supported for clone moves and will be ignored." << std::endl;
+        v->cloneMoveTypes &= ~piece_set(PAWN);
+    }
     parse_attribute("jumpCaptureTypes", v->jumpCaptureTypes, v);
     if (v->jumpCaptureTypes & PAWN)
     {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1622,6 +1622,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("openingSelfRemovalAdjacentToLast", v->openingSelfRemovalAdjacentToLast);
     parse_both_colors_with_overrides("openingSelfRemovalRegion", v->openingSelfRemovalRegion);
     parse_attribute("pieceDrops", v->pieceDrops);
+    parse_attribute("borrowOpponentDropsWhenEmpty", v->borrowOpponentDropsWhenEmpty);
     parse_attribute("virtualDrops", v->virtualDrops);
     const auto& it_virtual_drop_limit = config.find("virtualDropLimit");
     if (it_virtual_drop_limit != config.end())

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -240,7 +240,7 @@ namespace {
                   }
                   std::string rangeSpec = expandedBetza.substr(i + 2, close - i - 2);
                   std::size_t dash = rangeSpec.find('-');
-                  bool unsupportedCombo = !atomIsRider || hopper || contraHopper || lame || dynamicDistance || skiSlider || maxDistance;
+                  bool unsupportedCombo = !atomIsRider || atomIsTuple || hopper || contraHopper || lame || dynamicDistance || skiSlider || maxDistance;
                   bool malformedRange = dash == std::string::npos
                                      || rangeSpec.find('-', dash + 1) != std::string::npos
                                      || dash == 0;
@@ -324,11 +324,14 @@ namespace {
                                    : p->steps[initial][modality];
                   auto& leapRiderV = p->leapRider[initial][modality];
                   auto& tupleV = p->tupleSteps[initial][modality];
+                  auto& tupleSliderV = p->tupleSlider[initial][modality];
                   auto has_dir = [&](std::string s) {
                     return std::find(directions.begin(), directions.end(), s) != directions.end();
                   };
                   auto add_step = [&](int dr, int df) {
-                      if (atomIsTuple && !hopper && !rider)
+                      if (atomIsTuple && !hopper && rider)
+                          tupleSliderV.push_back({dr, df, distance});
+                      else if (atomIsTuple && !hopper && !rider)
                           tupleV.emplace_back(dr, df);
                       else
                       {
@@ -484,15 +487,13 @@ namespace {
           // Standard rose/circular knight rider.
           else if (c == '@')
               commit_rose();
-          // Tuple leaper atom: (x,y)
+          // Tuple atom: (x,y), optionally repeated or numeric for riders.
           else if (c == '(')
           {
-              // Tuple atoms are only supported as explicit leapers. Reject
-              // tuple+hoppers/riders to avoid Direction-based wrap artifacts.
-              if (hopper || contraHopper || rider || lame || dynamicDistance)
+              if (hopper || contraHopper || lame || dynamicDistance || skiSlider || maxDistance)
               {
                   std::cerr << "Unsupported Betza tuple modifier combination in '" << betza
-                            << "': tuple atoms only support explicit leapers. Ignoring tuple atom." << std::endl;
+                            << "': tuple atoms only support explicit leapers or repeated/numeric tuple riders. Ignoring tuple atom." << std::endl;
                   reset_parser_state();
                   auto closeUnsupported = expandedBetza.find(')', i + 1);
                   if (closeUnsupported != std::string::npos)
@@ -522,8 +523,12 @@ namespace {
                   continue;
               }
               std::vector<std::pair<int, int>> tupleAtom = { std::make_pair(dx, dy) };
-              i = close;
-              commit_atom(tupleAtom, false, i, ')', true);
+              std::string tupleText = expandedBetza.substr(i, close - i + 1);
+              std::string::size_type next = close + 1;
+              bool repeatedTupleRider = next < expandedBetza.size()
+                                     && expandedBetza.compare(next, tupleText.size(), tupleText) == 0;
+              i = repeatedTupleRider ? next + tupleText.size() - 1 : close;
+              commit_atom(tupleAtom, repeatedTupleRider, i, ')', true);
           }
       }
       return p.release();

--- a/src/piece.h
+++ b/src/piece.h
@@ -69,10 +69,17 @@ struct PieceInfo {
     AUGMENT_CONTRA = 1 << 2
   };
 
+  struct TupleRay {
+    int dr;
+    int df;
+    int limit;
+  };
+
   std::string name = "";
   std::string betza = "";
   std::map<Direction, int> steps[2][MOVE_MODALITY_NB] = {};
   std::vector<std::pair<int, int>> tupleSteps[2][MOVE_MODALITY_NB] = {};
+  std::vector<TupleRay> tupleSlider[2][MOVE_MODALITY_NB] = {};
   std::map<Direction, int> slider[2][MOVE_MODALITY_NB] = {};
   std::map<Direction, int> leapRider[2][MOVE_MODALITY_NB] = {};
   std::map<Direction, int> hopper[2][MOVE_MODALITY_NB] = {};

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -531,6 +531,50 @@ namespace {
     return blockers;
   }
 
+  inline bool weak_diagonal_link(const Position& pos, Color c, Square a, Square b) {
+    if (!is_ok(a) || !is_ok(b))
+        return false;
+    if (!(pos.pieces(c) & a) || !(pos.pieces(c) & b))
+        return false;
+
+    int df = int(file_of(b)) - int(file_of(a));
+    int dr = int(rank_of(b)) - int(rank_of(a));
+    if (std::abs(df) != 1 || std::abs(dr) != 1)
+        return false;
+
+    Square bridge1 = make_square(file_of(a), rank_of(b));
+    Square bridge2 = make_square(file_of(b), rank_of(a));
+    return !(pos.pieces(c) & bridge1) && !(pos.pieces(c) & bridge2);
+  }
+
+  Bitboard weak_connection_expansion(const Position& pos, Bitboard frontier, Bitboard connectPieces, Color c) {
+    Bitboard expanded = 0;
+
+    while (frontier)
+    {
+        Square from = pop_lsb(frontier);
+        Bitboard fromBb = square_bb(from);
+        for (Direction d : pos.getConnectDirections())
+            expanded |= shift(d, fromBb) & connectPieces;
+
+        if (!pos.weak_diagonal_connect())
+            continue;
+
+        static constexpr Direction diagonals[] = {NORTH_EAST, NORTH_WEST, SOUTH_EAST, SOUTH_WEST};
+        for (Direction d : diagonals)
+        {
+            Bitboard toBb = shift(d, fromBb) & connectPieces;
+            if (!toBb)
+                continue;
+            Square to = lsb(toBb);
+            if (weak_diagonal_link(pos, c, from, to))
+                expanded |= toBb;
+        }
+    }
+
+    return expanded;
+  }
+
 } // namespace
 
 namespace Zobrist {
@@ -2875,6 +2919,79 @@ bool Position::legal(Move m) const {
 
       if (friendly != 1 && friendly + enemy != 0)
           return false;
+  }
+
+  if (type_of(m) == DROP && (var->reciprocalWeakConnectionDrop || var->weakCrosscutDropIllegal))
+  {
+      auto has_color_at = [&](Color c, Square sq, Color placedColor) {
+          return sq == to ? c == placedColor : bool(pieces(c) & sq);
+      };
+
+      auto creates_hypothetical_weak_link = [&](Color c, Color placedColor) {
+          static constexpr int dfile[4] = {1, -1, 1, -1};
+          static constexpr int drank[4] = {1, 1, -1, -1};
+          for (int i = 0; i < 4; ++i)
+          {
+              int nf = int(file_of(to)) + dfile[i];
+              int nr = int(rank_of(to)) + drank[i];
+              if (nf < int(FILE_A) || nf > int(max_file()) || nr < int(RANK_1) || nr > int(max_rank()))
+                  continue;
+
+              Square diag = make_square(File(nf), Rank(nr));
+              if (!has_color_at(c, diag, placedColor))
+                  continue;
+
+              Square bridge1 = make_square(file_of(to), rank_of(diag));
+              Square bridge2 = make_square(file_of(diag), rank_of(to));
+              if (!has_color_at(c, bridge1, placedColor) && !has_color_at(c, bridge2, placedColor))
+                  return true;
+          }
+          return false;
+      };
+
+      bool weakFriendly = creates_hypothetical_weak_link(us, us);
+      if (weakFriendly)
+      {
+          if (var->reciprocalWeakConnectionDrop && !creates_hypothetical_weak_link(~us, ~us))
+              return false;
+
+          if (var->weakCrosscutDropIllegal)
+          {
+              auto enemy_at = [&](Square sq) { return sq != to && bool(pieces(~us) & sq); };
+              auto friendly_at = [&](Square sq) { return sq == to || bool(pieces(us) & sq); };
+
+              const struct {
+                  int of1, or1, of2, or2, dff, drr;
+              } patterns[] = {
+                  {0, 1, 1, 0, 1, 1},
+                  {0, 1, -1, 0, -1, 1},
+                  {0, -1, 1, 0, 1, -1},
+                  {0, -1, -1, 0, -1, -1},
+              };
+
+              for (const auto& p : patterns)
+              {
+                  int f1 = int(file_of(to)) + p.of1;
+                  int r1 = int(rank_of(to)) + p.or1;
+                  int f2 = int(file_of(to)) + p.of2;
+                  int r2 = int(rank_of(to)) + p.or2;
+                  int fd = int(file_of(to)) + p.dff;
+                  int rd = int(rank_of(to)) + p.drr;
+                  if (f1 < int(FILE_A) || f1 > int(max_file()) || r1 < int(RANK_1) || r1 > int(max_rank()))
+                      continue;
+                  if (f2 < int(FILE_A) || f2 > int(max_file()) || r2 < int(RANK_1) || r2 > int(max_rank()))
+                      continue;
+                  if (fd < int(FILE_A) || fd > int(max_file()) || rd < int(RANK_1) || rd > int(max_rank()))
+                      continue;
+
+                  Square orth1 = make_square(File(f1), Rank(r1));
+                  Square orth2 = make_square(File(f2), Rank(r2));
+                  Square diag = make_square(File(fd), Rank(rd));
+                  if (enemy_at(orth1) && enemy_at(orth2) && friendly_at(diag))
+                      return false;
+              }
+          }
+      }
   }
 
   if (dropMove && pay_points_to_drop()
@@ -6945,9 +7062,7 @@ bool Position::is_immediate_game_end(Value& result, int ply) const {
       bool hitsRegion3 = !region3 || bool(current & region3);
 
       while (true) {
-          Bitboard newBitboard = 0;
-          for (Direction d : var->connectDirections)
-              newBitboard |= shift(d, current | newBitboard) & connectPieces;
+          Bitboard newBitboard = weak_connection_expansion(*this, current, connectPieces, ~sideToMove);
 
           hitsRegion2 |= bool(newBitboard & region2);
           hitsRegion3 |= !region3 || bool(newBitboard & region3);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2739,6 +2739,7 @@ bool Position::legal(Move m) const {
   }
 
   bool rifleShot = rifle_capture(m) && capture(m) && type_of(m) != CASTLING;
+  bool cloneMove = is_clone_move(m);
   Square shotSq = capture(m) ? capture_square(m) : to;
   Bitboard removedAttackers = rifleShot ? square_bb(shotSq) : Bitboard(0);
   Square effectiveTo = rifleShot ? from : to;
@@ -3210,7 +3211,7 @@ bool Position::legal(Move m) const {
       const bool zeroRangeBlastOnCapture = zero_range_blast_on_capture(m);
       Square kto = rifleShot ? from : to;
       Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? shotSq : kto;
-      Bitboard occupied = rifleShot ? pieces() : (!dropMove ? pieces() ^ from : pieces());
+      Bitboard occupied = rifleShot ? pieces() : (!dropMove && !cloneMove ? pieces() ^ from : pieces());
       Bitboard blastImmune = blastOnCapture ? blast_immune_bb() : Bitboard(0);
       if (walling_rule() == DUCK)
           occupied ^= st->wallSquares;
@@ -3260,7 +3261,9 @@ bool Position::legal(Move m) const {
               pseudoRoyals |= square_bb(secondary_drop_square(m));
       }
       Bitboard pseudoRoyalsTheirs = st->pseudoRoyals & pieces(~sideToMove);
-      if (!rifleShot && is_ok(from) && (pseudoRoyals & from))
+      if (cloneMove && (pseudo_royal_types() & piece_set(movePt)))
+          pseudoRoyals |= kto;
+      else if (!rifleShot && is_ok(from) && (pseudoRoyals & from))
           pseudoRoyals ^= square_bb(from) ^ kto;
       if (type_of(m) == PROMOTION && (pseudo_royal_types() & promotion_type(m)))
       {
@@ -3292,7 +3295,9 @@ bool Position::legal(Move m) const {
       if (var->dupleCheck)
       {
           Bitboard pseudoRoyalCandidates = st->pseudoRoyalCandidates & pieces(sideToMove);
-          if (!rifleShot && is_ok(from) && (pseudoRoyalCandidates & from))
+          if (cloneMove && (pseudo_royal_types() & piece_set(movePt)))
+              pseudoRoyalCandidates |= kto;
+          else if (!rifleShot && is_ok(from) && (pseudoRoyalCandidates & from))
               pseudoRoyalCandidates ^= square_bb(from) ^ kto;
           if (type_of(m) == PROMOTION && (pseudo_royal_types() & promotion_type(m)))
               pseudoRoyalCandidates |= kto;
@@ -4361,6 +4366,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   }
   int pushRightsMask = 0;
   bool rifleShot = rifle_capture(m) && captured != NO_PIECE && type_of(m) != CASTLING;
+  bool cloneMove = is_clone_move(m);
   bool capturedDeadSquare = !dropMove && from != to && bool(st->deadSquares & to);
   PieceType exchanged = exchange_piece(m);
   Square jumpCapsq = is_jump_capture(m) ? jump_capture_square(from, to) : SQ_NONE;
@@ -4795,7 +4801,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   }
   else
   {
-      if (!pureWallMove)
+      if (!pureWallMove && !cloneMove)
           k ^= Zobrist::psq[pc][from] ^ Zobrist::psq[pc][to];
 
       // Reset rule 50 draw counter for irreversible moves
@@ -5017,6 +5023,24 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       else if (pureWallMove)
       {
           // Wall-only move: no mover piece is touched.
+      }
+      else if (cloneMove)
+      {
+          if (Eval::useNNUE)
+          {
+              dp.dirty_num = 1;
+              dp.piece[0] = pc;
+              dp.from[0] = SQ_NONE;
+              dp.to[0] = to;
+          }
+
+          put_piece(pc, to);
+          k ^= Zobrist::psq[pc][to];
+          st->materialKey ^= Zobrist::psq[pc][pieceCount[pc] - 1];
+          if (type_of(pc) == PAWN)
+              st->pawnKey ^= Zobrist::psq[pc][to];
+          else
+              st->nonPawnMaterial[us] += PieceValue[MG][pc];
       }
       else if (!rifleShot)
           move_piece(from, to);
@@ -6015,6 +6039,7 @@ void Position::undo_move(Move m) {
   Square from = from_sq(m);
   Square to = to_sq(m);
   bool rifleShot = rifle_capture(m) && st->capturedPiece != NO_PIECE && type_of(m) != CASTLING;
+  bool cloneMove = is_clone_move(m);
   Square moverSq = rifleShot ? from : to;
   Piece pc = piece_on(moverSq);
   PieceType exchange = exchange_piece(m);
@@ -6218,7 +6243,12 @@ void Position::undo_move(Move m) {
               put_piece(st->deadPiece, moverSq, st->deadPiecePromoted, st->deadUnpromotedPiece);
               pc = piece_on(moverSq);
           }
-          if (!rifleShot)
+          if (cloneMove)
+          {
+              remove_piece(to);
+              board[to] = NO_PIECE;
+          }
+          else if (!rifleShot)
               move_piece(to, from); // Put the piece back at the source square
       }
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -5026,6 +5026,9 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       }
       else if (cloneMove)
       {
+          bool clonedPromoted = is_promoted(from);
+          Piece clonedUnpromoted = clonedPromoted ? unpromoted_piece_on(from) : NO_PIECE;
+
           if (Eval::useNNUE)
           {
               dp.dirty_num = 1;
@@ -5034,7 +5037,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
               dp.to[0] = to;
           }
 
-          put_piece(pc, to);
+          put_piece(pc, to, clonedPromoted, clonedUnpromoted);
           k ^= Zobrist::psq[pc][to];
           st->materialKey ^= Zobrist::psq[pc][pieceCount[pc] - 1];
           if (type_of(pc) == PAWN)

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2740,6 +2740,8 @@ bool Position::legal(Move m) const {
 
   bool rifleShot = rifle_capture(m) && capture(m) && type_of(m) != CASTLING;
   bool cloneMove = is_clone_move(m);
+  if (cloneMove && !(clone_targets_from(us, from) & to))
+      return false;
   Square shotSq = capture(m) ? capture_square(m) : to;
   Bitboard removedAttackers = rifleShot ? square_bb(shotSq) : Bitboard(0);
   Square effectiveTo = rifleShot ? from : to;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2921,13 +2921,32 @@ bool Position::legal(Move m) const {
           return false;
   }
 
-  if (type_of(m) == DROP && (var->reciprocalWeakConnectionDrop || var->weakCrosscutDropIllegal))
+  if (type_of(m) == DROP
+      && (var->reciprocalWeakConnectionDrop
+          || var->weakCrosscutDropIllegal
+          || var->weakConnectionNobiImpossible))
   {
       auto has_color_at = [&](Color c, Square sq, Color placedColor) {
           return sq == to ? c == placedColor : bool(pieces(c) & sq);
       };
 
-      auto creates_hypothetical_weak_link = [&](Color c, Color placedColor) {
+      auto weak_link_between = [&](Color c, Color placedColor, Square a, Square b) {
+          if (!is_ok(a) || !is_ok(b))
+              return false;
+          if (!has_color_at(c, a, placedColor) || !has_color_at(c, b, placedColor))
+              return false;
+          int df = std::abs(int(file_of(a)) - int(file_of(b)));
+          int dr = std::abs(int(rank_of(a)) - int(rank_of(b)));
+          if (df != 1 || dr != 1)
+              return false;
+
+          Square bridge1 = make_square(file_of(a), rank_of(b));
+          Square bridge2 = make_square(file_of(b), rank_of(a));
+          return !has_color_at(c, bridge1, placedColor) && !has_color_at(c, bridge2, placedColor);
+      };
+
+      auto created_weak_link_anchors = [&](Color c, Color placedColor) {
+          std::vector<Square> anchors;
           static constexpr int dfile[4] = {1, -1, 1, -1};
           static constexpr int drank[4] = {1, 1, -1, -1};
           for (int i = 0; i < 4; ++i)
@@ -2938,22 +2957,93 @@ bool Position::legal(Move m) const {
                   continue;
 
               Square diag = make_square(File(nf), Rank(nr));
-              if (!has_color_at(c, diag, placedColor))
-                  continue;
+              if (weak_link_between(c, placedColor, to, diag))
+                  anchors.push_back(diag);
+          }
+          return anchors;
+      };
 
-              Square bridge1 = make_square(file_of(to), rank_of(diag));
-              Square bridge2 = make_square(file_of(diag), rank_of(to));
-              if (!has_color_at(c, bridge1, placedColor) && !has_color_at(c, bridge2, placedColor))
+      auto creates_hypothetical_weak_link = [&](Color c, Color placedColor) {
+          return !created_weak_link_anchors(c, placedColor).empty();
+      };
+
+      auto strong_nonweak_followup_exists = [&](Square anchor) {
+          auto occupied_any = [&](Square sq) {
+              return sq == to || bool(pieces() & sq);
+          };
+          auto friend_at = [&](Square sq) {
+              return has_color_at(us, sq, us);
+          };
+          auto enemy_at = [&](Square sq) {
+              return sq != to && bool(pieces(~us) & sq);
+          };
+          auto not_friend_at = [&](Square sq) {
+              return !friend_at(sq);
+          };
+
+          auto pattern_blocked = [&](Square q) {
+              if (q == anchor + NORTH) {
+                  Square nn = q + NORTH;
+                  Square nne = q + NORTH_EAST;
+                  Square nnw = q + NORTH_WEST;
+                  return (is_ok(nne) && friend_at(nne) && is_ok(nn) && not_friend_at(nn) && is_ok(anchor + NORTH_EAST) && not_friend_at(anchor + NORTH_EAST))
+                      || (is_ok(nnw) && friend_at(nnw) && is_ok(nn) && not_friend_at(nn) && is_ok(anchor + NORTH_WEST) && not_friend_at(anchor + NORTH_WEST))
+                      || (is_ok(nn) && friend_at(nn) && is_ok(nne) && enemy_at(nne) && is_ok(anchor + NORTH_EAST) && enemy_at(anchor + NORTH_EAST))
+                      || (is_ok(nn) && friend_at(nn) && is_ok(nnw) && enemy_at(nnw) && is_ok(anchor + NORTH_WEST) && enemy_at(anchor + NORTH_WEST));
+              }
+              if (q == anchor + SOUTH) {
+                  Square ss = q + SOUTH;
+                  Square sse = q + SOUTH_EAST;
+                  Square ssw = q + SOUTH_WEST;
+                  return (is_ok(sse) && friend_at(sse) && is_ok(ss) && not_friend_at(ss) && is_ok(anchor + SOUTH_EAST) && not_friend_at(anchor + SOUTH_EAST))
+                      || (is_ok(ssw) && friend_at(ssw) && is_ok(ss) && not_friend_at(ss) && is_ok(anchor + SOUTH_WEST) && not_friend_at(anchor + SOUTH_WEST))
+                      || (is_ok(ss) && friend_at(ss) && is_ok(sse) && enemy_at(sse) && is_ok(anchor + SOUTH_EAST) && enemy_at(anchor + SOUTH_EAST))
+                      || (is_ok(ss) && friend_at(ss) && is_ok(ssw) && enemy_at(ssw) && is_ok(anchor + SOUTH_WEST) && enemy_at(anchor + SOUTH_WEST));
+              }
+              if (q == anchor + EAST) {
+                  Square ee = q + EAST;
+                  Square nee = q + NORTH_EAST;
+                  Square see = q + SOUTH_EAST;
+                  return (is_ok(nee) && friend_at(nee) && is_ok(ee) && not_friend_at(ee) && is_ok(anchor + NORTH_EAST) && not_friend_at(anchor + NORTH_EAST))
+                      || (is_ok(see) && friend_at(see) && is_ok(ee) && not_friend_at(ee) && is_ok(anchor + SOUTH_EAST) && not_friend_at(anchor + SOUTH_EAST))
+                      || (is_ok(ee) && friend_at(ee) && is_ok(nee) && enemy_at(nee) && is_ok(anchor + NORTH_EAST) && enemy_at(anchor + NORTH_EAST))
+                      || (is_ok(ee) && friend_at(ee) && is_ok(see) && enemy_at(see) && is_ok(anchor + SOUTH_EAST) && enemy_at(anchor + SOUTH_EAST));
+              }
+              if (q == anchor + WEST) {
+                  Square ww = q + WEST;
+                  Square nww = q + NORTH_WEST;
+                  Square sww = q + SOUTH_WEST;
+                  return (is_ok(nww) && friend_at(nww) && is_ok(ww) && not_friend_at(ww) && is_ok(anchor + NORTH_WEST) && not_friend_at(anchor + NORTH_WEST))
+                      || (is_ok(sww) && friend_at(sww) && is_ok(ww) && not_friend_at(ww) && is_ok(anchor + SOUTH_WEST) && not_friend_at(anchor + SOUTH_WEST))
+                      || (is_ok(ww) && friend_at(ww) && is_ok(nww) && enemy_at(nww) && is_ok(anchor + NORTH_WEST) && enemy_at(anchor + NORTH_WEST))
+                      || (is_ok(ww) && friend_at(ww) && is_ok(sww) && enemy_at(sww) && is_ok(anchor + SOUTH_WEST) && enemy_at(anchor + SOUTH_WEST));
+              }
+              return true;
+          };
+
+          static constexpr Direction orth[] = {NORTH, SOUTH, EAST, WEST};
+          for (Direction d : orth)
+          {
+              Square q = anchor + d;
+              if (!is_ok(q) || occupied_any(q))
+                  continue;
+              if (!pattern_blocked(q))
                   return true;
           }
           return false;
       };
 
-      bool weakFriendly = creates_hypothetical_weak_link(us, us);
+      std::vector<Square> weakFriendlyAnchors = created_weak_link_anchors(us, us);
+      bool weakFriendly = !weakFriendlyAnchors.empty();
       if (weakFriendly)
       {
           if (var->reciprocalWeakConnectionDrop && !creates_hypothetical_weak_link(~us, ~us))
               return false;
+
+          if (var->weakConnectionNobiImpossible)
+              for (Square anchor : weakFriendlyAnchors)
+                  if (strong_nonweak_followup_exists(anchor))
+                      return false;
 
           if (var->weakCrosscutDropIllegal)
           {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -960,6 +960,25 @@ Key Position::material_key(EndgameEval e) const {
   return st->materialKey ^ reserve_key() ^ Zobrist::endgame[e];
 }
 
+Key Position::compute_material_key() const {
+
+  Key key = 0;
+
+  for (Color c : {WHITE, BLACK})
+      for (PieceType pt = PAWN; pt <= KING; ++pt)
+      {
+          Piece pc = make_piece(c, pt);
+          for (int cnt = 0; cnt < pieceCount[pc]; ++cnt)
+              key ^= Zobrist::psq[pc][cnt];
+      }
+
+  return key;
+}
+
+bool Position::material_key_is_ok() const {
+  return compute_material_key() == st->materialKey;
+}
+
 
 /// Position::set() initializes the position object with the given FEN string.
 /// This function is not very robust - make sure that input FENs are correct,
@@ -7521,6 +7540,9 @@ bool Position::pos_is_ok() const {
               || (count<KING>(c) && (castlingRightsMask[square<KING>(c)] & cr) != cr))
               assert(0 && "pos_is_ok: Castling");
       }
+
+  if (!material_key_is_ok())
+      assert(0 && "pos_is_ok: materialKey");
 
   return true;
 }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -679,6 +679,97 @@ namespace {
 
 std::ostream& operator<<(std::ostream& os, const Position& pos) {
 
+  auto append_debug_footer = [&]() {
+      os << "\nFen: " << pos.fen() << "\nSfen: " << pos.fen(true) << "\nKey: " << std::hex << std::uppercase
+         << std::setfill('0') << std::setw(16) << pos.key()
+         << std::setfill(' ') << std::dec << "\nCheckers: ";
+
+      for (Bitboard b = pos.checkers(); b; )
+          os << UCI::square(pos, pop_lsb(b)) << " ";
+
+      os << "\nChased: ";
+      for (Bitboard b = pos.state()->chased; b; )
+          os << UCI::square(pos, pop_lsb(b)) << " ";
+
+      if (    int(Tablebases::MaxCardinality) >= popcount(pos.pieces())
+          && Options["UCI_Variant"] == "chess"
+          && !pos.can_castle(ANY_CASTLING))
+      {
+          StateInfo st;
+          ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
+
+          Position p;
+          p.set(pos.variant(), pos.fen(), pos.is_chess960(), &st, pos.this_thread());
+          Tablebases::ProbeState s1, s2;
+          Tablebases::WDLScore wdl = Tablebases::probe_wdl(p, &s1);
+          int dtz = Tablebases::probe_dtz(p, &s2);
+          os << "\nTablebases WDL: " << std::setw(4) << wdl << " (" << s1 << ")"
+             << "\nTablebases DTZ: " << std::setw(4) << dtz << " (" << s2 << ")";
+      }
+  };
+
+  auto emit_debug_square = [&](Square sq) {
+      if (pos.state()->deadSquares & sq)
+          os << " ^";
+      else if (pos.state()->wallSquares & sq)
+          os << " *";
+      else if (pos.variant()->shogiStylePromotions && pos.unpromoted_piece_on(sq))
+          os << "+" << pos.piece_symbol(pos.unpromoted_piece_on(sq));
+      else if (((pos.captures_to_hand() && !pos.drop_loop()) || pos.two_boards()) && pos.is_promoted(sq))
+          os << "~" << pos.piece_symbol(pos.piece_on(sq));
+      else
+      {
+          const std::string& symbol = pos.piece_symbol(pos.piece_on(sq));
+          os << " " << (symbol.empty() ? " " : symbol);
+      }
+  };
+
+  if (pos.is_hex_board())
+  {
+      for (Rank r = pos.max_rank(); r >= RANK_1; --r)
+      {
+          os << "\n " << std::string(int(pos.max_rank() - r) * 2, ' ');
+          for (File f = FILE_A; f <= pos.max_file(); ++f)
+          {
+              Square sq = make_square(f, r);
+              os << "[";
+              emit_debug_square(sq);
+              os << "]";
+              if (f != pos.max_file())
+                  os << " ";
+          }
+#ifdef LARGEBOARDS
+          os << " " << (pos.max_rank() == RANK_10 && CurrentProtocol != UCI_GENERAL ? r : 1 + r);
+#else
+          os << " " << (1 + r);
+#endif
+          if (r == pos.max_rank() || r == RANK_1)
+          {
+              Color c = r == RANK_1 ? WHITE : BLACK;
+              os << (c == pos.side_to_move() ? " *" : "  ");
+              if (!pos.free_drops() && (pos.piece_drops() || pos.seirawan_gating()))
+              {
+                  os << " [";
+                  for (PieceType pt = KING; pt >= PAWN; --pt)
+                      for (int i = 0; i < pos.count_in_hand(c, pt); ++i)
+                          os << pos.piece_symbol(make_piece(c, pt));
+                  os << "]";
+              }
+          }
+      }
+
+      os << "\n ";
+      for (File f = FILE_A; f <= pos.max_file(); ++f)
+      {
+          if (f)
+              os << "   ";
+          os << char('a' + f);
+      }
+      os << "\n";
+      append_debug_footer();
+      return os;
+  }
+
   os << "\n ";
   for (File f = FILE_A; f <= pos.max_file(); ++f)
       os << "+---";
@@ -734,32 +825,7 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
   for (File f = FILE_A; f <= pos.max_file(); ++f)
       os << "   " << char('a' + f);
   os << "\n";
-  os << "\nFen: " << pos.fen() << "\nSfen: " << pos.fen(true) << "\nKey: " << std::hex << std::uppercase
-     << std::setfill('0') << std::setw(16) << pos.key()
-     << std::setfill(' ') << std::dec << "\nCheckers: ";
-
-  for (Bitboard b = pos.checkers(); b; )
-      os << UCI::square(pos, pop_lsb(b)) << " ";
-
-  os << "\nChased: ";
-  for (Bitboard b = pos.state()->chased; b; )
-      os << UCI::square(pos, pop_lsb(b)) << " ";
-
-  if (    int(Tablebases::MaxCardinality) >= popcount(pos.pieces())
-      && Options["UCI_Variant"] == "chess"
-      && !pos.can_castle(ANY_CASTLING))
-  {
-      StateInfo st;
-      ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
-
-      Position p;
-      p.set(pos.variant(), pos.fen(), pos.is_chess960(), &st, pos.this_thread());
-      Tablebases::ProbeState s1, s2;
-      Tablebases::WDLScore wdl = Tablebases::probe_wdl(p, &s1);
-      int dtz = Tablebases::probe_dtz(p, &s2);
-      os << "\nTablebases WDL: " << std::setw(4) << wdl << " (" << s1 << ")"
-         << "\nTablebases DTZ: " << std::setw(4) << dtz << " (" << s2 << ")";
-  }
+  append_debug_footer();
 
   return os;
 }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1795,6 +1795,7 @@ void Position::set_state(StateInfo* si) const {
   si->colorChangedUnpromoted = NO_PIECE;
   si->claimedSquares = 0;
   si->pendingClaimPass = false;
+  si->dropHandColor = COLOR_NB;
   si->forcedJumpSquare = SQ_NONE;
   si->forcedJumpHasFollowup = false;
   si->forcedJumpStep = 0;
@@ -3393,6 +3394,7 @@ bool Position::pseudo_legal(const Move m) const {
   Square from = from_sq(m);
   Square to = to_sq(m);
   Piece pc = moved_piece(m);
+  Color dropColor = dropMove ? drop_hand_color(us, in_hand_piece_type(m)) : us;
   bool rifleShot = rifle_capture(m) && capture(m) && type_of(m) != CASTLING;
   Square effectiveTo = rifleShot ? from : to;
   Bitboard removedAttackers = capture(m) ? square_bb(capture_square(m)) : Bitboard(0);
@@ -3496,7 +3498,7 @@ bool Position::pseudo_legal(const Move m) const {
 
           return   piece_drops()
                 && pc != NO_PIECE
-                && color_of(pc) == us
+                && color_of(pc) == dropColor
                 && (edge_insert_types() & type_of(pc))
                 && (edge_insert_region(us) & to)
                 && dirOk
@@ -3521,10 +3523,11 @@ bool Position::pseudo_legal(const Move m) const {
       if (paired_drop(m))
       {
           Square to2 = secondary_drop_square(m);
+          Color handColor = drop_hand_color(us, in_hand_piece_type(m));
           return   piece_drops()
                 && pc != NO_PIECE
-                && color_of(pc) == us
-                && count_in_hand(us, in_hand_piece_type(m)) >= 2
+                && color_of(pc) == handColor
+                && count_in_hand(handColor, in_hand_piece_type(m)) >= 2
                 && (symmetric_drop_types() & in_hand_piece_type(m))
                 && (!pay_points_to_drop() || st->pointsCount[us] >= 2 * var->piecePoints[type_of(pc)])
                 && !(pieces() & to2)
@@ -3537,7 +3540,7 @@ bool Position::pseudo_legal(const Move m) const {
 
       return   piece_drops()
             && pc != NO_PIECE
-            && color_of(pc) == us
+            && color_of(pc) == dropColor
             && (!pay_points_to_drop() || st->pointsCount[us] >= var->piecePoints[type_of(pc)])
             && (can_drop(us, in_hand_piece_type(m))
                 || (two_boards() && allow_virtual_drop(us, type_of(pc)))
@@ -4039,6 +4042,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   Square from = from_sq(m);
   Square to = to_sq(m);
   Piece pc = moved_piece(m);
+  Color dropColor = dropMove ? drop_hand_color(us, in_hand_piece_type(m)) : us;
   PieceType movedType = type_of(pc);
   Piece captured = captured_piece(m);
   if (type_of(m) == CASTLING && captured == NO_PIECE)
@@ -4117,6 +4121,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   st->pass = is_pass(m) && !openingSelfRemoval;
   st->claimedSquares = 0;
   st->pendingClaimPass = false;
+  st->dropHandColor = COLOR_NB;
   st->suppressedCaptureTransfer = false;
 
   if (stepwisePush)
@@ -4144,7 +4149,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
 
   ScopedSpellContext spellScope(freezeExtra, jumpRemoved);
 
-  assert(pureWallMove || color_of(pc) == us);
+  assert(pureWallMove || color_of(pc) == dropColor);
   assert(captured == NO_PIECE
          || (type_of(m) == CASTLING ? color_of(captured) == us
                                     : (color_of(captured) == them
@@ -4459,7 +4464,8 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   // Update hash key
   if (dropMove)
   {
-      Piece pc_hand = make_piece(us, in_hand_piece_type(m));
+      st->dropHandColor = dropColor;
+      Piece pc_hand = make_piece(dropColor, in_hand_piece_type(m));
       k ^= Zobrist::psq[pc][to];
       if (paired_drop(m))
       {
@@ -4586,16 +4592,16 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       {
           // Add drop piece
           dp.piece[0] = pc;
-          dp.handPiece[0] = make_piece(us, in_hand_piece_type(m));
-          dp.handCount[0] = pieceCountInHand[us][in_hand_piece_type(m)];
+          dp.handPiece[0] = make_piece(dropColor, in_hand_piece_type(m));
+          dp.handCount[0] = pieceCountInHand[dropColor][in_hand_piece_type(m)];
           dp.from[0] = SQ_NONE;
           dp.to[0] = to;
           if (paired_drop(m))
           {
               dp.dirty_num = 2;
               dp.piece[1] = pc;
-              dp.handPiece[1] = make_piece(us, in_hand_piece_type(m));
-              dp.handCount[1] = pieceCountInHand[us][in_hand_piece_type(m)] - 1;
+              dp.handPiece[1] = make_piece(dropColor, in_hand_piece_type(m));
+              dp.handCount[1] = pieceCountInHand[dropColor][in_hand_piece_type(m)] - 1;
               dp.from[1] = SQ_NONE;
               dp.to[1] = secondary_drop_square(m);
           }
@@ -4607,9 +4613,9 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
               st->nnueRefreshNeeded = true;
       }
 
-      drop_piece(make_piece(us, in_hand_piece_type(m)), pc, to, exchanged);
+      drop_piece(make_piece(dropColor, in_hand_piece_type(m)), pc, to, exchanged);
       if (paired_drop(m))
-          drop_piece(make_piece(us, in_hand_piece_type(m)), pc, secondary_drop_square(m), NO_PIECE_TYPE);
+          drop_piece(make_piece(dropColor, in_hand_piece_type(m)), pc, secondary_drop_square(m), NO_PIECE_TYPE);
       st->materialKey ^= Zobrist::psq[pc][pieceCount[pc]-1];
       if (paired_drop(m))
           st->materialKey ^= Zobrist::psq[pc][pieceCount[pc]-2];
@@ -5898,9 +5904,10 @@ void Position::undo_move(Move m) {
   {
       if (is_drop_move(m))
       {
+          Color dropColor = st->dropHandColor != COLOR_NB ? st->dropHandColor : us;
           if (paired_drop(m))
-              undrop_piece(make_piece(us, in_hand_piece_type(m)), secondary_drop_square(m), NO_PIECE_TYPE);
-          undrop_piece(make_piece(us, in_hand_piece_type(m)), to, exchange); // Remove the dropped piece
+              undrop_piece(make_piece(dropColor, in_hand_piece_type(m)), secondary_drop_square(m), NO_PIECE_TYPE);
+          undrop_piece(make_piece(dropColor, in_hand_piece_type(m)), to, exchange); // Remove the dropped piece
       }
       else if (wasOpeningSelfRemoval)
           put_piece(st->deadPiece, from, st->deadPiecePromoted, st->deadUnpromotedPiece);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -6936,30 +6936,36 @@ bool Position::is_immediate_game_end(Value& result, int ply) const {
       }
   }
 
-  if ((var->connectRegion1[~sideToMove] & connectPieces) && (var->connectRegion2[~sideToMove] & connectPieces))
-  {
-      Bitboard target = var->connectRegion2[~sideToMove];
-      Bitboard current = var->connectRegion1[~sideToMove] & connectPieces;
+  auto connected_regions = [&](Bitboard region1, Bitboard region2, Bitboard region3 = 0) {
+      if (!(region1 & connectPieces) || !(region2 & connectPieces) || (region3 && !(region3 & connectPieces)))
+          return false;
+
+      Bitboard current = region1 & connectPieces;
+      bool hitsRegion2 = bool(current & region2);
+      bool hitsRegion3 = !region3 || bool(current & region3);
 
       while (true) {
           Bitboard newBitboard = 0;
-          for (Direction d : var->connectDirections) {
-              newBitboard |= shift(d, current | newBitboard) & connectPieces; // the "| newBitboard" here probably saves a few loops
-          }
+          for (Direction d : var->connectDirections)
+              newBitboard |= shift(d, current | newBitboard) & connectPieces;
 
-          if (newBitboard & target) {
-              // A connection has been made
-              result = convert_mate_value(-connect_value(), ply);
+          hitsRegion2 |= bool(newBitboard & region2);
+          hitsRegion3 |= !region3 || bool(newBitboard & region3);
+          if (hitsRegion2 && hitsRegion3)
               return true;
-          }
 
-          if (!(newBitboard & ~current)) {
-              // The expansion got stuck; no further squares to explore
-              break;
-          }
+          if (!(newBitboard & ~current))
+              return false;
 
           current |= newBitboard;
       }
+  };
+
+  if (connected_regions(var->connectRegion1[~sideToMove], var->connectRegion2[~sideToMove],
+                        var->connectRegion3[~sideToMove]))
+  {
+      result = convert_mate_value(-connect_value(), ply);
+      return true;
   }
 
   if ((connect_nxn()) && (popcount(connectPieces) >= connect_nxn() * connect_nxn()))
@@ -7317,8 +7323,8 @@ bool Position::see_pruning_unreliable() const {
       || connect_n() > 0
       || connect_nxn() > 0
       || collinear_n() > 0
-      || var->connectRegion1[WHITE] || var->connectRegion2[WHITE]
-      || var->connectRegion1[BLACK] || var->connectRegion2[BLACK]
+      || var->connectRegion1[WHITE] || var->connectRegion2[WHITE] || var->connectRegion3[WHITE]
+      || var->connectRegion1[BLACK] || var->connectRegion2[BLACK] || var->connectRegion3[BLACK]
       || !connect_piece_goal_types(WHITE).empty()
       || !connect_piece_goal_types(BLACK).empty()
       || connect_group() != 0;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2288,6 +2288,7 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
       {
           PieceType pt = pop_lsb(ps);
           RiderType riderTypes = AttackRiderTypes[pt];
+          const PieceInfo* pi = pieceMap.get(pt);
           Bitboard ptPieces = pieces(c, pt);
           Bitboard b = sliders & (PseudoAttacks[~c][pt][s] ^ LeaperAttacks[~c][pt][s]) & ptPieces;
           if (b)
@@ -2305,7 +2306,7 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
               }
               else
                   snipers |= b & ~attacks_bb(~c, pt, s, pieces());
-              if (riderTypes & ~HOPPING_RIDERS)
+              if ((riderTypes & ~HOPPING_RIDERS) || !pi->tupleSlider[0][MODALITY_CAPTURE].empty())
                   slidingSnipers |= snipers & ptPieces;
           }
       }

--- a/src/position.h
+++ b/src/position.h
@@ -352,6 +352,7 @@ public:
   bool captures_to_hand() const;
   PieceSet capture_to_hand_types() const;
   PieceSet self_destruct_types() const;
+  PieceSet clone_move_types() const;
   bool first_rank_pawn_drops() const;
   bool can_drop(Color c, PieceType pt) const;
   bool has_exchange() const;
@@ -551,6 +552,7 @@ public:
   Square jump_capture_square(Square from, Square to) const;
   bool gives_check(Move m) const;
   Piece moved_piece(Move m) const;
+  bool is_clone_move(Move m) const;
   Piece captured_piece() const;
   Piece captured_piece(Move m) const;
   const std::string piece_to_partner() const;
@@ -1688,6 +1690,11 @@ inline PieceSet Position::self_destruct_types() const {
   return var->selfDestructTypes;
 }
 
+inline PieceSet Position::clone_move_types() const {
+  assert(var != nullptr);
+  return var->cloneMoveTypes;
+}
+
 inline bool Position::first_rank_pawn_drops() const {
   assert(var != nullptr);
   return var->firstRankPawnDrops;
@@ -2541,6 +2548,14 @@ inline Piece Position::moved_piece(Move m) const {
   if (is_drop_move(m))
       return make_piece(drop_hand_color(sideToMove, in_hand_piece_type(m)), dropped_piece_type(m));
   return piece_on(from_sq(m));
+}
+
+inline bool Position::is_clone_move(Move m) const {
+  if (type_of(m) != SPECIAL || is_gating(m) || from_sq(m) == to_sq(m))
+      return false;
+
+  Piece mover = moved_piece(m);
+  return mover != NO_PIECE && (clone_move_types() & piece_set(type_of(mover)));
 }
 
 inline Bitboard Position::pieces(PieceType pt) const {

--- a/src/position.h
+++ b/src/position.h
@@ -3277,7 +3277,7 @@ inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s, Bitboard
   const PieceInfo* pi = pieceMap.get(movePt);
 
   if ((fast_attacks() || fast_attacks2()) && pi->riderAugmentMask == PieceInfo::AUGMENT_NONE)
-      return attacks_bb(c, pt, s, occupancy) & board_bb();
+      return attacks_bb(c, movePt, s, occupancy) & board_bb();
 
   if (pi->friendlyJump)
       occupancy &= ~pieces(c);
@@ -3456,7 +3456,7 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
   const PieceInfo* pi = pieceMap.get(movePt);
 
   if ((fast_attacks() || fast_attacks2()) && pi->riderAugmentMask == PieceInfo::AUGMENT_NONE)
-      return (moves_bb(c, pt, s, occupancy) | extraDestinations) & board_bb();
+      return (moves_bb(c, movePt, s, occupancy) | extraDestinations) & board_bb();
 
   if (pi->friendlyJump)
       occupancy &= ~pieces(c);

--- a/src/position.h
+++ b/src/position.h
@@ -666,6 +666,11 @@ private:
                                         File maxFile, Rank maxRank,
                                         bool wrapFile, bool wrapRank,
                                         bool requireEmpty);
+  static Bitboard wrapped_tuple_rider_targets(const std::vector<PieceInfo::TupleRay>& rays,
+                                              Color c, Square sq, Bitboard occupied,
+                                              File maxFile, Rank maxRank,
+                                              bool wrapFile, bool wrapRank,
+                                              bool quietMode);
   static Bitboard wrapped_slider_targets(const std::map<Direction, int>& directions,
                                          Square sq, Bitboard occupied,
                                          File maxFile, Rank maxRank,
@@ -2815,6 +2820,40 @@ inline Bitboard Position::wrapped_tuple_targets(const std::vector<std::pair<int,
   return out;
 }
 
+inline Bitboard Position::wrapped_tuple_rider_targets(const std::vector<PieceInfo::TupleRay>& rays,
+                                                      Color c, Square sq, Bitboard occupied,
+                                                      File maxFile, Rank maxRank,
+                                                      bool wrapFile, bool wrapRank,
+                                                      bool quietMode) {
+  Bitboard out = 0;
+  for (const auto& ray : rays)
+  {
+      const int stepR = c == WHITE ? ray.dr : -ray.dr;
+      const int stepF = c == WHITE ? ray.df : -ray.df;
+      Square current = sq;
+      int count = 0;
+      for (;;)
+      {
+          Square next = SQ_NONE;
+          if (!wrapped_destination_square(current, stepF, stepR, maxFile, maxRank, wrapFile, wrapRank, next))
+              break;
+          if (next == sq)
+              break;
+
+          const bool blocked = bool(occupied & next);
+          if (!quietMode || !blocked)
+              out |= next;
+
+          current = next;
+          if (ray.limit > 0 && ++count >= ray.limit)
+              break;
+          if (blocked)
+              break;
+      }
+  }
+  return out;
+}
+
 inline Bitboard Position::wrapped_slider_targets(const std::map<Direction, int>& directions,
                                                  Square sq, Bitboard occupied,
                                                  File maxFile, Rank maxRank,
@@ -3174,6 +3213,7 @@ inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s, Bitboard
 
       b |= wrapped_step_targets(pi->steps[0][MODALITY_CAPTURE], s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, false);
       b |= wrapped_tuple_targets(pi->tupleSteps[0][MODALITY_CAPTURE], c, s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, false);
+      b |= wrapped_tuple_rider_targets(pi->tupleSlider[0][MODALITY_CAPTURE], c, s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, false);
       b |= wrapped_slider_targets(pi->slider[0][MODALITY_CAPTURE], s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, false);
       b |= wrapped_hopper_targets(pi->hopper[0][MODALITY_CAPTURE], s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, false);
       b |= wrapped_contra_hopper_targets(pi->contraHopper[0][MODALITY_CAPTURE], c, s, occupancy, pieces(c), max_file(), max_rank(), wrapFile, wrapRank, false, true);
@@ -3318,6 +3358,7 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
         Bitboard b = 0;
         b |= wrapped_step_targets(pi->steps[0][MODALITY_QUIET], s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
         b |= wrapped_tuple_targets(pi->tupleSteps[0][MODALITY_QUIET], c, s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
+        b |= wrapped_tuple_rider_targets(pi->tupleSlider[0][MODALITY_QUIET], c, s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
         b |= wrapped_slider_targets(pi->slider[0][MODALITY_QUIET], s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
         b |= wrapped_hopper_targets(pi->hopper[0][MODALITY_QUIET], s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
         b |= wrapped_contra_hopper_targets(pi->contraHopper[0][MODALITY_QUIET], c, s, occupancy, pieces(c), max_file(), max_rank(), wrapFile, wrapRank, true, false);
@@ -3333,6 +3374,7 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
         {
             b |= wrapped_step_targets(pi->steps[1][MODALITY_QUIET], s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
             b |= wrapped_tuple_targets(pi->tupleSteps[1][MODALITY_QUIET], c, s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
+            b |= wrapped_tuple_rider_targets(pi->tupleSlider[1][MODALITY_QUIET], c, s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
             b |= wrapped_slider_targets(pi->slider[1][MODALITY_QUIET], s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
             b |= wrapped_hopper_targets(pi->hopper[1][MODALITY_QUIET], s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
             b |= wrapped_contra_hopper_targets(pi->contraHopper[1][MODALITY_QUIET], c, s, occupancy, pieces(c), max_file(), max_rank(), wrapFile, wrapRank, true, false);

--- a/src/position.h
+++ b/src/position.h
@@ -142,6 +142,7 @@ struct StateInfo {
   bool       pass;
   Bitboard   claimedSquares;
   bool       pendingClaimPass;
+  Color      dropHandColor;
   Square     forcedJumpSquare;
   bool       forcedJumpHasFollowup;
   int        forcedJumpStep;
@@ -345,6 +346,7 @@ public:
   Bitboard opening_swap_drop_targets(Color c, PieceType pt) const;
   bool is_opening_self_removal_move(Move m) const;
   bool piece_drops() const;
+  Color drop_hand_color(Color c, PieceType pt) const;
   bool drop_loop() const;
   bool captures_to_hand() const;
   PieceSet capture_to_hand_types() const;
@@ -1612,6 +1614,17 @@ inline bool Position::piece_drops() const {
   return var->pieceDrops;
 }
 
+inline Color Position::drop_hand_color(Color c, PieceType pt) const {
+  assert(var != nullptr);
+  if (   var->borrowOpponentDropsWhenEmpty
+      && !var->freeDrops
+      && pt != ALL_PIECES
+      && count_in_hand(c, ALL_PIECES) == 0
+      && count_in_hand(~c, pt) > 0)
+      return ~c;
+  return c;
+}
+
 inline bool Position::drop_loop() const {
   assert(var != nullptr);
   return var->dropLoop;
@@ -2503,7 +2516,7 @@ inline Piece Position::unpromoted_piece_on(Square s) const {
 
 inline Piece Position::moved_piece(Move m) const {
   if (is_drop_move(m))
-      return make_piece(sideToMove, dropped_piece_type(m));
+      return make_piece(drop_hand_color(sideToMove, in_hand_piece_type(m)), dropped_piece_type(m));
   return piece_on(from_sq(m));
 }
 
@@ -3975,13 +3988,18 @@ inline bool Position::can_drop(Color c, PieceType pt) const {
       return true;
 
   if (pt == ALL_PIECES)
-      return count_in_hand(c, pt) > 0;
+      return count_in_hand(c, pt) > 0
+          || (variant()->borrowOpponentDropsWhenEmpty
+              && count_in_hand(c, ALL_PIECES) == 0
+              && count_in_hand(~c, ALL_PIECES) > 0);
 
-  if (count_in_hand(c, pt) <= 0)
+  Color handColor = drop_hand_color(c, pt);
+
+  if (count_in_hand(handColor, pt) <= 0)
       return false;
 
   if (variant()->dropKingLast && pt == king_type())
-      return count_in_hand(c, ALL_PIECES) <= count_in_hand(c, pt);
+      return count_in_hand(handColor, ALL_PIECES) <= count_in_hand(handColor, pt);
 
   return true;
 }

--- a/src/position.h
+++ b/src/position.h
@@ -353,6 +353,8 @@ public:
   PieceSet capture_to_hand_types() const;
   PieceSet self_destruct_types() const;
   PieceSet clone_move_types() const;
+  bool can_clone(Piece p) const;
+  Bitboard clone_targets_from(Color c, Square from) const;
   bool first_rank_pawn_drops() const;
   bool can_drop(Color c, PieceType pt) const;
   bool has_exchange() const;
@@ -1695,6 +1697,10 @@ inline PieceSet Position::clone_move_types() const {
   return var->cloneMoveTypes;
 }
 
+inline bool Position::can_clone(Piece p) const {
+  return p != NO_PIECE && (clone_move_types() & piece_set(type_of(p)));
+}
+
 inline bool Position::first_rank_pawn_drops() const {
   assert(var != nullptr);
   return var->firstRankPawnDrops;
@@ -2554,8 +2560,16 @@ inline bool Position::is_clone_move(Move m) const {
   if (type_of(m) != SPECIAL || is_gating(m) || from_sq(m) == to_sq(m))
       return false;
 
-  Piece mover = moved_piece(m);
-  return mover != NO_PIECE && (clone_move_types() & piece_set(type_of(mover)));
+  return can_clone(moved_piece(m));
+}
+
+inline Bitboard Position::clone_targets_from(Color c, Square from) const {
+  Piece mover = piece_on(from);
+  if (color_of(mover) != c || !can_clone(mover))
+      return 0;
+
+  PieceType pt = type_of(mover);
+  return (moves_from(c, pt, from) & ~pieces()) | (attacks_from(c, pt, from) & pieces(~c));
 }
 
 inline Bitboard Position::pieces(PieceType pt) const {

--- a/src/position.h
+++ b/src/position.h
@@ -609,6 +609,7 @@ public:
 
   // Position consistency check, for debugging
   bool pos_is_ok() const;
+  bool material_key_is_ok() const;
   void refresh_state_derived(StateInfo* si) const;
   void flip();
 
@@ -623,6 +624,7 @@ private:
   void set_castling_right(Color c, Square rfrom);
   void set_state(StateInfo* si) const;
   void recompute_state_hashes_and_material(StateInfo* si) const;
+  Key compute_material_key() const;
   Bitboard compute_checkers_bb(Color side) const;
   Bitboard compute_evasion_checkers_bb(Color side) const;
   void set_check_info(StateInfo* si) const;

--- a/src/position.h
+++ b/src/position.h
@@ -306,6 +306,7 @@ public:
   bool wraps_files() const;
   bool wraps_ranks() const;
   bool topology_wraps() const;
+  bool is_hex_board() const;
   bool checking_permitted() const;
   bool allow_checks() const;
   bool drop_checks() const;
@@ -1323,6 +1324,11 @@ inline bool Position::wraps_ranks() const {
 
 inline bool Position::topology_wraps() const {
   return wraps_files() || wraps_ranks();
+}
+
+inline bool Position::is_hex_board() const {
+  assert(var != nullptr);
+  return var->hexBoard;
 }
 
 inline bool Position::drop_checks() const {

--- a/src/position.h
+++ b/src/position.h
@@ -446,6 +446,7 @@ public:
   bool connect_horizontal() const;
   bool connect_vertical() const;
   bool connect_diagonal() const;
+  bool weak_diagonal_connect() const;
   const std::vector<Direction>& getConnectDirections() const;
   const std::vector<std::vector<Square>>& getConnectLines() const;
   int connect_nxn() const;
@@ -1602,7 +1603,12 @@ inline Bitboard Position::opening_swap_drop_targets(Color c, PieceType pt) const
   if (!(drop_piece_types(pt) & pt))
       return Bitboard(0);
 
-  return drop_region(c, pt) & enemy;
+  if (!var->openingSwapMirrorMainDiagonal)
+      return drop_region(c, pt) & enemy;
+
+  Square enemySq = lsb(enemy);
+  Square mirrorSq = make_square(File(int(rank_of(enemySq))), Rank(int(file_of(enemySq))));
+  return drop_region(c, pt) & square_bb(mirrorSq);
 }
 
 inline bool Position::is_opening_self_removal_move(Move m) const {
@@ -2386,6 +2392,10 @@ inline bool Position::connect_vertical() const {
 inline bool Position::connect_diagonal() const {
   assert(var != nullptr);
   return var->connectDiagonal;
+}
+inline bool Position::weak_diagonal_connect() const {
+  assert(var != nullptr);
+  return var->weakDiagonalConnect;
 }
 
 inline const std::vector<Direction>& Position::getConnectDirections() const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -584,10 +584,13 @@ void Thread::search() {
          lastBestMoveDepth = rootDepth;
       }
 
-      // Have we found a "mate in x"?
+      // Have we found a "mate in x" after a completed iteration?
       if (   Limits.mate
-          && bestValue >= VALUE_MATE_IN_MAX_PLY
-          && VALUE_MATE - bestValue <= 2 * Limits.mate)
+          && !Threads.stop
+          && (   (rootMoves[0].score >= VALUE_MATE_IN_MAX_PLY
+                && VALUE_MATE - rootMoves[0].score <= 2 * Limits.mate)
+              || (rootMoves[0].score <= VALUE_MATED_IN_MAX_PLY
+                && VALUE_MATE + rootMoves[0].score <= 2 * Limits.mate)))
           Threads.stop = true;
 
       if (!mainThread)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -304,8 +304,13 @@ void MainThread::search() {
                                              : "stalemate");
   }
 
-  // Send again PV info if we have a new best thread
-  if (bestThread != this && show_search_output())
+  bool extractedPonder = false;
+
+  if (bestThread->rootMoves[0].pv.size() == 1)
+      extractedPonder = bestThread->rootMoves[0].extract_ponder_from_tt(rootPos);
+
+  // Send again PV info if we have a new best thread or extracted a ponder move.
+  if ((bestThread != this || extractedPonder) && show_search_output())
       sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
 
   if (CurrentProtocol == XBOARD)
@@ -341,8 +346,7 @@ void MainThread::search() {
           {
               XBoard::stateMachine->do_move(bestMove);
               XBoard::stateMachine->moveAfterSearch = false;
-              if (Options["Ponder"] && (   bestThread->rootMoves[0].pv.size() > 1
-                                        || bestThread->rootMoves[0].extract_ponder_from_tt(rootPos)))
+              if (Options["Ponder"] && bestThread->rootMoves[0].pv.size() > 1)
                   XBoard::stateMachine->ponderMove = bestThread->rootMoves[0].pv[1];
           }
       }
@@ -352,7 +356,7 @@ void MainThread::search() {
   SyncCout out;
   out << "bestmove " << UCI::move(rootPos, bestThread->rootMoves[0].pv[0]);
 
-  if (bestThread->rootMoves[0].pv.size() > 1 || bestThread->rootMoves[0].extract_ponder_from_tt(rootPos))
+  if (bestThread->rootMoves[0].pv.size() > 1)
       out << " ponder " << UCI::move(rootPos, bestThread->rootMoves[0].pv[1]);
 
   out << sync_endl;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -284,6 +284,7 @@ void MainThread::search() {
 
   if (   int(Options["MultiPV"]) == 1
       && !Limits.depth
+      && !Limits.mate
       && !(Skill(Options["Skill Level"]).enabled() || int(Options["UCI_LimitStrength"]))
       && rootMoves[0].pv[0] != MOVE_NONE)
       bestThread = Threads.get_best_thread();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2181,13 +2181,17 @@ bool RootMove::extract_ponder_from_tt(Position& pos) {
         return false;
 
     pos.do_move(pv[0], st);
-    TTEntry* tte = TT.probe(pos.key(), ttHit);
 
-    if (ttHit)
+    if (!pos.is_draw(1))
     {
-        Move m = tte->move(); // Local copy to be SMP safe
-        if (MoveList<LEGAL>(pos).contains(m))
-            pv.push_back(m);
+        TTEntry* tte = TT.probe(pos.key(), ttHit);
+
+        if (ttHit)
+        {
+            Move m = tte->move(); // Local copy to be SMP safe
+            if (MoveList<LEGAL>(pos).contains(m))
+                pv.push_back(m);
+        }
     }
 
     pos.undo_move(pv[0]);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -376,7 +376,9 @@ void Thread::search() {
   Move  pv[MAX_PLY+1];
   Value bestValue, alpha, beta, delta;
   Move  lastBestMove = MOVE_NONE;
+  Value lastBestScore = -VALUE_INFINITE;
   Depth lastBestMoveDepth = 0;
+  std::vector<Move> lastBestPV;
   MainThread* mainThread = (this == Threads.main() ? Threads.main() : nullptr);
   double timeReduction = 1, totBestMoveChanges = 0;
   Color us = rootPos.side_to_move();
@@ -547,8 +549,29 @@ void Thread::search() {
 
           if (    mainThread
               && (Threads.stop || pvIdx + 1 == multiPV || Time.elapsed() > 3000))
-              if (show_search_output())
-                  sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
+              // If search stopped mid-iteration, an exact mated-in / TB-loss score
+              // at the front can be unproven for this thread. Suppress that PV here
+              // and below roll back to the last completed best line.
+              if (!(Threads.stop && completedDepth != rootDepth
+                    && rootMoves[0].score <= VALUE_TB_LOSS_IN_MAX_PLY))
+                  if (show_search_output())
+                      sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
+      }
+
+      if (   completedDepth != rootDepth
+          && rootMoves[0].score != -VALUE_INFINITE
+          && rootMoves[0].score <= VALUE_TB_LOSS_IN_MAX_PLY)
+      {
+          if (!lastBestPV.empty())
+          {
+              auto it = std::find_if(rootMoves.begin(), rootMoves.end(), [&lastBestPV](const RootMove& rm) {
+                  return rm == lastBestPV[0];
+              });
+              if (it != rootMoves.end())
+                  std::rotate(rootMoves.begin(), it, it + 1);
+              rootMoves[0].pv = lastBestPV;
+              rootMoves[0].score = lastBestScore;
+          }
       }
 
       if (!Threads.stop)
@@ -556,6 +579,8 @@ void Thread::search() {
 
       if (rootMoves[0].pv[0] != lastBestMove) {
          lastBestMove = rootMoves[0].pv[0];
+         lastBestScore = rootMoves[0].score;
+         lastBestPV = rootMoves[0].pv;
          lastBestMoveDepth = rootDepth;
       }
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1196,6 +1196,8 @@ Ret probe_table(const Position& pos, ProbeState* result, WDLScore wdl = WDLDraw)
     if (pos.count<ALL_PIECES>() == 2) // KvK
         return Ret(WDLDraw);
 
+    assert(pos.material_key_is_ok());
+
     TBTable<Type>* entry = TBTables.get<Type>(pos.material_key());
 
     if (!entry || !mapped(*entry, pos))

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -249,6 +249,9 @@ Thread* ThreadPool::get_best_thread() const {
 
     std::map<Move, int64_t> votes;
     Value minScore = VALUE_NONE;
+    auto incomplete_iteration = [](const Thread* th) {
+        return th->completedDepth != th->rootDepth;
+    };
 
     // Find minimum score of all threads
     for (Thread* th: *this)
@@ -266,14 +269,35 @@ Thread* ThreadPool::get_best_thread() const {
         votes[th->rootMoves[0].pv[0]] +=
             (th->rootMoves[0].score - minScore + 14) * int(th->completedDepth);
 
-        if (abs(bestThread->rootMoves[0].score) >= VALUE_TB_WIN_IN_MAX_PLY)
+        const auto bestThreadScore = bestThread->rootMoves[0].score;
+        const auto newThreadScore  = th->rootMoves[0].score;
+
+        const bool bestThreadInProvenWin  = bestThreadScore >= VALUE_TB_WIN_IN_MAX_PLY
+                                         && !incomplete_iteration(bestThread);
+        const bool newThreadInProvenWin   = newThreadScore >= VALUE_TB_WIN_IN_MAX_PLY
+                                         && !incomplete_iteration(th);
+        const bool bestThreadInProvenLoss = bestThreadScore != -VALUE_INFINITE
+                                         && bestThreadScore <= VALUE_TB_LOSS_IN_MAX_PLY
+                                         && !incomplete_iteration(bestThread);
+        const bool newThreadInProvenLoss  = newThreadScore != -VALUE_INFINITE
+                                         && newThreadScore <= VALUE_TB_LOSS_IN_MAX_PLY
+                                         && !incomplete_iteration(th);
+
+        if (bestThreadInProvenWin)
         {
-            // Make sure we pick the shortest mate / TB conversion or stave off mate the longest
-            if (th->rootMoves[0].score > bestThread->rootMoves[0].score)
+            // Make sure we pick the shortest mate / TB conversion
+            if (newThreadInProvenWin && newThreadScore > bestThreadScore)
                 bestThread = th;
         }
-        else if (   th->rootMoves[0].score >= VALUE_TB_WIN_IN_MAX_PLY
-                 || (   th->rootMoves[0].score > VALUE_TB_LOSS_IN_MAX_PLY
+        else if (bestThreadInProvenLoss)
+        {
+            // Make sure we pick the shortest mated / TB conversion
+            if (newThreadInProvenLoss && newThreadScore < bestThreadScore)
+                bestThread = th;
+        }
+        else if (   newThreadInProvenWin
+                 || newThreadInProvenLoss
+                 || (   newThreadScore > VALUE_TB_LOSS_IN_MAX_PLY
                      && votes[th->rootMoves[0].pv[0]] > votes[bestThread->rootMoves[0].pv[0]]))
             bestThread = th;
     }

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -104,9 +104,12 @@ void TimeManagement::init(const Position& pos, Search::LimitsType& limits, Color
       maxScale = std::min(6.3, 1.5 + 0.11 * mtg);
   }
 
-  // Never use more than 80% of the available time for this move
-  optimumTime = TimePoint(optScale * timeLeft);
-  maximumTime = TimePoint(std::min(0.8 * limits.time[us] - moveOverhead, maxScale * optimumTime));
+  // Avoid zero-time iterations and keep the hard limit above the optimum even
+  // at very low time controls or with large move overhead settings.
+  optimumTime = TimePoint(std::max(1.0, optScale * timeLeft));
+  maximumTime = TimePoint(std::max(double(optimumTime),
+                                   std::min(0.8 * limits.time[us] - moveOverhead,
+                                            maxScale * optimumTime)));
 
   if (Options["Ponder"])
       optimumTime += optimumTime / 4;

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -157,7 +157,7 @@ int TranspositionTable::hashfull() const {
       for (int j = 0; j < ClusterSize; ++j)
           cnt += table[i].entry[j].depth8 && (table[i].entry[j].genBound8 & GENERATION_MASK) == generation8;
 
-  return cnt / ClusterSize;
+  return sampleCount ? int((cnt * 1000) / (ClusterSize * sampleCount)) : 0;
 }
 
 } // namespace Stockfish

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -532,6 +532,7 @@ string UCI::move(const Position& pos, Move m) {
   Square from = from_sq(m);
   Square to = to_sq(m);
   bool wallMove = pos.walling(pos.side_to_move()) && is_gating(m);
+  bool cloneMove = pos.is_clone_move(m);
 
   if (m == MOVE_NONE)
       return CurrentProtocol == USI ? "resign" : "(none)";
@@ -593,6 +594,8 @@ string UCI::move(const Position& pos, Move m) {
       if (gating_square(m) != from)
           move += UCI::square(pos, gating_square(m));
   }
+  else if (cloneMove)
+      move += "c";
 
   if (pos.paired_drop(m))
       move += "," + UCI::square(pos, pos.secondary_drop_square(m));

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -2395,8 +2395,10 @@ Variant* Variant::conclude() {
     }
     if (connectDiagonal)
     {
-        connectDirections.push_back(NORTH_EAST);
-        connectDirections.push_back(SOUTH_EAST);
+        if (connectNorthEast)
+            connectDirections.push_back(NORTH_EAST);
+        if (connectSouthEast)
+            connectDirections.push_back(SOUTH_EAST);
     }
 
     connectLines.clear();
@@ -2421,7 +2423,8 @@ Variant* Variant::conclude() {
 
     // If not a connect variant, set connectPieceTypesTrimmed to no pieces.
     // connectPieceTypesTrimmed is separated so that connectPieceTypes is left unchanged for inheritance.
-    if ( !(connectRegion1[WHITE] || connectRegion1[BLACK] || connectN || connectNxN || collinearN || connectGroup) )
+    if ( !(connectRegion1[WHITE] || connectRegion1[BLACK] || connectRegion3[WHITE] || connectRegion3[BLACK]
+        || connectN || connectNxN || collinearN || connectGroup) )
     {
           connectPieceTypesTrimmed = NO_PIECE_SET;
     }

--- a/src/variant.h
+++ b/src/variant.h
@@ -198,6 +198,7 @@ struct Variant {
   bool openingSwapDrop = false;
   bool isPriorityDrop[PIECE_TYPE_NB] = {};
   bool pieceDrops = false;
+  bool borrowOpponentDropsWhenEmpty = false;
   bool virtualDrops = true;
   bool virtualDropLimitEnabled = false;
   int virtualDropLimit[PIECE_TYPE_NB] = {};

--- a/src/variant.h
+++ b/src/variant.h
@@ -241,6 +241,7 @@ struct Variant {
   bool surroundClaimExtraTurn = false;
   bool seirawanGating = false;
   bool commitGates = false;
+  PieceSet cloneMoveTypes = NO_PIECE_SET;
   PieceSet jumpCaptureTypes = NO_PIECE_SET;
   bool forcedJumpContinuation = false;
   bool forcedJumpSameDirection = false;

--- a/src/variant.h
+++ b/src/variant.h
@@ -334,10 +334,13 @@ struct Variant {
   bool connectHorizontal = true;
   bool connectVertical = true;
   bool connectDiagonal = true;
+  bool connectNorthEast = true;
+  bool connectSouthEast = true;
   bool connect3D = false;
   bool connect4D = false;
   Bitboard connectRegion1[COLOR_NB] = {};
   Bitboard connectRegion2[COLOR_NB] = {};
+  Bitboard connectRegion3[COLOR_NB] = {};
   int connectNxN = 0;
   int collinearN = 0;
   int connectGroup = 0;

--- a/src/variant.h
+++ b/src/variant.h
@@ -289,6 +289,7 @@ struct Variant {
   bool weakDiagonalConnect = false;
   bool reciprocalWeakConnectionDrop = false;
   bool weakCrosscutDropIllegal = false;
+  bool weakConnectionNobiImpossible = false;
   ChasingRule chasingRule = NO_CHASING;
   Value stalemateValue = VALUE_DRAW;
   bool stalematePieceCount = false; // multiply stalemate value by sign(count(~stm) - count(stm))

--- a/src/variant.h
+++ b/src/variant.h
@@ -196,6 +196,7 @@ struct Variant {
   bool openingSelfRemovalAdjacentToLast = false;
   Bitboard openingSelfRemovalRegion[COLOR_NB] = {AllSquares, AllSquares};
   bool openingSwapDrop = false;
+  bool openingSwapMirrorMainDiagonal = false;
   bool isPriorityDrop[PIECE_TYPE_NB] = {};
   bool pieceDrops = false;
   bool borrowOpponentDropsWhenEmpty = false;
@@ -285,6 +286,9 @@ struct Variant {
   bool samePlayerBoardRepetitionIllegal = false;
   bool alternating2x2DropIllegal = false;
   bool pathwayDropRule = false;
+  bool weakDiagonalConnect = false;
+  bool reciprocalWeakConnectionDrop = false;
+  bool weakCrosscutDropIllegal = false;
   ChasingRule chasingRule = NO_CHASING;
   Value stalemateValue = VALUE_DRAW;
   bool stalematePieceCount = false; // multiply stalemate value by sign(count(~stm) - count(stm))

--- a/src/variant.h
+++ b/src/variant.h
@@ -57,6 +57,7 @@ struct Variant {
   int pocketSize = 0;
   Rank maxRank = RANK_8;
   File maxFile = FILE_H;
+  bool hexBoard = false;
   bool cylindrical = false;
   bool toroidal = false;
   bool chess960 = false;

--- a/src/variants-incomplete.ini
+++ b/src/variants-incomplete.ini
@@ -102,13 +102,6 @@ surroundClaimExtraTurn = true
 materialCounting = unweighted
 materialCountingPieceTypes = b
 
-[dots-boxes-15x15:dots-boxes-2x2]
-maxRank = 15
-maxFile = o
-startFen = *1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1* w - - 0 1
-wallingRegion = b1 d1 f1 h1 j1 l1 n1 a2 c2 e2 g2 i2 k2 m2 o2 b3 d3 f3 h3 j3 l3 n3 a4 c4 e4 g4 i4 k4 m4 o4 b5 d5 f5 h5 j5 l5 n5 a6 c6 e6 g6 i6 k6 m6 o6 b7 d7 f7 h7 j7 l7 n7 a8 c8 e8 g8 i8 k8 m8 o8 b9 d9 f9 h9 j9 l9 n9 a10 c10 e10 g10 i10 k10 m10 o10 b11 d11 f11 h11 j11 l11 n11 a12 c12 e12 g12 i12 k12 m12 o12 b13 d13 f13 h13 j13 l13 n13 a14 c14 e14 g14 i14 k14 m14 o14 b15 d15 f15 h15 j15 l15 n15
-surroundClaimRegion = b2 d2 f2 h2 j2 l2 n2 b4 d4 f4 h4 j4 l4 n4 b6 d6 f6 h6 j6 l6 n6 b8 d8 f8 h8 j8 l8 n8 b10 d10 f10 h10 j10 l10 n10 b12 d12 f12 h12 j12 l12 n12 b14 d14 f14 h14 j14 l14 n14
-
 # Slide 5
 # Pousse
 # Source:

--- a/src/variants-incomplete.ini
+++ b/src/variants-incomplete.ini
@@ -117,34 +117,6 @@ wallingRegion = b1 d1 f1 h1 j1 l1 n1 a2 c2 e2 g2 i2 k2 m2 o2 b3 d3 f3 h3 j3 l3 n
 surroundClaimRegion = b2 d2 f2 h2 j2 l2 n2 b4 d4 f4 h4 j4 l4 n4 b6 d6 f6 h6 j6 l6 n6 b8 d8 f8 h8 j8 l8 n8 b10 d10 f10 h10 j10 l10 n10 b12 d12 f12 h12 j12 l12 n12 b14 d14 f14 h14 j14 l14 n14
 
 # Slide 5
-# Sources:
-# - https://boardgamegeek.com/boardgame/4118/slide-5
-# TODO for completion:
-# - 16-chip finite reserve and the "play opponent chips when out" penalty are not modeled.
-[slide-5:fairy]
-maxRank = 5
-maxFile = e
-pieceToCharTable = -
-king = -
-customPiece1 = a:-
-startFen = 5/5/5/5/5[AAAAAAAAAAAAAAAAaaaaaaaaaaaaaaaa] w - - 0 1
-pieceDrops = true
-mustDrop = true
-checking = false
-nMoveRule = 0
-captureType = hand
-captureToHandSide = owner
-edgeInsertOnly = true
-dropRegion = a* *5
-edgeInsertTypes = a
-edgeInsertRegion = a* *5
-edgeInsertFrom = top left
-pushingStrength = a:5
-pushFirstColor = either
-pushingRemoves = shove
-connectN = 5
-connectPieceTypes = a
-
 # Pousse
 # Source:
 # - https://cs.brown.edu/courses/cs173/2008/Manual/games/pousse.html

--- a/src/variants-incomplete.ini
+++ b/src/variants-incomplete.ini
@@ -102,13 +102,6 @@ surroundClaimExtraTurn = true
 materialCounting = unweighted
 materialCountingPieceTypes = b
 
-[dots-boxes-9x9:dots-boxes-2x2]
-maxRank = 9
-maxFile = i
-startFen = *1*1*1*1*/9/*1*1*1*1*/9/*1*1*1*1*/9/*1*1*1*1*/9/*1*1*1*1* w - - 0 1
-wallingRegion = b1 d1 f1 h1 a2 c2 e2 g2 i2 b3 d3 f3 h3 a4 c4 e4 g4 i4 b5 d5 f5 h5 a6 c6 e6 g6 i6 b7 d7 f7 h7 a8 c8 e8 g8 i8 b9 d9 f9 h9
-surroundClaimRegion = b2 d2 f2 h2 b4 d4 f4 h4 b6 d6 f6 h6 b8 d8 f8 h8
-
 [dots-boxes-15x15:dots-boxes-2x2]
 maxRank = 15
 maxFile = o

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -460,6 +460,7 @@
 # weakDiagonalConnect: diagonal stones connect only if the two bridging orthogonal squares are not friendly [bool] (default: false)
 # reciprocalWeakConnectionDrop: a drop creating a weak friendly diagonal link is legal only if the opponent would also create a weak diagonal link there [bool] (default: false)
 # weakCrosscutDropIllegal: prohibit drops that create a weak diagonal link while also creating a 2x2 crosscut against enemy weak links [bool] (default: false)
+# weakConnectionNobiImpossible: prohibit a weak link when one of its anchor stones still has a legal strong, non-weak follow-up placement available [bool] (default: false)
 # chasingRule: enable chasing rules [ChasingRule] (default: none)
 # stalemateValue: result in case of stalemate [Value] (default: draw)
 # stalematePieceCount: count material in case of stalemate [bool] (default: false)
@@ -3380,6 +3381,13 @@ weakCrosscutDropIllegal = true
 nMoveRule = 0
 passOnStalemate = true
 startFen = 8/8/8/8/8/8/8/8[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPpppppppppppppppppppppppppppppppp] b - - 0 1
+
+# Konobi
+# Sources:
+# - https://www.zillionsofgames.com/cgi-bin/zilligames/submissions.cgi?do=show;id=2198
+# - `Konobi.zrf` in `.local/reference/archives/zrf_flat.zip`
+[konobi:kopano]
+weakConnectionNobiImpossible = true
 
 # Pathway
 # Sources:

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -3398,6 +3398,32 @@ connectRegion2Black = *11
 nMoveRule = 0
 startFen = 11/11/11/11/11/11/11/11/11/11/11[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp] b - - 0 1
 
+# Mini Hexchess
+# Sources:
+# - `Mini Hexchess.lud` in the local Ludii checkout
+# - https://www.chessvariants.com/hexagonal.dir/minihex.html
+[minihexchess:chess]
+maxRank = 7
+maxFile = g
+hexBoard = true
+castling = false
+nMoveRule = 100
+doubleStep = false
+enPassantRegion = -
+customPiece1 = r:RrfBlbB
+customPiece2 = b:flBrbBrf(2,1)lb(2,1)fr(2,1)bl(2,1)
+customPiece3 = n:fl(2,1)lb(2,1)fr(2,1)rb(2,1)rf(2,1)bl(2,1)fl(1,2)rb(1,2)rf(1,2)lb(1,2)fr(1,2)bl(1,2)
+customPiece4 = p:mfWclFcrF
+rook = r
+bishop = b
+knight = n
+pawn = p
+king = k:WrfFlbFflFrbFrf(2,1)lb(2,1)fr(2,1)bl(2,1)
+promotionPieceTypes = rbn
+promotionRegionWhite = a4 b5 c6 d7 e7 f7 g7
+promotionRegionBlack = a1 b1 c1 d1 e2 f3 g4
+startFen = ***2rb/**2pkn/*3ppp/7/PPP3*/NKP2**/BRP1*** w - - 0 1
+
 # Kopano
 # Sources:
 # - https://www.zillionsofgames.com/cgi-bin/zilligames/submissions.cgi?do=show;id=2197

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -422,6 +422,7 @@
 # gatingPieceAfter/gatingPieceAfterWhite/gatingPieceAfterBlack: mandatory generated gate piece after a move by the given piece type, e.g. "p:n n:b" [piece->piece map]
 # seirawanGating: allow gating of pieces in hand like in S-Chess, requires "gating = true" [bool] (default: false)
 # commitGates: gating pieces are committed to gating squares like in Musketeer chess [bool] (default: false)
+# cloneMoveTypes: piece types that may duplicate in place onto a legal move target; UCI uses from+to+c [PieceSet] (default: none)
 # cambodianMoves: enable special moves of cambodian chess, requires "gating = true" [bool] (default: false)
 # diagonalLines: enable special moves along diagonal for specific squares (Janggi) [Bitboard]
 # pass: allow passing [bool] (default: false)
@@ -2935,6 +2936,17 @@ extinctionMustAppear = k
 # https://www.chessvariants.com/usualeq.dir/sacrifice.html
 [sacrifice:chess]
 selfDestructTypes = p
+
+# Kings or Lemmings?
+# Source:
+# - https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi?do=show;id=548
+[kings-or-lemmings:chess]
+king = -
+commoner = k
+castlingKingPiece = k
+pseudoRoyalTypes = k
+pseudoRoyalCount = 64
+cloneMoveTypes = k
 
 # Slide 5
 # Source:

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -2989,6 +2989,13 @@ surroundClaimExtraTurn = true
 materialCounting = unweighted
 materialCountingPieceTypes = b
 
+[dots-boxes-9x9:dots-boxes-7x7]
+maxRank = 9
+maxFile = i
+startFen = *1*1*1*1*/9/*1*1*1*1*/9/*1*1*1*1*/9/*1*1*1*1*/9/*1*1*1*1* w - - 0 1
+wallingRegion = b1 d1 f1 h1 a2 c2 e2 g2 i2 b3 d3 f3 h3 a4 c4 e4 g4 i4 b5 d5 f5 h5 a6 c6 e6 g6 i6 b7 d7 f7 h7 a8 c8 e8 g8 i8 b9 d9 f9 h9
+surroundClaimRegion = b2 d2 f2 h2 b4 d4 f4 h4 b6 d6 f6 h6 b8 d8 f8 h8
+
 #https://www.ludii.games/details.php?keyword=Quad%20Wrangle
 [quadwrangle:ataxx]
 #different sources give different info on whether it is a 7x7 or 8x8 board.

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -348,6 +348,7 @@
 # dropKingLast: kings may only be dropped after all other hand pieces are gone [bool] (default: false)
 # priorityDropTypes: piece types that must be dropped before dropping the other pieces [PieceType] (default: none)
 # pieceDrops: enable piece drops [bool] (default: false)
+# borrowOpponentDropsWhenEmpty: if a side's reserve is empty, it may drop the opponent's reserve pieces instead [bool] (default: false)
 # virtualDrops: allow virtual reserve drops in two-board search heuristics [bool] (default: true)
 # virtualDropLimit: per-piece cap for virtual drops, e.g., p:2 n:1 b:1 r:1 q:1 (default: disabled -> legacy heuristic)
 # dropLoop: captures promoted pieces are not demoted [bool] (default: false)
@@ -2918,6 +2919,34 @@ extinctionMustAppear = k
 # https://www.chessvariants.com/usualeq.dir/sacrifice.html
 [sacrifice:chess]
 selfDestructTypes = p
+
+# Slide 5
+# Source:
+# - https://boardgamegeek.com/boardgame/4118/slide-5
+[slide-5:fairy]
+maxRank = 5
+maxFile = e
+pieceToCharTable = -
+king = -
+customPiece1 = a:-
+startFen = 5/5/5/5/5[AAAAAAAAAAAAAAAAaaaaaaaaaaaaaaaa] w - - 0 1
+pieceDrops = true
+mustDrop = true
+checking = false
+nMoveRule = 0
+captureType = hand
+captureToHandSide = owner
+borrowOpponentDropsWhenEmpty = true
+edgeInsertOnly = true
+dropRegion = a* *5
+edgeInsertTypes = a
+edgeInsertRegion = a* *5
+edgeInsertFrom = top left
+pushingStrength = a:5
+pushFirstColor = either
+pushingRemoves = shove
+connectN = 5
+connectPieceTypes = a
 
 # https://www.chessvariants.com/page/MSbeastchess
 [beast-chess:chess]

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -1140,6 +1140,8 @@ stalemateValue = draw
 [tictactoe]
 maxRank = 3
 maxFile = 3
+pieceToCharTable = -
+king = -
 immobile = p
 startFen = 3/3/3[PPPPPpppp] w - - 0 1
 pieceDrops = true
@@ -2972,6 +2974,7 @@ promotionPieceTypes = qegh
 [dots-boxes-7x7:fairy]
 maxRank = 7
 maxFile = g
+pieceToCharTable = -
 startFen = *1*1*1*/7/*1*1*1*/7/*1*1*1*/7/*1*1*1* w - - 0 1
 checking = false
 king = -

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -136,7 +136,8 @@
 # - notes:
 #   - tuple atoms support explicit leapers, repeated open-ended riders such as (2,0)(2,0),
 #     and numeric limited riders such as (2,0)2
-#   - tuple atoms do not support hopper/ski/max/dynamic modifiers
+#   - tuple atoms do not support hopper/contra/lame/ski/max/dynamic modifiers
+#     or bracketed rider ranges
 #   - L/C are camel aliases; J/Z are zebra aliases
 
 ### Piece values

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -3798,9 +3798,20 @@ nFoldRule = 0
 
 [groups]
 # Richard Hutnik (1998), no captures:
-# - Step to orthogonally adjacent empty square
-# - Hop over one adjacent piece orthogonally to empty square beyond
-customPiece1 = g:mWmpW2
+# - Step to adjacent empty square in any direction
+# - Hop over one adjacent piece to empty square beyond in any direction
+customPiece1 = g:mKmpK2
+startFen = 8/8/3gG3/2gGgG2/2GgGg2/3Gg3/8/8 w - - 0 1
+connectGroup = -1
+connectDiagonal = false
+nMoveRule = 0
+nFoldRule = 0
+
+[groups-fixed]
+# Richard Hutnik (1998), no captures:
+# - Step to adjacent empty square in any direction
+# - Fixed setup, no jumping
+customPiece1 = g:mK
 startFen = 8/8/3gG3/2gGgG2/2GgGg2/3Gg3/8/8 w - - 0 1
 connectGroup = -1
 connectDiagonal = false
@@ -3824,12 +3835,68 @@ connectDiagonal = false
 nMoveRule = 0
 nFoldRule = 0
 
+[groups-jump-setup]
+# Richard Hutnik (1998), no captures:
+# - Six pieces per side dropped into alternating center squares
+# - Then step or hop over one adjacent piece in any direction
+# - Winning connectivity is orthogonal only
+customPiece1 = g:mKmpK2
+startFen = 8/8/8/8/8/8/8/8[GGGGGGgggggg] w - - 0 1
+pieceDrops = true
+mustDrop = true
+passUntilSetup = true
+dropRegionWhite = c4 c6 d3 d5 e4 e6 f3 f5
+dropRegionBlack = c3 c5 d4 d6 e3 e5 f4 f6
+connectGroup = -1
+connectDiagonal = false
+nMoveRule = 0
+nFoldRule = 0
+
 [groups-queen-setup]
 # Richard Hutnik (1998), no captures:
 # - Six pieces per side dropped into alternating center squares
 # - Then move like a queen to any empty square
 # - Winning connectivity is orthogonal only
 customPiece1 = g:mQ
+startFen = 8/8/8/8/8/8/8/8[GGGGGGgggggg] w - - 0 1
+pieceDrops = true
+mustDrop = true
+passUntilSetup = true
+dropRegionWhite = c4 c6 d3 d5 e4 e6 f3 f5
+dropRegionBlack = c3 c5 d4 d6 e3 e5 f4 f6
+connectGroup = -1
+connectDiagonal = false
+nMoveRule = 0
+nFoldRule = 0
+
+[groups-queen-fixed]
+# Richard Hutnik (1998), no captures:
+# - Move like a queen to any empty square
+# - Fixed setup, no jumping
+customPiece1 = g:mQ
+startFen = 8/8/3gG3/2gGgG2/2GgGg2/3Gg3/8/8 w - - 0 1
+connectGroup = -1
+connectDiagonal = false
+nMoveRule = 0
+nFoldRule = 0
+
+[groups-queen-jump-fixed]
+# Richard Hutnik (1998), no captures:
+# - Move like a queen to any empty square or hop over one adjacent piece
+# - Fixed setup
+customPiece1 = g:mQmpK2
+startFen = 8/8/3gG3/2gGgG2/2GgGg2/3Gg3/8/8 w - - 0 1
+connectGroup = -1
+connectDiagonal = false
+nMoveRule = 0
+nFoldRule = 0
+
+[groups-queen-jump-setup]
+# Richard Hutnik (1998), no captures:
+# - Six pieces per side dropped into alternating center squares
+# - Then move like a queen or hop over one adjacent piece in any direction
+# - Winning connectivity is orthogonal only
+customPiece1 = g:mQmpK2
 startFen = 8/8/8/8/8/8/8/8[GGGGGGgggggg] w - - 0 1
 pieceDrops = true
 mustDrop = true

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -110,7 +110,7 @@
 #     Bent riders may stop on the first-leg pivot square.
 #     If that pivot square is occupied, it may be captured but the second leg does not continue.
 #   - circular rider: rose (standard rose / circular knight rider)
-#   - explicit tuple leapers: (x,y), e.g. m(4,1)
+#   - explicit tuple atoms: (x,y), e.g. m(4,1)
 # - movement modalities:
 #   - m = quiet-only
 #   - c = capture-only
@@ -134,7 +134,9 @@
 #   - x = dynamic-distance modifier (Lines-of-Action style)
 #   - y = ignores friendly blockers
 # - notes:
-#   - tuple atoms are supported only as explicit leapers, not as riders/hoppers
+#   - tuple atoms support explicit leapers, repeated open-ended riders such as (2,0)(2,0),
+#     and numeric limited riders such as (2,0)2
+#   - tuple atoms do not support hopper/ski/max/dynamic modifiers
 #   - L/C are camel aliases; J/Z are zebra aliases
 
 ### Piece values

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -3355,14 +3355,15 @@ startFen = 8/8/8/8/8/8/8/8[SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSsssssssssssssssssssss
 [y:tictactoe]
 maxRank = 10
 maxFile = 10
+hexBoard = true
 mustDrop = true
 openingSwapDrop = true
 connectPieceTypes = p
 connectHorizontal = true
 connectVertical = true
 connectDiagonal = true
-connectNorthEast = true
-connectSouthEast = false
+connectNorthEast = false
+connectSouthEast = true
 connectRegion1White = a1 b1 c1 d1 e1 f1 g1 h1 i1 j1
 connectRegion2White = a1 b2 c3 d4 e5 f6 g7 h8 i9 j10
 connectRegion3White = j1 j2 j3 j4 j5 j6 j7 j8 j9 j10
@@ -3371,6 +3372,29 @@ connectRegion2Black = a1 b2 c3 d4 e5 f6 g7 h8 i9 j10
 connectRegion3Black = j1 j2 j3 j4 j5 j6 j7 j8 j9 j10
 nMoveRule = 0
 startFen = ^^^^^^^^^1/^^^^^^^^2/^^^^^^^3/^^^^^^4/^^^^^5/^^^^6/^^^7/^^8/^9/10[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPppppppppppppppppppppppppppppppppppppppppppppppppppppppp] b - - 0 1
+
+# Hex
+# Sources:
+# - https://www.zillionsofgames.com/cgi-bin/zilligames/submissions.cgi?do=show;id=454
+# - `Hex.zrf` in `.local/reference/archives/zrf_flat.zip`
+[hex:tictactoe]
+maxRank = 11
+maxFile = 11
+hexBoard = true
+mustDrop = true
+openingSwapDrop = true
+connectPieceTypes = p
+connectHorizontal = true
+connectVertical = true
+connectDiagonal = true
+connectNorthEast = false
+connectSouthEast = true
+connectRegion1White = a*
+connectRegion2White = k*
+connectRegion1Black = *1
+connectRegion2Black = *11
+nMoveRule = 0
+startFen = 11/11/11/11/11/11/11/11/11/11/11[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp] b - - 0 1
 
 # Kopano
 # Sources:

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -3378,7 +3378,7 @@ startFen = ********1/********2/*******3/******4/*****5/****6/***7/**8/*9/10[PPPP
 # Hex
 # Sources:
 # - https://www.zillionsofgames.com/cgi-bin/zilligames/submissions.cgi?do=show;id=454
-# - `Hex.zrf` in `.local/reference/archives/zrf_flat.zip`
+# - Hex - Zillions referenced
 [hex:tictactoe]
 maxRank = 11
 maxFile = 11
@@ -3400,7 +3400,7 @@ startFen = 11/11/11/11/11/11/11/11/11/11/11[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP
 
 # Mini Hexchess
 # Sources:
-# - `Mini Hexchess.lud` in the local Ludii checkout
+# - Mini Hexchess - Ludii referenced
 # - https://www.chessvariants.com/hexagonal.dir/minihex.html
 [minihexchess:chess]
 maxRank = 7
@@ -3426,7 +3426,7 @@ startFen = ***2rb/**2pkn/*3ppp/7/PPP3*/NKP2**/BRP1*** w - - 0 1
 
 # Glinski Chess
 # Sources:
-# - `Glinski Chess.lud` in the local Ludii checkout
+# - Glinski Chess - Ludii referenced
 # - https://en.wikipedia.org/wiki/Hexagonal_chess
 [glinski-chess:chess]
 maxRank = 11
@@ -3454,7 +3454,7 @@ startFen = *****1prnqb/****2p2bk/***3p1b1n/**4p3r/*5ppppp/11/PPPPP5*/R3P4**/N1B1
 
 # McCooey Chess
 # Sources:
-# - `McCooey Chess.lud` in the local Ludii checkout
+# - McCooey Chess - Ludii referenced
 # - https://en.wikipedia.org/wiki/Hexagonal_chess
 [mccooey-chess:chess]
 maxRank = 11
@@ -3483,7 +3483,7 @@ startFen = *****2prqb/****3pnbk/***4pbnr/**5pppp/*10/11/10*/PPPP5**/RNBP4***/QBN
 # Kopano
 # Sources:
 # - https://www.zillionsofgames.com/cgi-bin/zilligames/submissions.cgi?do=show;id=2197
-# - `Kopano.zrf` in `.local/reference/archives/zrf_flat.zip`
+# - Kopano - Zillions referenced
 [kopano:tictactoe]
 maxRank = 8
 maxFile = 8
@@ -3508,7 +3508,7 @@ startFen = 8/8/8/8/8/8/8/8[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPppppppppppppppppppppp
 # Konobi
 # Sources:
 # - https://www.zillionsofgames.com/cgi-bin/zilligames/submissions.cgi?do=show;id=2198
-# - `Konobi.zrf` in `.local/reference/archives/zrf_flat.zip`
+# - Konobi - Zillions referenced
 [konobi:kopano]
 weakConnectionNobiImpossible = true
 

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -3424,6 +3424,62 @@ promotionRegionWhite = a4 b5 c6 d7 e7 f7 g7
 promotionRegionBlack = a1 b1 c1 d1 e2 f3 g4
 startFen = ***2rb/**2pkn/*3ppp/7/PPP3*/NKP2**/BRP1*** w - - 0 1
 
+# Glinski Chess
+# Sources:
+# - `Glinski Chess.lud` in the local Ludii checkout
+# - https://en.wikipedia.org/wiki/Hexagonal_chess
+[glinski-chess:chess]
+maxRank = 11
+maxFile = 11
+hexBoard = true
+castling = false
+nMoveRule = 100
+customPiece1 = r:RrfBlbB
+customPiece2 = b:flBrbBrf(2,1)lb(2,1)fr(2,1)bl(2,1)
+customPiece3 = n:fl(2,1)lb(2,1)fr(2,1)rb(2,1)rf(2,1)bl(2,1)fl(1,2)rb(1,2)rf(1,2)lb(1,2)fr(1,2)bl(1,2)
+customPiece4 = p:mfWflWfrW
+customPiece5 = q:RrfBlbBflBrbBrf(2,1)lb(2,1)fr(2,1)bl(2,1)
+rook = r
+bishop = b
+knight = n
+pawn = p
+queen = q
+king = k:WrfFlbFflFrbFrf(2,1)lb(2,1)fr(2,1)bl(2,1)
+doubleStep = true
+doubleStepRegionWhite = a5 b5 c5 d5 e5 e4 e3 e2 e1
+doubleStepRegionBlack = g11 g10 g9 g8 g7 h7 i7 j7 k7
+promotionRegionWhite = a6 b7 c8 d9 e10 f11 g11 h11 i11 j11 k11
+promotionRegionBlack = a1 b1 c1 d1 e1 f1 g2 h3 i4 j5 k6
+startFen = ^^^^^1prnqb/^^^^2p2bk/^^^3p1b1n/^^4p3r/^5ppppp/11/PPPPP5^/R3P4^^/N1B1P3^^^/QB2P2^^^^/BKNRP1^^^^^ w - - 0 1
+
+# McCooey Chess
+# Sources:
+# - `McCooey Chess.lud` in the local Ludii checkout
+# - https://en.wikipedia.org/wiki/Hexagonal_chess
+[mccooey-chess:chess]
+maxRank = 11
+maxFile = 11
+hexBoard = true
+castling = false
+nMoveRule = 100
+customPiece1 = r:RrfBlbB
+customPiece2 = b:flBrbBrf(2,1)lb(2,1)fr(2,1)bl(2,1)
+customPiece3 = n:fl(2,1)lb(2,1)fr(2,1)rb(2,1)rf(2,1)bl(2,1)fl(1,2)rb(1,2)rf(1,2)lb(1,2)fr(1,2)bl(1,2)
+customPiece4 = p:mfWclFcrF
+customPiece5 = q:RrfBlbBflBrbBrf(2,1)lb(2,1)fr(2,1)bl(2,1)
+rook = r
+bishop = b
+knight = n
+pawn = p
+queen = q
+king = k:WrfFlbFflFrbFrf(2,1)lb(2,1)fr(2,1)bl(2,1)
+doubleStep = true
+doubleStepRegionWhite = a4 b4 c4 d3 d2 d1
+doubleStepRegionBlack = h11 h10 h9 i8 j8 k8
+promotionRegionWhite = a6 b7 c8 d9 e10 f11 g11 h11 i11 j11 k11
+promotionRegionBlack = a1 b1 c1 d1 e1 f1 g2 h3 i4 j5 k6
+startFen = ^^^^^2prqb/^^^^3pnbk/^^^4pbnr/^^5pppp/^10/11/10^/PPPP5^^/RNBP4^^^/QBNP3^^^^/BKRP2^^^^^ w - - 0 1
+
 # Kopano
 # Sources:
 # - https://www.zillionsofgames.com/cgi-bin/zilligames/submissions.cgi?do=show;id=2197

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -202,6 +202,7 @@
 ## Board, setup, and mobility
 # maxRank: maximum rank [Rank] (default: 8)
 # maxFile: maximum file [File] (default: 8)
+# hexBoard: use hex-board display/topology primitives for the variant [bool] (default: false)
 # cylindrical: wrap files left/right (A<->H on 8-file boards) [bool] (default: false)
 # toroidal: wrap both files and ranks [bool] (default: false)
 # chess960: allow chess960 castling [bool] (default: false)

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -284,7 +284,7 @@
 # petrifyOnCaptureTypes: defined pieces are turned into wall squares when capturing [PieceSet] (default: -)
 # petrifyOnCaptureSuppressTransfer: petrifying captures do not also transfer captured material to hand/prison [bool] (default: false)
 # petrifyBlastPieces: if petrify and blast combined, should pieces destroyed in the blast be petrified? [bool] (default: false)
-# removeConnectN: remove n-in-a-row from board (rejected with royal kings) [int] (default: 0)
+# removeConnectN: remove n-in-a-row from board (rejected with (pseudo/anti-)royal pieces or connection win conditions) [int] (default: 0)
 # removeConnectNByType: remove n-in-a-row by piece type, not by color [bool] (default: false)
 # surroundCaptureOpposite: enemy piece can be captured by having another of your pieces opposite it [bool] (default: false)
 # surroundCaptureIntervene: enemy piece can be captured by moving between two enemy pieces [bool] (default: false)

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -345,6 +345,8 @@
 # mustDropTypeBlack: black side specific mandatory drop piece type [PieceType] (default: *)
 # openingSwapDrop: allow a narrow swap-opening surrogate by letting the second player
 #                  overwrite the lone opening enemy stone in simple move-out drop variants [bool] (default: false)
+# openingSwapMirrorMainDiagonal: when openingSwapDrop is enabled on a square board,
+#                                use the opening stone's main-diagonal mirror square instead [bool] (default: false)
 # dropKingLast: kings may only be dropped after all other hand pieces are gone [bool] (default: false)
 # priorityDropTypes: piece types that must be dropped before dropping the other pieces [PieceType] (default: none)
 # pieceDrops: enable piece drops [bool] (default: false)
@@ -455,6 +457,9 @@
 # samePlayerBoardRepetitionIllegal: prohibit moves that recreate a board layout reached at the end of the same side's earlier turn [bool] (default: false)
 # alternating2x2DropIllegal: prohibit drop placements that create an alternating 2x2 checker pattern [bool] (default: false)
 # pathwayDropRule: legal drops must create either no orthogonal adjacencies, or exactly one friendly orthogonal adjacency and any number of enemy ones [bool] (default: false)
+# weakDiagonalConnect: diagonal stones connect only if the two bridging orthogonal squares are not friendly [bool] (default: false)
+# reciprocalWeakConnectionDrop: a drop creating a weak friendly diagonal link is legal only if the opponent would also create a weak diagonal link there [bool] (default: false)
+# weakCrosscutDropIllegal: prohibit drops that create a weak diagonal link while also creating a 2x2 crosscut against enemy weak links [bool] (default: false)
 # chasingRule: enable chasing rules [ChasingRule] (default: none)
 # stalemateValue: result in case of stalemate [Value] (default: draw)
 # stalematePieceCount: count material in case of stalemate [bool] (default: false)
@@ -3347,6 +3352,31 @@ connectRegion2Black = a1 b2 c3 d4 e5 f6 g7 h8 i9 j10
 connectRegion3Black = j1 j2 j3 j4 j5 j6 j7 j8 j9 j10
 nMoveRule = 0
 startFen = ^^^^^^^^^1/^^^^^^^^2/^^^^^^^3/^^^^^^4/^^^^^5/^^^^6/^^^7/^^8/^9/10[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPppppppppppppppppppppppppppppppppppppppppppppppppppppppp] b - - 0 1
+
+# Kopano
+# Sources:
+# - https://www.zillionsofgames.com/cgi-bin/zilligames/submissions.cgi?do=show;id=2197
+# - `Kopano.zrf` in `.local/reference/archives/zrf_flat.zip`
+[kopano:tictactoe]
+maxRank = 8
+maxFile = 8
+mustDrop = true
+openingSwapDrop = true
+openingSwapMirrorMainDiagonal = true
+connectN = 0
+connectHorizontal = true
+connectVertical = true
+connectDiagonal = false
+connectRegion1White = a*
+connectRegion2White = h*
+connectRegion1Black = *1
+connectRegion2Black = *8
+weakDiagonalConnect = true
+reciprocalWeakConnectionDrop = true
+weakCrosscutDropIllegal = true
+nMoveRule = 0
+passOnStalemate = true
+startFen = 8/8/8/8/8/8/8/8[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPpppppppppppppppppppppppppppppppp] b - - 0 1
 
 # Pathway
 # Sources:

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -506,12 +506,16 @@
 # connectVertical: connectN looks at Vertical rows [bool] (default: true)
 # connectHorizontal: connectN looks at Horizontal rows [bool] (default: true)
 # connectDiagonal: connectN looks at Diagonal rows [bool] (default: true)
+# connectNorthEast: include the NE/SW diagonal axis in connect logic when connectDiagonal is enabled [bool] (default: true)
+# connectSouthEast: include the SE/NW diagonal axis in connect logic when connectDiagonal is enabled [bool] (default: true)
 # connect3D: interpret either a 3x9 board as flattened 3x3x3 or an 8x8 board as flattened 4x4x4 [bool] (default: false)
 # connect4D: interpret a connectN^2 x connectN^2 board as flattened connectN^4 tic-tac-toe for connectN >= 3 [bool] (default: false)
-# connectRegion1White: connect Region 1 to Region 2 for win. obeys connectVertical, connectHorizontal, connectDiagonal [Bitboard] (default: -)
+# connectRegion1White: connect Region 1 to Region 2/3 for win. obeys connectVertical, connectHorizontal, connectDiagonal [Bitboard] (default: -)
 # connectRegion2White: "
+# connectRegion3White: optional third region for connection wins such as Y [Bitboard] (default: -)
 # connectRegion1Black: "
 # connectRegion2Black: "
+# connectRegion3Black: "
 # connectNxN: connect a tight NxN square for win [int] (default: 0)
 # collinearN: arrange N pieces collinearly (other squares can be between pieces) [int] (default: 0)
 # connectGroup: arrange N pieces in any shape (-1 means all remaining pieces connected) [int] (default: 0)
@@ -3319,6 +3323,30 @@ connectRegion2White = h*
 connectRegion1Black = *1
 connectRegion2Black = *8
 startFen = 8/8/8/8/8/8/8/8[SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSssssssssssssssssssssssssssssssss] b - - 0 1
+
+# Y
+# Sources:
+# - https://www.ludii.games/details.php?keyword=Y
+# - https://www.marksteeregames.com/Y_rules.pdf
+[y:tictactoe]
+maxRank = 10
+maxFile = 10
+mustDrop = true
+openingSwapDrop = true
+connectPieceTypes = p
+connectHorizontal = true
+connectVertical = true
+connectDiagonal = true
+connectNorthEast = true
+connectSouthEast = false
+connectRegion1White = a1 b1 c1 d1 e1 f1 g1 h1 i1 j1
+connectRegion2White = a1 b2 c3 d4 e5 f6 g7 h8 i9 j10
+connectRegion3White = j1 j2 j3 j4 j5 j6 j7 j8 j9 j10
+connectRegion1Black = a1 b1 c1 d1 e1 f1 g1 h1 i1 j1
+connectRegion2Black = a1 b2 c3 d4 e5 f6 g7 h8 i9 j10
+connectRegion3Black = j1 j2 j3 j4 j5 j6 j7 j8 j9 j10
+nMoveRule = 0
+startFen = ^^^^^^^^^1/^^^^^^^^2/^^^^^^^3/^^^^^^4/^^^^^5/^^^^6/^^^7/^^8/^9/10[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPppppppppppppppppppppppppppppppppppppppppppppppppppppppp] b - - 0 1
 
 # Pathway
 # Sources:

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -3373,7 +3373,7 @@ connectRegion1Black = a1 b1 c1 d1 e1 f1 g1 h1 i1 j1
 connectRegion2Black = a1 b2 c3 d4 e5 f6 g7 h8 i9 j10
 connectRegion3Black = j1 j2 j3 j4 j5 j6 j7 j8 j9 j10
 nMoveRule = 0
-startFen = ^^^^^^^^^1/^^^^^^^^2/^^^^^^^3/^^^^^^4/^^^^^5/^^^^6/^^^7/^^8/^9/10[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPppppppppppppppppppppppppppppppppppppppppppppppppppppppp] b - - 0 1
+startFen = ********1/********2/*******3/******4/*****5/****6/***7/**8/*9/10[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPppppppppppppppppppppppppppppppppppppppppppppppppppppppp] b - - 0 1
 
 # Hex
 # Sources:
@@ -3450,7 +3450,7 @@ doubleStepRegionWhite = a5 b5 c5 d5 e5 e4 e3 e2 e1
 doubleStepRegionBlack = g11 g10 g9 g8 g7 h7 i7 j7 k7
 promotionRegionWhite = a6 b7 c8 d9 e10 f11 g11 h11 i11 j11 k11
 promotionRegionBlack = a1 b1 c1 d1 e1 f1 g2 h3 i4 j5 k6
-startFen = ^^^^^1prnqb/^^^^2p2bk/^^^3p1b1n/^^4p3r/^5ppppp/11/PPPPP5^/R3P4^^/N1B1P3^^^/QB2P2^^^^/BKNRP1^^^^^ w - - 0 1
+startFen = *****1prnqb/****2p2bk/***3p1b1n/**4p3r/*5ppppp/11/PPPPP5*/R3P4**/N1B1P3***/QB2P2****/BKNRP1***** w - - 0 1
 
 # McCooey Chess
 # Sources:
@@ -3478,7 +3478,7 @@ doubleStepRegionWhite = a4 b4 c4 d3 d2 d1
 doubleStepRegionBlack = h11 h10 h9 i8 j8 k8
 promotionRegionWhite = a6 b7 c8 d9 e10 f11 g11 h11 i11 j11 k11
 promotionRegionBlack = a1 b1 c1 d1 e1 f1 g2 h3 i4 j5 k6
-startFen = ^^^^^2prqb/^^^^3pnbk/^^^4pbnr/^^5pppp/^10/11/10^/PPPP5^^/RNBP4^^^/QBNP3^^^^/BKRP2^^^^^ w - - 0 1
+startFen = *****2prqb/****3pnbk/***4pbnr/**5pppp/*10/11/10*/PPPP5**/RNBP4***/QBNP3****/BKRP2***** w - - 0 1
 
 # Kopano
 # Sources:

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -3807,6 +3807,40 @@ connectDiagonal = false
 nMoveRule = 0
 nFoldRule = 0
 
+[groups-setup]
+# Richard Hutnik (1998), no captures:
+# - Six pieces per side dropped into alternating center squares
+# - Then step one square in any direction to an empty square
+# - Winning connectivity is orthogonal only
+customPiece1 = g:mWmF
+startFen = 8/8/8/8/8/8/8/8[GGGGGGgggggg] w - - 0 1
+pieceDrops = true
+mustDrop = true
+passUntilSetup = true
+dropRegionWhite = c4 c6 d3 d5 e4 e6 f3 f5
+dropRegionBlack = c3 c5 d4 d6 e3 e5 f4 f6
+connectGroup = -1
+connectDiagonal = false
+nMoveRule = 0
+nFoldRule = 0
+
+[groups-queen-setup]
+# Richard Hutnik (1998), no captures:
+# - Six pieces per side dropped into alternating center squares
+# - Then move like a queen to any empty square
+# - Winning connectivity is orthogonal only
+customPiece1 = g:mQ
+startFen = 8/8/8/8/8/8/8/8[GGGGGGgggggg] w - - 0 1
+pieceDrops = true
+mustDrop = true
+passUntilSetup = true
+dropRegionWhite = c4 c6 d3 d5 e4 e6 f3 f5
+dropRegionBlack = c3 c5 d4 d6 e3 e5 f4 f6
+connectGroup = -1
+connectDiagonal = false
+nMoveRule = 0
+nFoldRule = 0
+
 [checkers]
 customPiece1 = m:fFfA
 customPiece2 = k:FA

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -3386,7 +3386,7 @@ connectRegion1Black = a1 b1 c1 d1 e1 f1 g1 h1 i1 j1
 connectRegion2Black = a1 b2 c3 d4 e5 f6 g7 h8 i9 j10
 connectRegion3Black = j1 j2 j3 j4 j5 j6 j7 j8 j9 j10
 nMoveRule = 0
-startFen = ********1/********2/*******3/******4/*****5/****6/***7/**8/*9/10[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPppppppppppppppppppppppppppppppppppppppppppppppppppppppp] b - - 0 1
+startFen = *********1/********2/*******3/******4/*****5/****6/***7/**8/*9/10[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPppppppppppppppppppppppppppppppppppppppppppppppppppppppp] b - - 0 1
 
 # Hex
 # Sources:

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -2996,6 +2996,13 @@ startFen = *1*1*1*1*/9/*1*1*1*1*/9/*1*1*1*1*/9/*1*1*1*1*/9/*1*1*1*1* w - - 0 1
 wallingRegion = b1 d1 f1 h1 a2 c2 e2 g2 i2 b3 d3 f3 h3 a4 c4 e4 g4 i4 b5 d5 f5 h5 a6 c6 e6 g6 i6 b7 d7 f7 h7 a8 c8 e8 g8 i8 b9 d9 f9 h9
 surroundClaimRegion = b2 d2 f2 h2 b4 d4 f4 h4 b6 d6 f6 h6 b8 d8 f8 h8
 
+[dots-boxes-15x15:dots-boxes-9x9]
+maxRank = 15
+maxFile = o
+startFen = *1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1*/15/*1*1*1*1*1*1*1* w - - 0 1
+wallingRegion = b1 d1 f1 h1 j1 l1 n1 a2 c2 e2 g2 i2 k2 m2 o2 b3 d3 f3 h3 j3 l3 n3 a4 c4 e4 g4 i4 k4 m4 o4 b5 d5 f5 h5 j5 l5 n5 a6 c6 e6 g6 i6 k6 m6 o6 b7 d7 f7 h7 j7 l7 n7 a8 c8 e8 g8 i8 k8 m8 o8 b9 d9 f9 h9 j9 l9 n9 a10 c10 e10 g10 i10 k10 m10 o10 b11 d11 f11 h11 j11 l11 n11 a12 c12 e12 g12 i12 k12 m12 o12 b13 d13 f13 h13 j13 l13 n13 a14 c14 e14 g14 i14 k14 m14 o14 b15 d15 f15 h15 j15 l15 n15
+surroundClaimRegion = b2 d2 f2 h2 j2 l2 n2 b4 d4 f4 h4 j4 l4 n4 b6 d6 f6 h6 j6 l6 n6 b8 d8 f8 h8 j8 l8 n8 b10 d10 f10 h10 j10 l10 n10 b12 d12 f12 h12 j12 l12 n12 b14 d14 f14 h14 j14 l14 n14
+
 #https://www.ludii.games/details.php?keyword=Quad%20Wrangle
 [quadwrangle:ataxx]
 #different sources give different info on whether it is a 7x7 or 8x8 board.

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -3399,6 +3399,37 @@ connectRegion2Black = *11
 nMoveRule = 0
 startFen = 11/11/11/11/11/11/11/11/11/11/11[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp] b - - 0 1
 
+# 7x7 Hex
+# Sources:
+# - https://www.zillionsofgames.com/cgi-bin/zilligames/submissions.cgi?do=show;id=454
+# - Hex - Zillions referenced
+[hex-7x7:hex]
+maxRank = 7
+maxFile = 7
+connectRegion2White = g*
+connectRegion2Black = *7
+startFen = 7/7/7/7/7/7/7[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPppppppppppppppppppppppppppppppppppppppppppppppppp] b - - 0 1
+
+# 10x10 Hex
+# Sources:
+# - https://www.ludii.games/details.php?keyword=Hex
+# - Hex - Ludii referenced
+[hex-10x10:hex]
+maxRank = 10
+maxFile = 10
+connectRegion1White = a*
+connectRegion2White = j*
+connectRegion1Black = *1
+connectRegion2Black = *10
+startFen = 10/10/10/10/10/10/10/10/10/10[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPpppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp] b - - 0 1
+
+# Misere Hex
+# Sources:
+# - https://www.ludii.games/details.php?keyword=Hex
+# - Hex - Ludii referenced
+[misere-hex:hex]
+connectValue = loss
+
 # Mini Hexchess
 # Sources:
 # - Mini Hexchess - Ludii referenced

--- a/test.py
+++ b/test.py
@@ -390,6 +390,24 @@ class TestPyffish(unittest.TestCase):
         self.assertTrue("shogun" in variants)
         self.assertTrue("hostageblank" in variants)
 
+    def test_remove_connect_n_rejections(self):
+        # removeConnectN should be rejected when combined with connection win conditions.
+        variant_config = """
+[test-connect-remove]
+maxRank = 3
+maxFile = 3
+connectN = 3
+removeConnectN = 3
+pieceToCharTable = -
+king = -
+immobile = p
+startFen = 3/3/3[PPPPPpppp] w - - 0 1
+pieceDrops = true
+"""
+        sf.load_variant_config(variant_config)
+        with self.assertRaises(Exception):
+             sf.start_fen("test-connect-remove")
+
     def test_set_option(self):
         result = sf.set_option("UCI_Variant", "capablanca")
         self.assertIsNone(result)

--- a/tests/alfil-dabbaba-riders.sh
+++ b/tests/alfil-dabbaba-riders.sh
@@ -12,8 +12,18 @@ customPiece1 = a:AA
 pieceToCharTable = PNBRQ............A...Kpnbrq............a...k
 startFen = 7k/8/8/8/3A4/8/8/K7 w - - 0 1
 
+[alfil-rider-tuple:chess]
+customPiece1 = a:(2,2)(2,2)
+pieceToCharTable = PNBRQ............A...Kpnbrq............a...k
+startFen = 7k/8/8/8/3A4/8/8/K7 w - - 0 1
+
 [dabbaba-rider:chess]
 customPiece1 = a:DD
+pieceToCharTable = PNBRQ............A...Kpnbrq............a...k
+startFen = 7k/8/8/8/3A4/8/8/K7 w - - 0 1
+
+[dabbaba-rider-tuple:chess]
+customPiece1 = a:(2,0)2
 pieceToCharTable = PNBRQ............A...Kpnbrq............a...k
 startFen = 7k/8/8/8/3A4/8/8/K7 w - - 0 1
 INI
@@ -29,8 +39,10 @@ piece_moves() {
 expected_alfil=$(mktemp)
 expected_dabbaba=$(mktemp)
 actual_alfil=$(mktemp)
+actual_alfil_tuple=$(mktemp)
 actual_dabbaba=$(mktemp)
-trap 'rm -f "$tmp_ini" "$expected_alfil" "$expected_dabbaba" "$actual_alfil" "$actual_dabbaba"' EXIT
+actual_dabbaba_tuple=$(mktemp)
+trap 'rm -f "$tmp_ini" "$expected_alfil" "$expected_dabbaba" "$actual_alfil" "$actual_alfil_tuple" "$actual_dabbaba" "$actual_dabbaba_tuple"' EXIT
 
 cat > "$expected_alfil" <<'EOF'
 d4b2
@@ -50,9 +62,13 @@ d4h4
 EOF
 
 piece_moves alfil-rider > "$actual_alfil"
+piece_moves alfil-rider-tuple > "$actual_alfil_tuple"
 piece_moves dabbaba-rider > "$actual_dabbaba"
+piece_moves dabbaba-rider-tuple > "$actual_dabbaba_tuple"
 
 cmp "$actual_alfil" "$expected_alfil"
+cmp "$actual_alfil_tuple" "$expected_alfil"
 cmp "$actual_dabbaba" "$expected_dabbaba"
+cmp "$actual_dabbaba_tuple" "$expected_dabbaba"
 
 echo "alfil-dabbaba-riders test OK"

--- a/tests/borrow-opponent-drops.sh
+++ b/tests/borrow-opponent-drops.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+error() {
+  echo "borrow-opponent-drops regression failed on line $1"
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+ENGINE="${1:-./src/stockfish}"
+
+TMP_VARIANT_PATH=$(mktemp /tmp/fsx-borrow-drops-XXXXXX.ini)
+trap 'rm -f "${TMP_VARIANT_PATH}"' EXIT
+
+cat >"${TMP_VARIANT_PATH}" <<'INI'
+[borrow-slide:fairy]
+maxRank = 5
+maxFile = e
+pieceToCharTable = -
+king = -
+customPiece1 = a:-
+pieceDrops = true
+mustDrop = true
+captureType = hand
+captureToHandSide = owner
+borrowOpponentDropsWhenEmpty = true
+edgeInsertOnly = true
+dropRegion = a* *5
+edgeInsertTypes = a
+edgeInsertRegion = a* *5
+edgeInsertFrom = top left
+pushingStrength = a:5
+startFen = 5/5/5/5/5[a] w - - 0 1
+INI
+
+run_cmds() {
+  cat <<EOF | "${ENGINE}" 2>/dev/null
+uci
+setoption name VariantPath value ${TMP_VARIANT_PATH}
+setoption name UCI_Variant value borrow-slide
+$1
+quit
+EOF
+}
+
+out=$(run_cmds "position startpos
+go perft 1")
+echo "${out}" | grep -q "^A@a1,b1: 1$"
+
+out=$(run_cmds "position startpos moves A@a1,b1
+d")
+echo "${out}" | grep -Fq "Fen: 5/5/5/5/a4[] b - - 0 1"
+
+echo "borrow-opponent-drops regression passed"

--- a/tests/connect-region3.sh
+++ b/tests/connect-region3.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+error() {
+  echo "connect-region3 regression failed on line $1"
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+ENGINE="${1:-./src/stockfish}"
+
+TMP_VARIANT_PATH=$(mktemp /tmp/fsx-connect-region3-XXXXXX.ini)
+trap 'rm -f "${TMP_VARIANT_PATH}"' EXIT
+
+cat >"${TMP_VARIANT_PATH}" <<'INI'
+[mini-y:fairy]
+maxRank = 5
+maxFile = 5
+pieceToCharTable = -
+king = -
+customPiece1 = s:m
+pieceDrops = true
+mustDrop = true
+openingSwapDrop = true
+connectPieceTypes = s
+connectHorizontal = true
+connectVertical = true
+connectDiagonal = true
+connectNorthEast = true
+connectSouthEast = false
+connectRegion1White = a1 b1 c1 d1 e1
+connectRegion2White = a1 b2 c3 d4 e5
+connectRegion3White = e1 e2 e3 e4 e5
+connectRegion1Black = a1 b1 c1 d1 e1
+connectRegion2Black = a1 b2 c3 d4 e5
+connectRegion3Black = e1 e2 e3 e4 e5
+nMoveRule = 0
+startFen = ^^^^1/^^^2/^^3/^4/5[SSSSSSSSSSSSSSSsssssssssssssss] b - - 0 1
+INI
+
+run_cmds() {
+  cat <<EOF | "${ENGINE}" 2>/dev/null
+uci
+setoption name VariantPath value ${TMP_VARIANT_PATH}
+setoption name UCI_Variant value mini-y
+$1
+quit
+EOF
+}
+
+out=$(run_cmds "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 15"
+
+out=$(run_cmds "position fen ^^^^b/^^^1b/^^2b/^3b/bbbbb w - - 0 1
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 0"
+
+out=$(run_cmds "position fen ^^^^1/^^^2/^^3/^b1b1/b1b1b[S] w - - 0 1
+go perft 1")
+echo "${out}" | grep -q "^S@b1: 1$"
+
+echo "connect-region3 regression passed"

--- a/tests/connect-region3.sh
+++ b/tests/connect-region3.sh
@@ -37,7 +37,7 @@ connectRegion1Black = a1 b1 c1 d1 e1
 connectRegion2Black = a1 b2 c3 d4 e5
 connectRegion3Black = e1 e2 e3 e4 e5
 nMoveRule = 0
-startFen = ^^^^1/^^^2/^^3/^4/5[SSSSSSSSSSSSSSSsssssssssssssss] b - - 0 1
+startFen = ****1/***2/**3/*4/5[SSSSSSSSSSSSSSSsssssssssssssss] b - - 0 1
 INI
 
 run_cmds() {

--- a/tests/connect-region3.sh
+++ b/tests/connect-region3.sh
@@ -7,7 +7,8 @@ error() {
 }
 trap 'error ${LINENO}' ERR
 
-ENGINE="${1:-./src/stockfish}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENGINE="${1:-${SCRIPT_DIR}/../src/stockfish}"
 
 TMP_VARIANT_PATH=$(mktemp /tmp/fsx-connect-region3-XXXXXX.ini)
 trap 'rm -f "${TMP_VARIANT_PATH}"' EXIT

--- a/tests/connect-region3.sh
+++ b/tests/connect-region3.sh
@@ -16,6 +16,7 @@ cat >"${TMP_VARIANT_PATH}" <<'INI'
 [mini-y:fairy]
 maxRank = 5
 maxFile = 5
+hexBoard = true
 pieceToCharTable = -
 king = -
 customPiece1 = s:m
@@ -26,8 +27,8 @@ connectPieceTypes = s
 connectHorizontal = true
 connectVertical = true
 connectDiagonal = true
-connectNorthEast = true
-connectSouthEast = false
+connectNorthEast = false
+connectSouthEast = true
 connectRegion1White = a1 b1 c1 d1 e1
 connectRegion2White = a1 b2 c3 d4 e5
 connectRegion3White = e1 e2 e3 e4 e5

--- a/tests/dots-and-boxes.sh
+++ b/tests/dots-and-boxes.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENGINE="${1:-/home/chris/Fairy-Stockfish-X/src/stockfish}"
-VARIANTS_MAIN="${2:-/home/chris/Fairy-Stockfish-X/src/variants.ini}"
-VARIANTS_INCOMPLETE="${3:-/home/chris/Fairy-Stockfish-X/src/variants-incomplete.ini}"
-ENGINE_LARGE="${4:-/home/chris/Fairy-Stockfish-X/src/stockfish-large}"
-ENGINE_VLB="${5:-/home/chris/Fairy-Stockfish-X/src/stockfish-vlb}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENGINE="${1:-$ROOT_DIR/src/stockfish}"
+VARIANTS_MAIN="${2:-$ROOT_DIR/src/variants.ini}"
+VARIANTS_INCOMPLETE="${3:-$ROOT_DIR/src/variants-incomplete.ini}"
+ENGINE_LARGE="${4:-$ROOT_DIR/src/stockfish-large}"
+ENGINE_VLB="${5:-$ROOT_DIR/src/stockfish-vlb}"
 
 run_cmds() {
   local variants="$1"

--- a/tests/dots-and-boxes.sh
+++ b/tests/dots-and-boxes.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ENGINE="${1:-/home/chris/Fairy-Stockfish-X/src/stockfish}"
 VARIANTS_MAIN="${2:-/home/chris/Fairy-Stockfish-X/src/variants.ini}"
 VARIANTS_INCOMPLETE="${3:-/home/chris/Fairy-Stockfish-X/src/variants-incomplete.ini}"
+ENGINE_LARGE="${4:-/home/chris/Fairy-Stockfish-X/src/stockfish-large}"
 
 run_cmds() {
   local variants="$1"
@@ -24,6 +25,13 @@ out=$(run_cmds "$VARIANTS_MAIN" dots-boxes-7x7 \
   "position startpos
 go perft 1")
 echo "$out" | grep -q "Nodes searched: 24"
+
+if [[ -x "${ENGINE_LARGE}" ]]; then
+  out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nposition startpos\ngo perft 1\nquit\n' \
+    "$VARIANTS_MAIN" "dots-boxes-9x9" | "$ENGINE_LARGE")
+  echo "$out" | grep -q "info string variant dots-boxes-9x9 "
+  echo "$out" | grep -q "Nodes searched: 40"
+fi
 
 out=$(run_cmds "$VARIANTS_INCOMPLETE" dots-boxes-2x2 \
   "position startpos moves a1a1,b5 a1a1,a4 a1a1,b3 a1a1,c4

--- a/tests/dots-and-boxes.sh
+++ b/tests/dots-and-boxes.sh
@@ -5,6 +5,7 @@ ENGINE="${1:-/home/chris/Fairy-Stockfish-X/src/stockfish}"
 VARIANTS_MAIN="${2:-/home/chris/Fairy-Stockfish-X/src/variants.ini}"
 VARIANTS_INCOMPLETE="${3:-/home/chris/Fairy-Stockfish-X/src/variants-incomplete.ini}"
 ENGINE_LARGE="${4:-/home/chris/Fairy-Stockfish-X/src/stockfish-large}"
+ENGINE_VLB="${5:-/home/chris/Fairy-Stockfish-X/src/stockfish-vlb}"
 
 run_cmds() {
   local variants="$1"
@@ -31,6 +32,13 @@ if [[ -x "${ENGINE_LARGE}" ]]; then
     "$VARIANTS_MAIN" "dots-boxes-9x9" | "$ENGINE_LARGE")
   echo "$out" | grep -q "info string variant dots-boxes-9x9 "
   echo "$out" | grep -q "Nodes searched: 40"
+fi
+
+if [[ -x "${ENGINE_VLB}" ]]; then
+  out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nposition startpos\ngo perft 1\nquit\n' \
+    "$VARIANTS_MAIN" "dots-boxes-15x15" | "$ENGINE_VLB")
+  echo "$out" | grep -q "info string variant dots-boxes-15x15 "
+  echo "$out" | grep -q "Nodes searched: 112"
 fi
 
 out=$(run_cmds "$VARIANTS_INCOMPLETE" dots-boxes-2x2 \

--- a/tests/edge-insert.sh
+++ b/tests/edge-insert.sh
@@ -41,24 +41,24 @@ quit
 EOF
 }
 
-# Corner insertion must be disambiguated by marker square.
+# Corner insertion uses drop-style notation with an explicit insertion lane.
 out=$(run_cmds "setoption name UCI_Variant value edge-insert-demo
 position fen A4/5/5/5/5[AAAAAAAAA] w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^a5a4: 1$"
-echo "${out}" | grep -q "^a5b5: 1$"
+echo "${out}" | grep -q "^A@a4,b4: 1$"
+echo "${out}" | grep -q "^A@b5,b4: 1$"
 
-# Top-edge insertion at a5 pushes down the file.
+# Top-edge insertion on the a-file pushes down the file.
 out=$(run_cmds "setoption name UCI_Variant value edge-insert-demo
-position fen A4/5/5/5/5[AAAAAAAAA] w - - 0 1 moves a5a4
+position fen A4/5/5/5/5[AAAAAAAAA] w - - 0 1 moves A@a4,b4
 d")
-echo "${out}" | grep -q "Fen: 5/A4/5/5/5\\[AAAAAAAAA\\] b - - 1 1"
+echo "${out}" | grep -q "Fen: A4/A4/5/5/5\\[AAAAAAAA\\] b - - 0 1"
 
-# Left-edge insertion at a5 pushes across the rank.
+# Top-edge insertion on the b-file pushes across the top rank.
 out=$(run_cmds "setoption name UCI_Variant value edge-insert-demo
-position fen A4/5/5/5/5[AAAAAAAAA] w - - 0 1 moves a5b5
+position fen A4/5/5/5/5[AAAAAAAAA] w - - 0 1 moves A@b5,b4
 d")
-echo "${out}" | grep -q "Fen: 1A3/5/5/5/5\\[AAAAAAAAA\\] b - - 1 1"
+echo "${out}" | grep -q "Fen: AA3/5/5/5/5\\[AAAAAAAA\\] b - - 0 1"
 
 # Plain drops must be rejected when edgeInsertOnly is enabled.
 out=$(run_cmds "setoption name UCI_Variant value edge-insert-demo

--- a/tests/hex-board-display.sh
+++ b/tests/hex-board-display.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENGINE="${1:-/home/chris/Fairy-Stockfish-X/src/stockfish}"
+
+error() {
+  echo "hex-board display regression failed on line $1" >&2
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+hex_ini=$(mktemp)
+cat > "${hex_ini}" <<'INI'
+[hex-display:fairy]
+maxRank = 5
+maxFile = e
+hexBoard = true
+checking = false
+king = -
+pieceToCharTable = -
+startFen = 5/5/5/5/5 w - - 0 1
+INI
+
+out=$(cat <<EOF | "${ENGINE}"
+uci
+setoption name VariantPath value ${hex_ini}
+setoption name UCI_Variant value hex-display
+position startpos
+d
+quit
+EOF
+)
+
+echo "${out}" | grep -Fq " [  ] [  ] [  ] [  ] [  ] 5"
+echo "${out}" | grep -Fq "         [  ] [  ] [  ] [  ] [  ] 1 *"
+echo "${out}" | grep -Fq " a   b   c   d   e"
+echo "${out}" | grep -Fq "Fen: 5/5/5/5/5 w - - 0 1"
+
+bad_ini=$(mktemp)
+cat > "${bad_ini}" <<'INI'
+[bad-hex:fairy]
+hexBoard = true
+cylindrical = true
+startFen = 8/8/8/8/8/8/8/8 w - - 0 1
+INI
+
+bad_out=$("${ENGINE}" check "${bad_ini}" 2>&1 || true)
+echo "${bad_out}" | grep -Fq "hexBoard is not supported together with cylindrical or toroidal topology."
+echo "${bad_out}" | grep -Fq "Variant 'bad-hex' has invalid configuration. Skipping."
+
+rm -f "${hex_ini}" "${bad_ini}"
+
+echo "hex-board display regression passed"

--- a/tests/hex-chess-variants.sh
+++ b/tests/hex-chess-variants.sh
@@ -28,9 +28,12 @@ d")
   echo "${out}" | grep -q "info string variant ${v} "
 }
 
-variant_available "minihexchess"
-variant_available "glinski-chess"
-variant_available "mccooey-chess"
+if ! variant_available "minihexchess" \
+  || ! variant_available "glinski-chess" \
+  || ! variant_available "mccooey-chess"; then
+  echo "Requires a very-large-board capable engine. Skipping."
+  exit 0
+fi
 
 out=$(run_cmds "setoption name UCI_Variant value minihexchess
 position startpos

--- a/tests/hex-chess-variants.sh
+++ b/tests/hex-chess-variants.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+error() {
+  echo "hex chess variants regression failed on line $1"
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+ENGINE=${1:-src/stockfish-vlb}
+VARIANT_PATH=${2:-src/variants.ini}
+
+run_cmds() {
+  cat <<EOF | "${ENGINE}" 2>/dev/null
+uci
+setoption name VariantPath value ${VARIANT_PATH}
+$1
+quit
+EOF
+}
+
+variant_available() {
+  local v="$1"
+  local out
+  out=$(run_cmds "setoption name UCI_Variant value ${v}
+d")
+  echo "${out}" | grep -q "info string variant ${v} "
+}
+
+variant_available "minihexchess"
+variant_available "glinski-chess"
+variant_available "mccooey-chess"
+
+out=$(run_cmds "setoption name UCI_Variant value minihexchess
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 6"
+echo "${out}" | grep -q "^a2b4: 1$"
+echo "${out}" | grep -q "^a3a4: 1$"
+echo "${out}" | grep -q "^b3b4: 1$"
+echo "${out}" | grep -q "^c3c4: 1$"
+echo "${out}" | grep -q "^b2d3: 1$"
+echo "${out}" | grep -q "^b2c4: 1$"
+
+out=$(run_cmds "setoption name UCI_Variant value glinski-chess
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 34"
+echo "${out}" | grep -q "^d1d2: 1$"
+echo "${out}" | grep -q "^a4b4: 1$"
+echo "${out}" | grep -q "^a1c2: 1$"
+echo "${out}" | grep -q "^a5a6: 1$"
+echo "${out}" | grep -q "^b1d2: 1$"
+
+out=$(run_cmds "setoption name UCI_Variant value mccooey-chess
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 10"
+echo "${out}" | grep -q "^c3e4: 1$"
+echo "${out}" | grep -q "^c2e1: 1$"
+echo "${out}" | grep -q "^a4a5: 1$"
+
+echo "hex chess variants regression passed"

--- a/tests/hex-connection-variants.sh
+++ b/tests/hex-connection-variants.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+error() {
+  echo "hex connection variants regression failed on line $1"
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+ENGINE="${1:-}"
+if [[ -z "${ENGINE}" ]]; then
+  if [[ -x "src/stockfish-vlb" ]]; then
+    ENGINE="src/stockfish-vlb"
+  elif [[ -x "./src/stockfish-vlb" ]]; then
+    ENGINE="./src/stockfish-vlb"
+  else
+    ENGINE="./src/stockfish"
+  fi
+fi
+VARIANT_PATH="${2:-./src/variants.ini}"
+
+run_cmds() {
+  cat <<EOF | "${ENGINE}" 2>/dev/null
+uci
+setoption name VariantPath value ${VARIANT_PATH}
+setoption name UCI_Variant value $1
+$2
+quit
+EOF
+}
+
+variant_available() {
+  local v="$1"
+  local out
+  out=$(run_cmds "${v}" "d")
+  echo "${out}" | grep -q "info string variant ${v} "
+}
+
+if ! variant_available "hex"; then
+  echo "hex connection variants regression requires a very-large-board capable engine"
+  exit 1
+fi
+
+out=$(run_cmds "hex" "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 121"
+
+out=$(run_cmds "hex" "position fen 11/11/11/11/11/11/11/11/11/11/PPPPPPPPPPP b - - 0 1
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 0"
+
+out=$(run_cmds "y" "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 55"
+
+echo "hex connection variants regression passed"

--- a/tests/hex-connection-variants.sh
+++ b/tests/hex-connection-variants.sh
@@ -45,12 +45,24 @@ out=$(run_cmds "hex" "position startpos
 go perft 1")
 echo "${out}" | grep -q "Nodes searched: 121"
 
+out=$(run_cmds "hex-7x7" "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 49"
+
+out=$(run_cmds "hex-10x10" "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 100"
+
 out=$(run_cmds "hex" "position fen 11/11/11/11/11/11/11/11/11/11/PPPPPPPPPPP b - - 0 1
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 0"
+
+out=$(run_cmds "misere-hex" "position fen 11/11/11/11/11/11/11/11/11/11/PPPPPPPPPPP[P] b - - 0 1
 go perft 1")
 echo "${out}" | grep -q "Nodes searched: 0"
 
 out=$(run_cmds "y" "position startpos
 go perft 1")
-echo "${out}" | grep -q "Nodes searched: 55"
+echo "${out}" | grep -q "Nodes searched: 56"
 
 echo "hex connection variants regression passed"

--- a/tests/hex-piece-movement.sh
+++ b/tests/hex-piece-movement.sh
@@ -47,6 +47,12 @@ startFen = 7/7/7/3N3/7/7/7 w - - 0 1
 maxRank = 7
 maxFile = g
 startFen = 7/7/7/3P3/2x1x2/7/7 w - - 0 1
+
+[hex-royal-king-test:hex-rook-test]
+maxRank = 7
+maxFile = g
+king = k:WrfFlbFflFrbFrf(2,1)lb(2,1)fr(2,1)bl(2,1)
+startFen = 6k/7/7/3K3/7/7/7 w - - 0 1
 INI
 
 run_cmds() {
@@ -125,5 +131,21 @@ echo "${out}" | grep -q "Nodes searched: 3"
 echo "${out}" | grep -q "^d4c3: 1$"
 echo "${out}" | grep -q "^d4d5: 1$"
 echo "${out}" | grep -q "^d4e3: 1$"
+
+out=$(run_cmds "hex-royal-king-test" "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 12"
+echo "${out}" | grep -q "^d4c2: 1$"
+echo "${out}" | grep -q "^d4b3: 1$"
+echo "${out}" | grep -q "^d4c3: 1$"
+echo "${out}" | grep -q "^d4d3: 1$"
+echo "${out}" | grep -q "^d4e3: 1$"
+echo "${out}" | grep -q "^d4c4: 1$"
+echo "${out}" | grep -q "^d4e4: 1$"
+echo "${out}" | grep -q "^d4c5: 1$"
+echo "${out}" | grep -q "^d4d5: 1$"
+echo "${out}" | grep -q "^d4e5: 1$"
+echo "${out}" | grep -q "^d4f5: 1$"
+echo "${out}" | grep -q "^d4e6: 1$"
 
 echo "hex piece movement regression passed"

--- a/tests/hex-piece-movement.sh
+++ b/tests/hex-piece-movement.sh
@@ -18,13 +18,15 @@ cat >"${TMP_VARIANT_PATH}" <<'INI'
 maxRank = 5
 maxFile = e
 hexBoard = true
-pieceToCharTable = RKBQN.rkbqn
+pieceToCharTable = RKBQNPX.rkbqnp.x
 king = -
 customPiece1 = r:RrfBlbB
 customPiece2 = k:WrfFlbF
 customPiece3 = b:flBrbBrf(2,1)lb(2,1)fr(2,1)bl(2,1)
 customPiece4 = q:RrfBlbBflBrbBrf(2,1)lb(2,1)fr(2,1)bl(2,1)
 customPiece5 = n:fl(2,1)lb(2,1)fr(2,1)rb(2,1)rf(2,1)bl(2,1)fl(1,2)lb(1,2)fr(1,2)rb(1,2)rf(1,2)bl(1,2)
+customPiece6 = p:mfWclFcrF
+customPiece7 = x:WrfFlbF
 startFen = 5/5/2R2/5/5 w - - 0 1
 
 [hex-king-test:hex-rook-test]
@@ -40,6 +42,11 @@ startFen = 5/5/2Q2/5/5 w - - 0 1
 maxRank = 7
 maxFile = g
 startFen = 7/7/7/3N3/7/7/7 w - - 0 1
+
+[hex-pawn-test:hex-rook-test]
+maxRank = 7
+maxFile = g
+startFen = 7/7/7/3P3/2x1x2/7/7 w - - 0 1
 INI
 
 run_cmds() {
@@ -111,5 +118,12 @@ echo "${out}" | grep -q "^d4b5: 1$"
 echo "${out}" | grep -q "^d4f5: 1$"
 echo "${out}" | grep -q "^d4c6: 1$"
 echo "${out}" | grep -q "^d4e6: 1$"
+
+out=$(run_cmds "hex-pawn-test" "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 3"
+echo "${out}" | grep -q "^d4c3: 1$"
+echo "${out}" | grep -q "^d4d5: 1$"
+echo "${out}" | grep -q "^d4e3: 1$"
 
 echo "hex piece movement regression passed"

--- a/tests/hex-piece-movement.sh
+++ b/tests/hex-piece-movement.sh
@@ -17,12 +17,13 @@ cat >"${TMP_VARIANT_PATH}" <<'INI'
 maxRank = 5
 maxFile = e
 hexBoard = true
-pieceToCharTable = RKBQ.rkbq
+pieceToCharTable = RKBQN.rkbqn
 king = -
 customPiece1 = r:RrfBlbB
 customPiece2 = k:WrfFlbF
 customPiece3 = b:flBrbBrf(2,1)lb(2,1)fr(2,1)bl(2,1)
 customPiece4 = q:RrfBlbBflBrbBrf(2,1)lb(2,1)fr(2,1)bl(2,1)
+customPiece5 = n:fl(2,1)lb(2,1)fr(2,1)rb(2,1)rf(2,1)bl(2,1)fl(1,2)lb(1,2)fr(1,2)rb(1,2)rf(1,2)bl(1,2)
 startFen = 5/5/2R2/5/5 w - - 0 1
 
 [hex-king-test:hex-rook-test]
@@ -33,6 +34,11 @@ startFen = 5/5/2B2/5/5 w - - 0 1
 
 [hex-queen-test:hex-rook-test]
 startFen = 5/5/2Q2/5/5 w - - 0 1
+
+[hex-knight-test:hex-rook-test]
+maxRank = 7
+maxFile = g
+startFen = 7/7/7/3N3/7/7/7 w - - 0 1
 INI
 
 run_cmds() {
@@ -92,5 +98,17 @@ echo "${out}" | grep -q "^c3b1: 1$"
 echo "${out}" | grep -q "^c3e1: 1$"
 echo "${out}" | grep -q "^c3a2: 1$"
 echo "${out}" | grep -q "^c3d5: 1$"
+
+out=$(run_cmds "hex-knight-test" "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 8"
+echo "${out}" | grep -q "^d4c2: 1$"
+echo "${out}" | grep -q "^d4e2: 1$"
+echo "${out}" | grep -q "^d4b3: 1$"
+echo "${out}" | grep -q "^d4f3: 1$"
+echo "${out}" | grep -q "^d4b5: 1$"
+echo "${out}" | grep -q "^d4f5: 1$"
+echo "${out}" | grep -q "^d4c6: 1$"
+echo "${out}" | grep -q "^d4e6: 1$"
 
 echo "hex piece movement regression passed"

--- a/tests/hex-piece-movement.sh
+++ b/tests/hex-piece-movement.sh
@@ -7,7 +7,8 @@ error() {
 }
 trap 'error ${LINENO}' ERR
 
-ENGINE="${1:-./src/stockfish}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENGINE="${1:-${SCRIPT_DIR}/../src/stockfish}"
 
 TMP_VARIANT_PATH=$(mktemp /tmp/fsx-hex-pieces-XXXXXX.ini)
 trap 'rm -f "${TMP_VARIANT_PATH}"' EXIT

--- a/tests/hex-piece-movement.sh
+++ b/tests/hex-piece-movement.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+error() {
+  echo "hex piece movement regression failed on line $1"
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+ENGINE="${1:-./src/stockfish}"
+
+TMP_VARIANT_PATH=$(mktemp /tmp/fsx-hex-pieces-XXXXXX.ini)
+trap 'rm -f "${TMP_VARIANT_PATH}"' EXIT
+
+cat >"${TMP_VARIANT_PATH}" <<'INI'
+[hex-rook-test:fairy]
+maxRank = 5
+maxFile = e
+hexBoard = true
+pieceToCharTable = RK.rk
+king = -
+customPiece1 = r:RrfBlbB
+customPiece2 = k:WrfFlbF
+startFen = 5/5/2R2/5/5 w - - 0 1
+
+[hex-king-test:hex-rook-test]
+startFen = 5/5/2K2/5/5 w - - 0 1
+INI
+
+run_cmds() {
+  cat <<EOF | "${ENGINE}" 2>/dev/null
+uci
+setoption name VariantPath value ${TMP_VARIANT_PATH}
+setoption name UCI_Variant value $1
+$2
+quit
+EOF
+}
+
+out=$(run_cmds "hex-rook-test" "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 12"
+echo "${out}" | grep -q "^c3a1: 1$"
+echo "${out}" | grep -q "^c3c1: 1$"
+echo "${out}" | grep -q "^c3b2: 1$"
+echo "${out}" | grep -q "^c3c2: 1$"
+echo "${out}" | grep -q "^c3a3: 1$"
+echo "${out}" | grep -q "^c3b3: 1$"
+echo "${out}" | grep -q "^c3d3: 1$"
+echo "${out}" | grep -q "^c3e3: 1$"
+echo "${out}" | grep -q "^c3c4: 1$"
+echo "${out}" | grep -q "^c3d4: 1$"
+echo "${out}" | grep -q "^c3c5: 1$"
+echo "${out}" | grep -q "^c3e5: 1$"
+
+out=$(run_cmds "hex-king-test" "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 6"
+echo "${out}" | grep -q "^c3b2: 1$"
+echo "${out}" | grep -q "^c3c2: 1$"
+echo "${out}" | grep -q "^c3b3: 1$"
+echo "${out}" | grep -q "^c3d3: 1$"
+echo "${out}" | grep -q "^c3c4: 1$"
+echo "${out}" | grep -q "^c3d4: 1$"
+
+echo "hex piece movement regression passed"

--- a/tests/hex-piece-movement.sh
+++ b/tests/hex-piece-movement.sh
@@ -17,14 +17,22 @@ cat >"${TMP_VARIANT_PATH}" <<'INI'
 maxRank = 5
 maxFile = e
 hexBoard = true
-pieceToCharTable = RK.rk
+pieceToCharTable = RKBQ.rkbq
 king = -
 customPiece1 = r:RrfBlbB
 customPiece2 = k:WrfFlbF
+customPiece3 = b:flBrbBrf(2,1)lb(2,1)fr(2,1)bl(2,1)
+customPiece4 = q:RrfBlbBflBrbBrf(2,1)lb(2,1)fr(2,1)bl(2,1)
 startFen = 5/5/2R2/5/5 w - - 0 1
 
 [hex-king-test:hex-rook-test]
 startFen = 5/5/2K2/5/5 w - - 0 1
+
+[hex-bishop-test:hex-rook-test]
+startFen = 5/5/2B2/5/5 w - - 0 1
+
+[hex-queen-test:hex-rook-test]
+startFen = 5/5/2Q2/5/5 w - - 0 1
 INI
 
 run_cmds() {
@@ -62,5 +70,27 @@ echo "${out}" | grep -q "^c3b3: 1$"
 echo "${out}" | grep -q "^c3d3: 1$"
 echo "${out}" | grep -q "^c3c4: 1$"
 echo "${out}" | grep -q "^c3d4: 1$"
+
+out=$(run_cmds "hex-bishop-test" "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 8"
+echo "${out}" | grep -q "^c3b1: 1$"
+echo "${out}" | grep -q "^c3e1: 1$"
+echo "${out}" | grep -q "^c3a2: 1$"
+echo "${out}" | grep -q "^c3d2: 1$"
+echo "${out}" | grep -q "^c3b4: 1$"
+echo "${out}" | grep -q "^c3e4: 1$"
+echo "${out}" | grep -q "^c3a5: 1$"
+echo "${out}" | grep -q "^c3d5: 1$"
+
+out=$(run_cmds "hex-queen-test" "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 20"
+echo "${out}" | grep -q "^c3a1: 1$"
+echo "${out}" | grep -q "^c3e5: 1$"
+echo "${out}" | grep -q "^c3b1: 1$"
+echo "${out}" | grep -q "^c3e1: 1$"
+echo "${out}" | grep -q "^c3a2: 1$"
+echo "${out}" | grep -q "^c3d5: 1$"
 
 echo "hex piece movement regression passed"

--- a/tests/kings-or-lemmings.sh
+++ b/tests/kings-or-lemmings.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENGINE="${1:-/home/chris/Fairy-Stockfish-X/src/stockfish}"
+VARIANTS="${2:-/home/chris/Fairy-Stockfish-X/src/variants.ini}"
+
+run_cmds() {
+  local cmds="$1"
+  printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value kings-or-lemmings\n%s\nquit\n' \
+    "$VARIANTS" "$cmds" | "$ENGINE"
+}
+
+echo "kings or lemmings regression started"
+
+out=$(run_cmds "position fen 4k3/8/8/8/8/8/8/4K3 w - - 0 1
+go perft 1")
+echo "$out" | grep -q "^e1e2: 1$"
+echo "$out" | grep -q "^e1e2c: 1$"
+
+out=$(run_cmds "position fen 4k3/8/8/8/8/8/4p3/4K3 w - - 0 1 moves e1e2c
+d")
+echo "$out" | grep -Fq "Fen: 4k3/8/8/8/8/8/4K3/4K3 b - - 0 1"
+
+out=$(run_cmds "position fen 8/8/8/8/8/8/8/R3K2R w KQ - 0 1
+go perft 1")
+echo "$out" | grep -q "^e1g1: 1$"
+echo "$out" | grep -q "^e1c1: 1$"
+
+out=$(run_cmds "position fen 8/8/8/8/8/8/8/R3K2R w KQ - 0 1 moves e1e2c
+d")
+echo "$out" | grep -Fq "Fen: 8/8/8/8/8/8/4K3/R3K2R b - - 1 1"
+
+out=$(run_cmds "position fen 7k/8/8/8/8/8/rq6/K6K w - - 0 1
+go depth 1")
+echo "$out" | grep -q "^bestmove (none)$"
+
+echo "kings or lemmings regression passed"

--- a/tests/konobi.sh
+++ b/tests/konobi.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+error() { echo "konobi regression failed on line $1"; exit 1; }
+trap 'error ${LINENO}' ERR
+ENGINE="${1:-./src/stockfish}"
+VARIANT_PATH="${2:-./src/variants.ini}"
+
+run_cmds() {
+  cat <<EOF | "${ENGINE}" 2>/dev/null
+uci
+setoption name VariantPath value ${VARIANT_PATH}
+setoption name UCI_Variant value konobi
+$1
+quit
+EOF
+}
+
+out=$(run_cmds "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 64"
+
+out=$(run_cmds "position startpos moves P@b1
+go perft 1")
+echo "${out}" | grep -q "^P@a2: 1$"
+! echo "${out}" | grep -q "^P@b1: 1$"
+
+# Same setup as Kopano, but Konobi forbids the weak link because b3/c2/a2/b1
+# still leave a strong, non-weak follow-up placement around b2.
+out=$(run_cmds "position fen 8/8/8/8/3p4/8/1P6/8[Pp] w - - 0 1
+go perft 1")
+! echo "${out}" | grep -q "^P@c3: 1$"
+
+# Once all strong, non-weak follow-up placements around b2 are blocked, the
+# weak link becomes legal again.
+out=$(run_cmds "position fen 8/8/8/8/3p4/8/pPp5/p7[Pp] w - - 0 1
+go perft 1")
+echo "${out}" | grep -q "^P@c3: 1$"
+
+# Existing Kopano crosscut restriction still applies.
+out=$(run_cmds "position fen 8/8/8/8/2pP4/3p4/8/8[Pp] w - - 0 1
+go perft 1")
+! echo "${out}" | grep -q "^P@c3: 1$"
+
+echo "konobi regression passed"

--- a/tests/kopano.sh
+++ b/tests/kopano.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+error() {
+  echo "kopano regression failed on line $1"
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+ENGINE="${1:-./src/stockfish}"
+VARIANT_PATH="${2:-./src/variants.ini}"
+
+run_cmds() {
+  cat <<EOF | "${ENGINE}" 2>/dev/null
+uci
+setoption name VariantPath value ${VARIANT_PATH}
+setoption name UCI_Variant value kopano
+$1
+quit
+EOF
+}
+
+out=$(run_cmds "position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 64"
+
+out=$(run_cmds "position startpos moves P@b1
+go perft 1")
+echo "${out}" | grep -q "^P@a2: 1$"
+! echo "${out}" | grep -q "^P@b1: 1$"
+
+out=$(run_cmds "position fen 8/8/8/8/8/8/1P6/8[Pp] w - - 0 1
+go perft 1")
+! echo "${out}" | grep -q "^P@c3: 1$"
+
+out=$(run_cmds "position fen 8/8/8/8/3p4/8/1P6/8[Pp] w - - 0 1
+go perft 1")
+echo "${out}" | grep -q "^P@c3: 1$"
+
+out=$(run_cmds "position fen 8/8/8/8/2pP4/3p4/8/8[Pp] w - - 0 1
+go perft 1")
+! echo "${out}" | grep -q "^P@c3: 1$"
+
+out=$(run_cmds "position fen 7p/6p1/5p2/4p3/3p4/2p5/1p6/p7 w - - 0 1
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 0"
+
+echo "kopano regression passed"

--- a/tests/movegen-regressions.sh
+++ b/tests/movegen-regressions.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENGINE="${1:-/home/chris/Fairy-Stockfish-X/src/stockfish-large}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENGINE="${1:-$ROOT_DIR/src/stockfish-large}"
 
 TMP_INI="$(mktemp)"
 cleanup() {

--- a/tests/new-variants-smoke.sh
+++ b/tests/new-variants-smoke.sh
@@ -374,6 +374,21 @@ go perft 1")
 echo "${out}" | grep -q "Nodes searched: 0"
 fi
 
+# 7d) Hex-family connection variants: Y and Hex load on the expected build sizes.
+if variant_available "y"; then
+out=$(run_cmds "setoption name UCI_Variant value y
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 55"
+fi
+
+if variant_available "hex"; then
+out=$(run_cmds "setoption name UCI_Variant value hex
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 121"
+fi
+
 # 8) Neutreeko: max-distance move completes a line and ends the game.
 if variant_available "neutreeko"; then
 out=$(run_cmds "setoption name UCI_Variant value neutreeko

--- a/tests/new-variants-smoke.sh
+++ b/tests/new-variants-smoke.sh
@@ -161,6 +161,27 @@ go perft 1")
 echo "${out}" | grep -q "Nodes searched: 8"
 
 # 5bb1) Mini Hexchess loads on the masked 37-cell hex board and exposes the expected opening moves.
+if variant_available "hex-7x7"; then
+out=$(run_cmds "setoption name UCI_Variant value hex-7x7
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 49"
+fi
+
+if variant_available "hex-10x10"; then
+out=$(run_cmds "setoption name UCI_Variant value hex-10x10
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 100"
+fi
+
+if variant_available "misere-hex"; then
+out=$(run_cmds "setoption name UCI_Variant value misere-hex
+position fen 11/11/11/11/11/11/11/11/11/11/PPPPPPPPPPP[P] b - - 0 1
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 0"
+fi
+
 if variant_available "minihexchess"; then
 out=$(run_cmds "setoption name UCI_Variant value minihexchess
 position startpos
@@ -415,7 +436,7 @@ if variant_available "y"; then
 out=$(run_cmds "setoption name UCI_Variant value y
 position startpos
 go perft 1")
-echo "${out}" | grep -q "Nodes searched: 55"
+echo "${out}" | grep -q "Nodes searched: 56"
 fi
 
 if variant_available "hex"; then

--- a/tests/new-variants-smoke.sh
+++ b/tests/new-variants-smoke.sh
@@ -140,14 +140,22 @@ go perft 1")
 echo "${out}" | grep -q "^e1d2: 1$"
 
 # 5bb) Additional Groups variants load and expose the expected setup-phase drops.
-for v in groups groups-setup groups-queen-setup; do
+for v in groups groups-fixed groups-setup groups-jump-setup groups-queen-fixed groups-queen-jump-fixed groups-queen-setup groups-queen-jump-setup; do
   variant_available "${v}"
 done
 out=$(run_cmds "setoption name UCI_Variant value groups-setup
 position startpos
 go perft 1")
 echo "${out}" | grep -q "Nodes searched: 8"
+out=$(run_cmds "setoption name UCI_Variant value groups-jump-setup
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 8"
 out=$(run_cmds "setoption name UCI_Variant value groups-queen-setup
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 8"
+out=$(run_cmds "setoption name UCI_Variant value groups-queen-jump-setup
 position startpos
 go perft 1")
 echo "${out}" | grep -q "Nodes searched: 8"

--- a/tests/new-variants-smoke.sh
+++ b/tests/new-variants-smoke.sh
@@ -340,6 +340,40 @@ go perft 1")
 echo "${out}" | grep -q "Nodes searched: 0"
 fi
 
+# 7c) Kopano: mirrored opening swap, reciprocal weak links, crosscut blocks, and no-placement wins.
+if variant_available "kopano"; then
+out=$(run_cmds "setoption name UCI_Variant value kopano
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 64"
+
+out=$(run_cmds "setoption name UCI_Variant value kopano
+position startpos moves P@b1
+go perft 1")
+echo "${out}" | grep -q "^P@a2: 1$"
+! echo "${out}" | grep -q "^P@b1: 1$"
+
+out=$(run_cmds "setoption name UCI_Variant value kopano
+position fen 8/8/8/8/8/8/1P6/8[Pp] w - - 0 1
+go perft 1")
+! echo "${out}" | grep -q "^P@c3: 1$"
+
+out=$(run_cmds "setoption name UCI_Variant value kopano
+position fen 8/8/8/8/3p4/8/1P6/8[Pp] w - - 0 1
+go perft 1")
+echo "${out}" | grep -q "^P@c3: 1$"
+
+out=$(run_cmds "setoption name UCI_Variant value kopano
+position fen 8/8/8/8/2pP4/3p4/8/8[Pp] w - - 0 1
+go perft 1")
+! echo "${out}" | grep -q "^P@c3: 1$"
+
+out=$(run_cmds "setoption name UCI_Variant value kopano
+position fen 7p/6p1/5p2/4p3/3p4/2p5/1p6/p7 w - - 0 1
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 0"
+fi
+
 # 8) Neutreeko: max-distance move completes a line and ends the game.
 if variant_available "neutreeko"; then
 out=$(run_cmds "setoption name UCI_Variant value neutreeko

--- a/tests/new-variants-smoke.sh
+++ b/tests/new-variants-smoke.sh
@@ -174,6 +174,28 @@ echo "${out}" | grep -q "^b2d3: 1$"
 echo "${out}" | grep -q "^b2c4: 1$"
 fi
 
+if variant_available "glinski-chess"; then
+out=$(run_cmds "setoption name UCI_Variant value glinski-chess
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 34"
+echo "${out}" | grep -q "^d1d2: 1$"
+echo "${out}" | grep -q "^a4b4: 1$"
+echo "${out}" | grep -q "^a1c2: 1$"
+echo "${out}" | grep -q "^a5a6: 1$"
+echo "${out}" | grep -q "^b1d2: 1$"
+fi
+
+if variant_available "mccooey-chess"; then
+out=$(run_cmds "setoption name UCI_Variant value mccooey-chess
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 10"
+echo "${out}" | grep -q "^c3e4: 1$"
+echo "${out}" | grep -q "^c2e1: 1$"
+echo "${out}" | grep -q "^a4a5: 1$"
+fi
+
 # 5bc) Simplified inheritance stanzas still preserve start positions.
 out=$(run_cmds "setoption name UCI_Variant value maharajah
 position startpos

--- a/tests/new-variants-smoke.sh
+++ b/tests/new-variants-smoke.sh
@@ -160,6 +160,20 @@ position startpos
 go perft 1")
 echo "${out}" | grep -q "Nodes searched: 8"
 
+# 5bb1) Mini Hexchess loads on the masked 37-cell hex board and exposes the expected opening moves.
+if variant_available "minihexchess"; then
+out=$(run_cmds "setoption name UCI_Variant value minihexchess
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 6"
+echo "${out}" | grep -q "^a2b4: 1$"
+echo "${out}" | grep -q "^a3a4: 1$"
+echo "${out}" | grep -q "^b3b4: 1$"
+echo "${out}" | grep -q "^c3c4: 1$"
+echo "${out}" | grep -q "^b2d3: 1$"
+echo "${out}" | grep -q "^b2c4: 1$"
+fi
+
 # 5bc) Simplified inheritance stanzas still preserve start positions.
 out=$(run_cmds "setoption name UCI_Variant value maharajah
 position startpos

--- a/tests/new-variants-smoke.sh
+++ b/tests/new-variants-smoke.sh
@@ -139,7 +139,20 @@ position startpos
 go perft 1")
 echo "${out}" | grep -q "^e1d2: 1$"
 
-# 5bb) Simplified inheritance stanzas still preserve start positions.
+# 5bb) Additional Groups variants load and expose the expected setup-phase drops.
+for v in groups groups-setup groups-queen-setup; do
+  variant_available "${v}"
+done
+out=$(run_cmds "setoption name UCI_Variant value groups-setup
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 8"
+out=$(run_cmds "setoption name UCI_Variant value groups-queen-setup
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 8"
+
+# 5bc) Simplified inheritance stanzas still preserve start positions.
 out=$(run_cmds "setoption name UCI_Variant value maharajah
 position startpos
 d")

--- a/tests/owner-return-hand.sh
+++ b/tests/owner-return-hand.sh
@@ -61,9 +61,9 @@ d")
 echo "${out}" | grep -q "Sfen: 3/1A1/3 w Aa 2"
 
 out=$(run_cmds "setoption name UCI_Variant value owner-hand-eject
-position startpos moves A@a5,b5
+position startpos moves A@a1,b1
 d")
-echo "${out}" | grep -q "Fen: AAAAA/5/5/5/5\\[a\\] b - - 0 1"
+echo "${out}" | grep -q "Fen: AAAAa/5/5/5/A4\\[\\] b - - 0 1"
 
 rm -f "${tmp_ini}"
 echo "owner-return-hand tests passed"

--- a/tests/slide5-regression.sh
+++ b/tests/slide5-regression.sh
@@ -9,7 +9,7 @@ error() {
 trap 'error ${LINENO}' ERR
 
 ENGINE=${1:-./src/stockfish}
-VARIANT_PATH=${2:-./src/variants-incomplete.ini}
+VARIANT_PATH=${2:-./src/variants.ini}
 
 perft_out=$(cat <<EOF | "${ENGINE}" 2>/dev/null
 uci

--- a/tests/test_binding_regression.py
+++ b/tests/test_binding_regression.py
@@ -1,6 +1,9 @@
 
 import pyffish as sf
 import unittest
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
 
 class TestBindings(unittest.TestCase):
     def test_is_capture_invalid_move(self):
@@ -12,7 +15,7 @@ class TestBindings(unittest.TestCase):
         self.assertEqual(res, sf.VALUE_NONE)
 
     def test_enclosing_drop_startpos_not_drawn_by_insufficient_material(self):
-        with open("/home/chris/Fairy-Stockfish-X/src/variants.ini", "r", encoding="utf-8") as f:
+        with open(ROOT_DIR / "src" / "variants.ini", "r", encoding="utf-8") as f:
             sf.load_variant_config(f.read())
         fen = sf.start_fen("snort")
         self.assertTrue(sf.legal_moves("snort", fen, []))

--- a/tests/vlb-symbol-check.sh
+++ b/tests/vlb-symbol-check.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN=${1:-/home/chris/Fairy-Stockfish-X/src/stockfish}
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="${1:-$ROOT_DIR/src/stockfish}"
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT


### PR DESCRIPTION
This PR updates the variant parser to reject the combination of 'removeConnectN' with connection win conditions (like 'connectN', 'connectRegion*', etc.) and (pseudo/anti-)royal pieces. These combinations are unorthodox and lead to undefined or inconsistent behavior, such as a player connecting N pieces but having them removed by the engine before the win is adjudicated. Consolidated existing king check for removeConnectN into the new check.