### PR TITLE
Refactor mustDropType to use ColorSetting

### DIFF
--- a/refactor_proposals.md
+++ b/refactor_proposals.md
@@ -1,0 +1,27 @@
+# Fairy-Stockfish-X Variant Option Refactoring Proposals
+
+Based on an analysis of the configuration parsers, struct definitions, and option usages, the following proposals aim to consolidate single-purpose options, reduce boilerplate parsing, and eliminate redundant option families in `variants.ini`.
+
+## 1. Unify Region Override Options (Step / Drop / Promotion Regions)
+**Current state:** There are massive families of 5 separate options controlling regions (e.g., `doubleStepRegionWhite`, `doubleStepRegionBlack`, `pieceSpecificDoubleStepRegion`, `whitePieceDoubleStepRegion`, `blackPieceDoubleStepRegion`). This pattern is repeated for `tripleStepRegion`, `dropRegion`, and `promotionRegion`.
+**Proposal:** The existing `PieceTypeBitboardGroup` type parses piece-specific bitboards (e.g., `P(e4,*1)`). By enhancing its parser to support a fallback wildcard piece `*(...)`, we can replace all 5 options with a single `[Action]Region` setting. For example: `doubleStepRegion = P(e4,*1); *(**)` allows specific piece overrides while defining a global fallback, entirely deprecating the `pieceSpecific...` and `[color]Piece...` options and significantly speeding up internal `position.h` logic.
+
+## 2. Refactor Color-Specific Options to use `ColorSetting<T>`
+**Current state:** A huge source of bloat is options duplicated for colors (e.g., `mustDropType`, `mustDropTypeWhite`, `mustDropTypeBlack`). Currently, the codebase handles this with manually duplicated arrays like `v->dropNoDoubledByColor[WHITE] = v->dropNoDoubled;` scattered all over `parser.cpp`.
+**Proposal:** `Fairy-Stockfish-X` introduced an excellent generic wrapper, `ColorSetting<T>`, that cleanly isolates global values from explicit color overrides using a safe `.has_override(c)` API. However, it was never fully adopted. I propose aggressively replacing the ad-hoc `T[COLOR_NB]` arrays and boilerplate blocks for options like `mustDrop`, `mustDropType`, `dropChecks`, `mustCapture`, `pass`, and `dropNoDoubled` with `ColorSetting<T>`.
+
+## 3. Merge `promotionPieceTypesByFile` into `promotionPieceTypes`
+**Current state:** Pawn promotions are defined either globally (`promotionPieceTypes = nbrq`) or per-file via a completely different option (`promotionPieceTypesByFile = a:r b:n`), each of which *also* has White/Black variants.
+**Proposal:** Enhance the standard `promotionPieceTypes` parser into a smarter format that accepts either a flat `PieceSet` (legacy) or a `File->PieceSet map`. By adding support for a file fallback wildcard (e.g., `promotionPieceTypes = a:r b:n *:q`), the engine can entirely deprecate the `...ByFile` option family.
+
+## 4. Enhance `dropNoDoubled` to handle `PieceSet`
+**Current state:** The `dropNoDoubled` rule (which prevents dropping a piece on a file that already has one, like the Shogi pawn) is hardcoded to accept a single `PieceType`. If a variant designer wants to restrict both pawns *and* lances, they can't.
+**Proposal:** Change `dropNoDoubled` from a single `PieceType` to a `PieceSet`. This allows variant designers to restrict multiple piece types at once (e.g., `dropNoDoubled = p l`). Furthermore, integrating it with `ColorSetting<PieceSet>` (from Proposal 2) safely deprecates `dropNoDoubledWhite` and `dropNoDoubledBlack`.
+
+## 5. Convert Blast Booleans into a unified `blastPattern` 
+**Current state:** Atomic and explosion variants determine the shape of the blast using three hardcoded, single-purpose booleans: `blastDiagonals`, `blastOrthogonals`, and `blastCenter`.
+**Proposal:** Deprecate these three booleans in favor of a new `blastPattern` option. This could accept a Betza string (e.g., `K` for the standard 3x3 square, `N` for knight-jump explosions, or `W` for orthogonal crosses) or a relative `Bitboard` mask. This provides infinite shape flexibility for variant creators while shrinking the option count.
+
+## 6. Consolidate `edgeInsert` direction logic
+**Current state:** Edge insertion drops require users to specify the board edges as direction tokens (`edgeInsertFrom = top left`) and the actual entry squares (`edgeInsertRegion = *8 a*`). This redundancy requires 6 underlying arrays in `Variant` just to track direction aliases.
+**Proposal:** The engine should infer the valid push directions mathematically based on the closest physical edge to the `edgeInsertRegion` bitboards. This removes the need for `edgeInsertFrom` entirely, trusting the bitboard geometry instead.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1583,9 +1583,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("mustDrop", v->mustDrop);
     parse_attribute("mustDropWhite", v->mustDropByColor[WHITE]);
     parse_attribute("mustDropBlack", v->mustDropByColor[BLACK]);
-    parse_attribute("mustDropType", v->mustDropType, v);
-    parse_attribute("mustDropTypeWhite", v->mustDropTypeByColor[WHITE], v);
-    parse_attribute("mustDropTypeBlack", v->mustDropTypeByColor[BLACK], v);
+    parse_color_setting_piece("mustDropType", v->mustDropType);
     parse_attribute("openingSwapDrop", v->openingSwapDrop);
     parse_attribute("openingSwapMirrorMainDiagonal", v->openingSwapMirrorMainDiagonal);
     parse_attribute("dropKingLast", v->dropKingLast);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1466,10 +1466,8 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("royalPieceNoThroughCheck", v->royalPieceNoThroughCheck);
     parse_color_setting("dropChecks", v->dropChecks);
     parse_color_setting("dropMates", v->dropMates);
-    parse_attribute("mustCapture", v->mustCapture);
+    parse_color_setting("mustCapture", v->mustCapture);
     parse_attribute("mustCaptureEnPassant", v->mustCaptureEnPassant);
-    parse_attribute("mustCaptureWhite", v->mustCaptureByColor[WHITE]);
-    parse_attribute("mustCaptureBlack", v->mustCaptureByColor[BLACK]);
     parse_attribute("rifleCapture", v->rifleCapture);
     const auto& it_push_strength = config.find("pushingStrength");
     if (it_push_strength != config.end())
@@ -1580,9 +1578,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("blastOnSameTypeCapture", v->blastOnSameTypeCapture);
     parse_attribute("captureMorph", v->captureMorph);
     parse_attribute("rexExclusiveMorph", v->rexExclusiveMorph);
-    parse_attribute("mustDrop", v->mustDrop);
-    parse_attribute("mustDropWhite", v->mustDropByColor[WHITE]);
-    parse_attribute("mustDropBlack", v->mustDropByColor[BLACK]);
+    parse_color_setting("mustDrop", v->mustDrop);
     parse_color_setting_piece("mustDropType", v->mustDropType);
     parse_attribute("openingSwapDrop", v->openingSwapDrop);
     parse_attribute("openingSwapMirrorMainDiagonal", v->openingSwapMirrorMainDiagonal);
@@ -1647,20 +1643,8 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("dropPromoted", v->dropPromoted);
     parse_attribute("symmetricDropTypes", v->symmetricDropTypes, v);
     parse_attribute("captureDrops", v->captureDrops, v);
-    parse_attribute("dropNoDoubled", v->dropNoDoubled, v);
-    v->dropNoDoubledByColor[WHITE] = v->dropNoDoubled;
-    v->dropNoDoubledByColor[BLACK] = v->dropNoDoubled;
-    if (config.find("dropNoDoubledWhite") != config.end())
-        parse_attribute("dropNoDoubledWhite", v->dropNoDoubledByColor[WHITE], v);
-    if (config.find("dropNoDoubledBlack") != config.end())
-        parse_attribute("dropNoDoubledBlack", v->dropNoDoubledByColor[BLACK], v);
-    parse_attribute("dropNoDoubledCount", v->dropNoDoubledCount);
-    v->dropNoDoubledCountByColor[WHITE] = v->dropNoDoubledCount;
-    v->dropNoDoubledCountByColor[BLACK] = v->dropNoDoubledCount;
-    if (config.find("dropNoDoubledCountWhite") != config.end())
-        parse_attribute("dropNoDoubledCountWhite", v->dropNoDoubledCountByColor[WHITE]);
-    if (config.find("dropNoDoubledCountBlack") != config.end())
-        parse_attribute("dropNoDoubledCountBlack", v->dropNoDoubledCountByColor[BLACK]);
+    parse_color_setting_piece("dropNoDoubled", v->dropNoDoubled);
+    parse_color_setting("dropNoDoubledCount", v->dropNoDoubledCount);
     parse_attribute("freeDrops", v->freeDrops);
     parse_attribute("payPointsToDrop", v->payPointsToDrop);
     parse_attribute("potions", v->potions);

--- a/src/position.h
+++ b/src/position.h
@@ -401,8 +401,8 @@ public:
   PieceSet drop_piece_types(PieceType pt) const;
   PieceSet symmetric_drop_types() const;
   PieceSet capture_drop_types() const;
-  PieceType drop_no_doubled() const;
-  PieceType drop_no_doubled(Color c) const;
+  PieceSet drop_no_doubled() const;
+  PieceSet drop_no_doubled(Color c) const;
   PieceSet promotion_pawn_types(Color c) const;
   PieceSet pawn_like_types(Color c) const;
   PieceSet en_passant_types(Color c) const;
@@ -1546,9 +1546,7 @@ inline bool Position::rex_exclusive_morph() const {
 
 inline bool Position::must_capture() const {
   assert(var != nullptr);
-  if (var->mustCaptureByColor[WHITE] || var->mustCaptureByColor[BLACK])
-      return var->mustCaptureByColor[side_to_move()];
-  return var->mustCapture;
+  return var->mustCapture.get(side_to_move());
 }
 
 inline bool Position::must_capture_en_passant() const {
@@ -1609,9 +1607,7 @@ inline bool Position::has_en_passant_capture() const {
 
 inline bool Position::must_drop() const {
   assert(var != nullptr);
-  if (var->mustDropByColor[WHITE] || var->mustDropByColor[BLACK])
-      return var->mustDropByColor[side_to_move()];
-  return var->mustDrop;
+  return var->mustDrop.get(side_to_move());
 }
 
 inline PieceType Position::must_drop_type() const {
@@ -1800,9 +1796,9 @@ inline Bitboard Position::drop_region(Color c, PieceType pt) const {
           b &= ~rank_bb(relative_rank(c, RANK_1, max_rank()));
   }
   // Doubled shogi pawns
-  if (pt == drop_no_doubled(c))
+  if (piece_set(pt) & drop_no_doubled(c))
       for (File f = FILE_A; f <= max_file(); ++f)
-          if (popcount(file_bb(f) & pieces(c, pt)) >= var->dropNoDoubledCountByColor[c])
+          if (popcount(file_bb(f) & pieces(c, pt)) >= var->dropNoDoubledCount.get(c))
               b &= ~file_bb(f);
   // Sittuyin rook drops
   if (pt == ROOK && sittuyin_rook_drop())
@@ -1922,14 +1918,14 @@ inline PieceSet Position::capture_drop_types() const {
   return var->captureDrops;
 }
 
-inline PieceType Position::drop_no_doubled() const {
+inline PieceSet Position::drop_no_doubled() const {
   assert(var != nullptr);
-  return var->dropNoDoubledByColor[side_to_move()];
+  return var->dropNoDoubled.get(side_to_move());
 }
 
-inline PieceType Position::drop_no_doubled(Color c) const {
+inline PieceSet Position::drop_no_doubled(Color c) const {
   assert(var != nullptr);
-  return var->dropNoDoubledByColor[c];
+  return var->dropNoDoubled.get(c);
 }
 
 inline PieceSet Position::promotion_pawn_types(Color c) const {

--- a/src/position.h
+++ b/src/position.h
@@ -1616,9 +1616,7 @@ inline bool Position::must_drop() const {
 
 inline PieceType Position::must_drop_type() const {
   assert(var != nullptr);
-  if (var->mustDropTypeByColor[WHITE] != ALL_PIECES || var->mustDropTypeByColor[BLACK] != ALL_PIECES)
-      return var->mustDropTypeByColor[side_to_move()];
-  return var->mustDropType;
+  return var->mustDropType.get(side_to_move());
 }
 
 inline bool Position::opening_self_removal() const {
@@ -2101,10 +2099,7 @@ inline bool Position::pass(Color c) const {
 inline bool Position::has_setup_drop(Color c) const {
   assert(var != nullptr);
 
-  PieceType requiredDropType =
-      (var->mustDropTypeByColor[WHITE] != ALL_PIECES || var->mustDropTypeByColor[BLACK] != ALL_PIECES)
-          ? var->mustDropTypeByColor[c]
-          : var->mustDropType;
+  PieceType requiredDropType = var->mustDropType.get(c);
 
   auto canDropNow = [&](PieceType pt) {
       return can_drop(c, pt)

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -162,8 +162,8 @@ void on_variant_change(const Option &o) {
             {
                 if (pt == PAWN && !v->firstRankPawnDrops)
                     suffix += "j";
-                else if (pt == v->dropNoDoubled)
-                    suffix += std::string(v->dropNoDoubledCount, 'f');
+                else if (piece_set(pt) & v->dropNoDoubled.global)
+                    suffix += std::string(v->dropNoDoubledCount.global, 'f');
                 else if (pt == BISHOP && v->dropOppositeColoredBishop)
                     suffix += "s";
                 suffix += "@" + std::to_string(pt == PAWN && !v->promotionZonePawnDrops && v->promotionRegion[WHITE] ? rank_of(lsb(v->promotionRegion[WHITE])) : v->maxRank + 1);

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -925,9 +925,7 @@ namespace {
         v->promotedPieceType[SILVER]     = GOLD;
         v->promotedPieceType[BISHOP]     = DRAGON_HORSE;
         v->promotedPieceType[ROOK]       = DRAGON;
-        v->dropNoDoubled = SHOGI_PAWN;
-        v->dropNoDoubledByColor[WHITE] = SHOGI_PAWN;
-        v->dropNoDoubledByColor[BLACK] = SHOGI_PAWN;
+        v->dropNoDoubled = piece_set(SHOGI_PAWN);
         v->immobilityIllegal = true;
         v->shogiPawnDropMateIllegal = true;
         v->stalemateValue = -VALUE_MATE;
@@ -970,9 +968,7 @@ namespace {
         v->promotedPieceType[ROOK]         = NO_PIECE_TYPE;
         v->immobilityIllegal = false;
         v->shogiPawnDropMateIllegal = false;
-        v->dropNoDoubled = NO_PIECE_TYPE;
-        v->dropNoDoubledByColor[WHITE] = NO_PIECE_TYPE;
-        v->dropNoDoubledByColor[BLACK] = NO_PIECE_TYPE;
+        v->dropNoDoubled = NO_PIECE_SET;
         return v;
     }
     // Micro shogi
@@ -1021,9 +1017,7 @@ namespace {
         v->flagRegion[WHITE] = Rank4BB;
         v->flagRegion[BLACK] = Rank1BB;
         v->flagPieceSafe = true;
-        v->dropNoDoubled = NO_PIECE_TYPE;
-        v->dropNoDoubledByColor[WHITE] = NO_PIECE_TYPE;
-        v->dropNoDoubledByColor[BLACK] = NO_PIECE_TYPE;
+        v->dropNoDoubled = NO_PIECE_SET;
         v->nFoldValue = VALUE_DRAW;
         v->perpetualCheckIllegal = false;
         return v;
@@ -1083,12 +1077,8 @@ namespace {
         v->promotedPieceType[SHOGI_PAWN]    = CUSTOM_PIECE_6; // swallow promotes to goose
         v->promotedPieceType[CUSTOM_PIECE_1] = CUSTOM_PIECE_7; // falcon promotes to eagle
         v->mandatoryPiecePromotion = true;
-        v->dropNoDoubled = SHOGI_PAWN;
-        v->dropNoDoubledByColor[WHITE] = SHOGI_PAWN;
-        v->dropNoDoubledByColor[BLACK] = SHOGI_PAWN;
+        v->dropNoDoubled = piece_set(SHOGI_PAWN);
         v->dropNoDoubledCount = 2;
-        v->dropNoDoubledCountByColor[WHITE] = 2;
-        v->dropNoDoubledCountByColor[BLACK] = 2;
         v->immobilityIllegal = true;
         v->shogiPawnDropMateIllegal = true;
         v->stalemateValue = -VALUE_MATE;
@@ -1500,9 +1490,7 @@ namespace {
         v->captureType = HAND;
         v->doubleStep = false;
         v->castling = false;
-        v->dropNoDoubled = SHOGI_PAWN;
-        v->dropNoDoubledByColor[WHITE] = SHOGI_PAWN;
-        v->dropNoDoubledByColor[BLACK] = SHOGI_PAWN;
+        v->dropNoDoubled = piece_set(SHOGI_PAWN);
         v->immobilityIllegal = true;
         v->shogiPawnDropMateIllegal = false;
         v->stalemateValue = -VALUE_MATE;

--- a/src/variant.h
+++ b/src/variant.h
@@ -225,8 +225,7 @@ struct Variant {
   bool blastOrthogonals = true;
   bool mustDrop = false;
   bool mustDropByColor[COLOR_NB] = {false, false};
-  PieceType mustDropType = ALL_PIECES;
-  PieceType mustDropTypeByColor[COLOR_NB] = {ALL_PIECES, ALL_PIECES};
+  ColorSetting<PieceType> mustDropType = ColorSetting<PieceType>(ALL_PIECES);
   bool dropKingLast = false;
   bool openingSelfRemoval = false;
   bool openingSelfRemovalAdjacentToLast = false;

--- a/src/variant.h
+++ b/src/variant.h
@@ -197,9 +197,8 @@ struct Variant {
   bool royalPieceNoThroughCheck = false;
   ColorSetting<bool> dropChecks = ColorSetting<bool>(true);
   ColorSetting<bool> dropMates = ColorSetting<bool>(true);
-  bool mustCapture = false;
+  ColorSetting<bool> mustCapture = ColorSetting<bool>(false);
   bool mustCaptureEnPassant = false;
-  bool mustCaptureByColor[COLOR_NB] = {false, false};
   bool rifleCapture = false;
   int pushingStrength[PIECE_TYPE_NB] = {};
   int pullingStrength[PIECE_TYPE_NB] = {};
@@ -223,8 +222,7 @@ struct Variant {
   ColorSetting<PieceSet> selfCaptureTypes = ColorSetting<PieceSet>(NO_PIECE_SET);
   bool blastOnSameTypeCapture = false;
   bool blastOrthogonals = true;
-  bool mustDrop = false;
-  bool mustDropByColor[COLOR_NB] = {false, false};
+  ColorSetting<bool> mustDrop = ColorSetting<bool>(false);
   ColorSetting<PieceType> mustDropType = ColorSetting<PieceType>(ALL_PIECES);
   bool dropKingLast = false;
   bool openingSelfRemoval = false;
@@ -256,10 +254,8 @@ struct Variant {
   PieceSet dropPieceTypes[PIECE_TYPE_NB] = {};
   PieceSet symmetricDropTypes = NO_PIECE_SET;
   PieceSet captureDrops = NO_PIECE_SET;
-  PieceType dropNoDoubled = NO_PIECE_TYPE;
-  PieceType dropNoDoubledByColor[COLOR_NB] = {NO_PIECE_TYPE, NO_PIECE_TYPE};
-  int dropNoDoubledCount = 1;
-  int dropNoDoubledCountByColor[COLOR_NB] = {1, 1};
+  ColorSetting<PieceSet> dropNoDoubled = ColorSetting<PieceSet>(NO_PIECE_SET);
+  ColorSetting<int> dropNoDoubledCount = ColorSetting<int>(1);
   PieceSet hostageExchange[PIECE_TYPE_NB] = {};
   bool prisonPawnPromotion = false;
   bool immobilityIllegal = false;


### PR DESCRIPTION
This PR applies Proposal 2 from the refactor proposals. It replaces the separate mustDropType and mustDropTypeByColor arrays with a single ColorSetting to reduce boilerplate and clean up variants.ini option parsing. Also included is the initial set of proposals for further variants refactoring (refactor_proposals.md).