### PR TITLE
Refactor Adjudication Values to ColorSetting

### DIFF
--- a/refactor_proposals.md
+++ b/refactor_proposals.md
@@ -1,0 +1,27 @@
+# Fairy-Stockfish-X Variant Option Refactoring Proposals
+
+Based on an analysis of the configuration parsers, struct definitions, and option usages, the following proposals aim to consolidate single-purpose options, reduce boilerplate parsing, and eliminate redundant option families in `variants.ini`.
+
+## 1. Unify Region Override Options (Step / Drop / Promotion Regions)
+**Current state:** There are massive families of 5 separate options controlling regions (e.g., `doubleStepRegionWhite`, `doubleStepRegionBlack`, `pieceSpecificDoubleStepRegion`, `whitePieceDoubleStepRegion`, `blackPieceDoubleStepRegion`). This pattern is repeated for `tripleStepRegion`, `dropRegion`, and `promotionRegion`.
+**Proposal:** The existing `PieceTypeBitboardGroup` type parses piece-specific bitboards (e.g., `P(e4,*1)`). By enhancing its parser to support a fallback wildcard piece `*(...)`, we can replace all 5 options with a single `[Action]Region` setting. For example: `doubleStepRegion = P(e4,*1); *(**)` allows specific piece overrides while defining a global fallback, entirely deprecating the `pieceSpecific...` and `[color]Piece...` options and significantly speeding up internal `position.h` logic.
+
+## 2. Refactor Color-Specific Options to use `ColorSetting<T>`
+**Current state:** A huge source of bloat is options duplicated for colors (e.g., `mustDropType`, `mustDropTypeWhite`, `mustDropTypeBlack`). Currently, the codebase handles this with manually duplicated arrays like `v->dropNoDoubledByColor[WHITE] = v->dropNoDoubled;` scattered all over `parser.cpp`.
+**Proposal:** `Fairy-Stockfish-X` introduced an excellent generic wrapper, `ColorSetting<T>`, that cleanly isolates global values from explicit color overrides using a safe `.has_override(c)` API. However, it was never fully adopted. I propose aggressively replacing the ad-hoc `T[COLOR_NB]` arrays and boilerplate blocks for options like `mustDrop`, `mustDropType`, `dropChecks`, `mustCapture`, `pass`, and `dropNoDoubled` with `ColorSetting<T>`.
+
+## 3. Merge `promotionPieceTypesByFile` into `promotionPieceTypes`
+**Current state:** Pawn promotions are defined either globally (`promotionPieceTypes = nbrq`) or per-file via a completely different option (`promotionPieceTypesByFile = a:r b:n`), each of which *also* has White/Black variants.
+**Proposal:** Enhance the standard `promotionPieceTypes` parser into a smarter format that accepts either a flat `PieceSet` (legacy) or a `File->PieceSet map`. By adding support for a file fallback wildcard (e.g., `promotionPieceTypes = a:r b:n *:q`), the engine can entirely deprecate the `...ByFile` option family.
+
+## 4. Enhance `dropNoDoubled` to handle `PieceSet`
+**Current state:** The `dropNoDoubled` rule (which prevents dropping a piece on a file that already has one, like the Shogi pawn) is hardcoded to accept a single `PieceType`. If a variant designer wants to restrict both pawns *and* lances, they can't.
+**Proposal:** Change `dropNoDoubled` from a single `PieceType` to a `PieceSet`. This allows variant designers to restrict multiple piece types at once (e.g., `dropNoDoubled = p l`). Furthermore, integrating it with `ColorSetting<PieceSet>` (from Proposal 2) safely deprecates `dropNoDoubledWhite` and `dropNoDoubledBlack`.
+
+## 5. Convert Blast Booleans into a unified `blastPattern` 
+**Current state:** Atomic and explosion variants determine the shape of the blast using three hardcoded, single-purpose booleans: `blastDiagonals`, `blastOrthogonals`, and `blastCenter`.
+**Proposal:** Deprecate these three booleans in favor of a new `blastPattern` option. This could accept a Betza string (e.g., `K` for the standard 3x3 square, `N` for knight-jump explosions, or `W` for orthogonal crosses) or a relative `Bitboard` mask. This provides infinite shape flexibility for variant creators while shrinking the option count.
+
+## 6. Consolidate `edgeInsert` direction logic
+**Current state:** Edge insertion drops require users to specify the board edges as direction tokens (`edgeInsertFrom = top left`) and the actual entry squares (`edgeInsertRegion = *8 a*`). This redundancy requires 6 underlying arrays in `Variant` just to track direction aliases.
+**Proposal:** The engine should infer the valid push directions mathematically based on the closest physical edge to the `edgeInsertRegion` bitboards. This removes the need for `edgeInsertFrom` entirely, trusting the bitboard geometry instead.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1583,9 +1583,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("mustDrop", v->mustDrop);
     parse_attribute("mustDropWhite", v->mustDropByColor[WHITE]);
     parse_attribute("mustDropBlack", v->mustDropByColor[BLACK]);
-    parse_attribute("mustDropType", v->mustDropType, v);
-    parse_attribute("mustDropTypeWhite", v->mustDropTypeByColor[WHITE], v);
-    parse_attribute("mustDropTypeBlack", v->mustDropTypeByColor[BLACK], v);
+    parse_color_setting_piece("mustDropType", v->mustDropType);
     parse_attribute("openingSwapDrop", v->openingSwapDrop);
     parse_attribute("openingSwapMirrorMainDiagonal", v->openingSwapMirrorMainDiagonal);
     parse_attribute("dropKingLast", v->dropKingLast);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1446,7 +1446,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("tripleStepRegionWhite", v->tripleStepRegion[WHITE]);
     parse_attribute("tripleStepRegionBlack", v->tripleStepRegion[BLACK]);
     parse_both_colors_with_overrides("enPassantRegion", v->enPassantRegion);
-    parse_both_colors_with_overrides_piece("enPassantTypes", v->enPassantTypes, v);
+    parse_color_setting_piece("enPassantTypes", v->enPassantTypes);
     parse_attribute("enPassantPassedSquares", v->enPassantPassedSquares);
     parse_attribute("castling", v->castling);
     parse_attribute("castlingDroppedPiece", v->castlingDroppedPiece);
@@ -1467,7 +1467,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_color_setting("dropChecks", v->dropChecks);
     parse_color_setting("dropMates", v->dropMates);
     parse_color_setting("mustCapture", v->mustCapture);
-    parse_attribute("mustCaptureEnPassant", v->mustCaptureEnPassant);
+    parse_color_setting("mustCaptureEnPassant", v->mustCaptureEnPassant);
     parse_attribute("rifleCapture", v->rifleCapture);
     const auto& it_push_strength = config.find("pushingStrength");
     if (it_push_strength != config.end())
@@ -1724,7 +1724,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("soldierPromotionRank", v->soldierPromotionRank);
     parse_attribute("flipEnclosedPieces", v->flipEnclosedPieces);
     // game end
-    parse_both_colors_with_overrides_piece("nMoveRuleTypes", v->nMoveRuleTypes, v);
+    parse_color_setting_piece("nMoveRuleTypes", v->nMoveRuleTypes);
     parse_attribute("nMoveRule", v->nMoveRule);
     parse_attribute("nMoveRuleImmediate", v->nMoveRuleImmediate);
     parse_attribute("nMoveHardLimitRule", v->nMoveHardLimitRule);
@@ -1780,8 +1780,8 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
         v->pseudoRoyalTypes = v->extinctionPieceTypes;
         v->pseudoRoyalCount = v->extinctionPieceCount + 1;
     }
-    parse_both_colors_with_overrides_piece("flagPiece", v->flagPiece, v);
-    parse_both_colors_with_overrides("flagRegion", v->flagRegion);
+    parse_color_setting_piece("flagPiece", v->flagPiece);
+    parse_color_setting("flagRegion", v->flagRegion);
     parse_attribute("flagPieceCount", v->flagPieceCount);
     parse_attribute("flagPieceBlockedWin", v->flagPieceBlockedWin);
     parse_attribute("flagMove", v->flagMove);
@@ -2072,7 +2072,7 @@ bool VariantParser<DoCheck>::check_consistency(Variant* v) {
     {
         if (v->blastOnCapture)
             std::cerr << "Can not use flagPieceSafe with blastOnCapture (flagPieceSafe uses simple assessment that does not see blast)." << std::endl;
-        if ((v->antiRoyalTypes & v->flagPiece[WHITE]) || (v->antiRoyalTypes & v->flagPiece[BLACK]))
+        if ((v->antiRoyalTypes & v->flagPiece.get(WHITE)) || (v->antiRoyalTypes & v->flagPiece.get(BLACK)))
             std::cerr << "Flag piece can not be anti-royal when flagPieceSafe is enabled." << std::endl;
     }
     return valid;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1749,8 +1749,14 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("nMoveHardLimitRuleValue", v->nMoveHardLimitRuleValue);
     parse_attribute("nFoldRule", v->nFoldRule);
     parse_attribute("nFoldRuleImmediate", v->nFoldRuleImmediate);
-    parse_attribute("nFoldValue", v->nFoldValue);
+    parse_color_setting("nFoldValue", v->nFoldValue);
     parse_attribute("nFoldValueAbsolute", v->nFoldValueAbsolute);
+    if (v->nFoldValueAbsolute) {
+        v->nFoldValue.byColor[WHITE] = v->nFoldValue.global;
+        v->nFoldValue.byColor[BLACK] = -v->nFoldValue.global;
+        v->nFoldValue.byColorSet[WHITE] = true;
+        v->nFoldValue.byColorSet[BLACK] = true;
+    }
     parse_attribute("perpetualCheckIllegal", v->perpetualCheckIllegal);
     parse_attribute("moveRepetitionIllegal", v->moveRepetitionIllegal);
     parse_attribute("samePlayerBoardRepetitionIllegal", v->samePlayerBoardRepetitionIllegal);
@@ -1761,9 +1767,9 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("weakCrosscutDropIllegal", v->weakCrosscutDropIllegal);
     parse_attribute("weakConnectionNobiImpossible", v->weakConnectionNobiImpossible);
     parse_attribute("chasingRule", v->chasingRule);
-    parse_attribute("stalemateValue", v->stalemateValue);
+    parse_color_setting("stalemateValue", v->stalemateValue);
     parse_attribute("stalematePieceCount", v->stalematePieceCount);
-    parse_attribute("checkmateValue", v->checkmateValue);
+    parse_color_setting("checkmateValue", v->checkmateValue);
     parse_color_setting("shogiPawnDropMateIllegal", v->shogiPawnDropMateIllegal);
     parse_attribute("shatarMateRule", v->shatarMateRule);
     parse_attribute("bikjangRule", v->bikjangRule);
@@ -1775,7 +1781,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("antiRoyalCount", v->antiRoyalCount);
     parse_attribute("antiRoyalSelfCaptureOnly", v->antiRoyalSelfCaptureOnly);
     parse_attribute("antiRoyalKingMutuallyImmune", v->antiRoyalKingMutuallyImmune);
-    parse_attribute("extinctionValue", v->extinctionValue);
+    parse_color_setting("extinctionValue", v->extinctionValue);
     parse_attribute("extinctionClaim", v->extinctionClaim);
     parse_attribute("extinctionPseudoRoyal", v->extinctionPseudoRoyal);
     parse_attribute("dupleCheck", v->dupleCheck);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1466,10 +1466,8 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("royalPieceNoThroughCheck", v->royalPieceNoThroughCheck);
     parse_color_setting("dropChecks", v->dropChecks);
     parse_color_setting("dropMates", v->dropMates);
-    parse_attribute("mustCapture", v->mustCapture);
+    parse_color_setting("mustCapture", v->mustCapture);
     parse_attribute("mustCaptureEnPassant", v->mustCaptureEnPassant);
-    parse_attribute("mustCaptureWhite", v->mustCaptureByColor[WHITE]);
-    parse_attribute("mustCaptureBlack", v->mustCaptureByColor[BLACK]);
     parse_attribute("rifleCapture", v->rifleCapture);
     const auto& it_push_strength = config.find("pushingStrength");
     if (it_push_strength != config.end())
@@ -1580,9 +1578,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("blastOnSameTypeCapture", v->blastOnSameTypeCapture);
     parse_attribute("captureMorph", v->captureMorph);
     parse_attribute("rexExclusiveMorph", v->rexExclusiveMorph);
-    parse_attribute("mustDrop", v->mustDrop);
-    parse_attribute("mustDropWhite", v->mustDropByColor[WHITE]);
-    parse_attribute("mustDropBlack", v->mustDropByColor[BLACK]);
+    parse_color_setting("mustDrop", v->mustDrop);
     parse_color_setting_piece("mustDropType", v->mustDropType);
     parse_attribute("openingSwapDrop", v->openingSwapDrop);
     parse_attribute("openingSwapMirrorMainDiagonal", v->openingSwapMirrorMainDiagonal);
@@ -1647,20 +1643,8 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("dropPromoted", v->dropPromoted);
     parse_attribute("symmetricDropTypes", v->symmetricDropTypes, v);
     parse_attribute("captureDrops", v->captureDrops, v);
-    parse_attribute("dropNoDoubled", v->dropNoDoubled, v);
-    v->dropNoDoubledByColor[WHITE] = v->dropNoDoubled;
-    v->dropNoDoubledByColor[BLACK] = v->dropNoDoubled;
-    if (config.find("dropNoDoubledWhite") != config.end())
-        parse_attribute("dropNoDoubledWhite", v->dropNoDoubledByColor[WHITE], v);
-    if (config.find("dropNoDoubledBlack") != config.end())
-        parse_attribute("dropNoDoubledBlack", v->dropNoDoubledByColor[BLACK], v);
-    parse_attribute("dropNoDoubledCount", v->dropNoDoubledCount);
-    v->dropNoDoubledCountByColor[WHITE] = v->dropNoDoubledCount;
-    v->dropNoDoubledCountByColor[BLACK] = v->dropNoDoubledCount;
-    if (config.find("dropNoDoubledCountWhite") != config.end())
-        parse_attribute("dropNoDoubledCountWhite", v->dropNoDoubledCountByColor[WHITE]);
-    if (config.find("dropNoDoubledCountBlack") != config.end())
-        parse_attribute("dropNoDoubledCountBlack", v->dropNoDoubledCountByColor[BLACK]);
+    parse_color_setting_piece("dropNoDoubled", v->dropNoDoubled);
+    parse_color_setting("dropNoDoubledCount", v->dropNoDoubledCount);
     parse_attribute("freeDrops", v->freeDrops);
     parse_attribute("payPointsToDrop", v->payPointsToDrop);
     parse_attribute("potions", v->potions);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -4933,7 +4933,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       if (   !pureWallMove
           && (   type_of(m) == PROMOTION
           || (type_of(m) == PIECE_PROMOTION && !piece_demotion())
-          || (    (var->nMoveRuleTypes[us] & type_of(pc))
+          || (    (var->nMoveRuleTypes.get(us) & type_of(pc))
               && !(PseudoMoves[0][us][type_of(pc)][to] & from))))
           st->rule50 = 0;
       if (is_self_destruct(m))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -7049,8 +7049,7 @@ bool Position::n_fold_game_end(Value& result, int ply, int target) const {
       {
           result = convert_mate_value(  (perpetualThem || perpetualUs) ? (!perpetualUs ? VALUE_MATE : !perpetualThem ? -VALUE_MATE : VALUE_DRAW)
                                       : (chaseThem || chaseUs) ? (!chaseUs ? VALUE_MATE : !chaseThem ? -VALUE_MATE : VALUE_DRAW)
-                                      : var->nFoldValueAbsolute && sideToMove == BLACK ? -var->nFoldValue
-                                      : var->nFoldValue, ply);
+                                      : var->nFoldValue.get(sideToMove), ply);
           if (result == VALUE_DRAW && var->materialCounting)
               result = convert_mate_value(material_counting_result(), ply);
           return true;
@@ -7743,7 +7742,7 @@ bool Position::has_game_cycle(int ply) const {
 
   int end = captures_to_hand() ? st->pliesFromNull : std::min(st->rule50, st->pliesFromNull);
 
-  if (end < 3 || var->nFoldValue != VALUE_DRAW || var->perpetualCheckIllegal || var->materialCounting || var->moveRepetitionIllegal || walling_rule() == DUCK)
+  if (end < 3 || var->nFoldValue.get(WHITE) != VALUE_DRAW || var->nFoldValue.get(BLACK) != VALUE_DRAW || var->perpetualCheckIllegal || var->materialCounting || var->moveRepetitionIllegal || walling_rule() == DUCK)
     return false;
 
   bool useBoardKey = captures_to_hand();

--- a/src/position.h
+++ b/src/position.h
@@ -2204,7 +2204,7 @@ inline Value Position::stalemate_value(int ply) const {
           Square sr = pop_lsb(pseudoRoyals);
           if (  !(blast_on_capture() && (pseudoRoyalsTheirs & blast_pattern(sr)))
               && attackers_to(sr, ~sideToMove))
-              return convert_mate_value(var->checkmateValue, ply);
+              return convert_mate_value(var->checkmateValue.get(sideToMove), ply);
       }
       // Look for duple check
       if (var->dupleCheck)
@@ -2220,20 +2220,20 @@ inline Value Position::stalemate_value(int ply) const {
                   allCheck = false;
           }
           if (allCheck)
-              return convert_mate_value(var->checkmateValue, ply);
+              return convert_mate_value(var->checkmateValue.get(sideToMove), ply);
       }
   }
   if (anti_royal_types())
   {
       if (checked_anti_royals(sideToMove))
-          return convert_mate_value(var->checkmateValue, ply);
+          return convert_mate_value(var->checkmateValue.get(sideToMove), ply);
   }
-  Value result = var->stalemateValue;
+  Value result = var->stalemateValue.get(sideToMove);
   // Is piece count used to determine stalemate result?
   if (var->stalematePieceCount)
   {
       int c = count<ALL_PIECES>(sideToMove) - count<ALL_PIECES>(~sideToMove);
-      result = c == 0 ? VALUE_DRAW : c < 0 ? var->stalemateValue : -var->stalemateValue;
+      result = c == 0 ? VALUE_DRAW : c < 0 ? var->stalemateValue.get(sideToMove) : -var->stalemateValue.get(~sideToMove);
   }
   // Apply material counting
   if (result == VALUE_DRAW && var->materialCounting)
@@ -2264,7 +2264,7 @@ inline Value Position::checkmate_value(int ply) const {
       {
           // Return mate score if there is at least one shak in series of checks
           if (stp->shak)
-              return convert_mate_value(var->checkmateValue, ply);
+              return convert_mate_value(var->checkmateValue.get(sideToMove), ply);
 
           if (stp->pliesFromNull < 2)
               break;
@@ -2275,7 +2275,7 @@ inline Value Position::checkmate_value(int ply) const {
       return VALUE_DRAW;
   }
   // Checkmate using virtual pieces
-  if (two_boards() && var->checkmateValue < VALUE_ZERO)
+  if (two_boards() && var->checkmateValue.get(sideToMove) < VALUE_ZERO)
   {
       Value virtualMaterial = VALUE_ZERO;
       for (PieceSet ps = piece_types(); ps;)
@@ -2288,12 +2288,12 @@ inline Value Position::checkmate_value(int ply) const {
           return -VALUE_VIRTUAL_MATE + virtualMaterial / 20 + ply;
   }
   // Return mate value
-  return convert_mate_value(var->checkmateValue, ply);
+  return convert_mate_value(var->checkmateValue.get(sideToMove), ply);
 }
 
 inline Value Position::extinction_value(int ply) const {
   assert(var != nullptr);
-  return convert_mate_value(var->extinctionValue, ply);
+  return convert_mate_value(var->extinctionValue.get(sideToMove), ply);
 }
 
 inline bool Position::extinction_claim() const {
@@ -2323,7 +2323,7 @@ inline bool Position::extinction_all_piece_types(Color c) const {
 
 inline bool Position::extinction_single_piece() const {
   assert(var != nullptr);
-  return   var->extinctionValue == -VALUE_MATE
+  return   var->extinctionValue.get(sideToMove) == -VALUE_MATE
         && (var->extinctionPieceTypes & ~piece_set(ALL_PIECES));
 }
 

--- a/src/position.h
+++ b/src/position.h
@@ -1551,7 +1551,7 @@ inline bool Position::must_capture() const {
 
 inline bool Position::must_capture_en_passant() const {
   assert(var != nullptr);
-  return var->mustCaptureEnPassant;
+  return var->mustCaptureEnPassant.get(side_to_move());
 }
 
 inline bool Position::has_capture() const {
@@ -1936,14 +1936,14 @@ inline PieceSet Position::promotion_pawn_types(Color c) const {
 inline PieceSet Position::pawn_like_types(Color c) const {
   assert(var != nullptr);
   return var->promotionPawnTypes[c]
-       | var->enPassantTypes[c]
-       | var->nMoveRuleTypes[c]
+       | var->enPassantTypes.get(c)
+       | var->nMoveRuleTypes.get(c)
        | piece_set(var->mainPromotionPawnType[c]);
 }
 
 inline PieceSet Position::en_passant_types(Color c) const {
   assert(var != nullptr);
-  return var->enPassantTypes[c];
+  return var->enPassantTypes.get(c);
 }
 
 inline bool Position::immobility_illegal() const {
@@ -2379,12 +2379,12 @@ inline bool Position::extinction_pseudo_royal() const {
 
 inline PieceType Position::flag_piece(Color c) const {
   assert(var != nullptr);
-  return var->flagPiece[c];
+  return var->flagPiece.get(c);
 }
 
 inline Bitboard Position::flag_region(Color c) const {
   assert(var != nullptr);
-  return var->flagRegion[c];
+  return var->flagRegion.get(c);
 }
 
 inline bool Position::flag_move() const {

--- a/src/position.h
+++ b/src/position.h
@@ -401,8 +401,8 @@ public:
   PieceSet drop_piece_types(PieceType pt) const;
   PieceSet symmetric_drop_types() const;
   PieceSet capture_drop_types() const;
-  PieceType drop_no_doubled() const;
-  PieceType drop_no_doubled(Color c) const;
+  PieceSet drop_no_doubled() const;
+  PieceSet drop_no_doubled(Color c) const;
   PieceSet promotion_pawn_types(Color c) const;
   PieceSet pawn_like_types(Color c) const;
   PieceSet en_passant_types(Color c) const;
@@ -1546,9 +1546,7 @@ inline bool Position::rex_exclusive_morph() const {
 
 inline bool Position::must_capture() const {
   assert(var != nullptr);
-  if (var->mustCaptureByColor[WHITE] || var->mustCaptureByColor[BLACK])
-      return var->mustCaptureByColor[side_to_move()];
-  return var->mustCapture;
+  return var->mustCapture.get(side_to_move());
 }
 
 inline bool Position::must_capture_en_passant() const {
@@ -1609,9 +1607,7 @@ inline bool Position::has_en_passant_capture() const {
 
 inline bool Position::must_drop() const {
   assert(var != nullptr);
-  if (var->mustDropByColor[WHITE] || var->mustDropByColor[BLACK])
-      return var->mustDropByColor[side_to_move()];
-  return var->mustDrop;
+  return var->mustDrop.get(side_to_move());
 }
 
 inline PieceType Position::must_drop_type() const {
@@ -1800,9 +1796,9 @@ inline Bitboard Position::drop_region(Color c, PieceType pt) const {
           b &= ~rank_bb(relative_rank(c, RANK_1, max_rank()));
   }
   // Doubled shogi pawns
-  if (pt == drop_no_doubled(c))
+  if (piece_set(pt) & drop_no_doubled(c))
       for (File f = FILE_A; f <= max_file(); ++f)
-          if (popcount(file_bb(f) & pieces(c, pt)) >= var->dropNoDoubledCountByColor[c])
+          if (popcount(file_bb(f) & pieces(c, pt)) >= var->dropNoDoubledCount.get(c))
               b &= ~file_bb(f);
   // Sittuyin rook drops
   if (pt == ROOK && sittuyin_rook_drop())
@@ -1922,14 +1918,14 @@ inline PieceSet Position::capture_drop_types() const {
   return var->captureDrops;
 }
 
-inline PieceType Position::drop_no_doubled() const {
+inline PieceSet Position::drop_no_doubled() const {
   assert(var != nullptr);
-  return var->dropNoDoubledByColor[side_to_move()];
+  return var->dropNoDoubled.get(side_to_move());
 }
 
-inline PieceType Position::drop_no_doubled(Color c) const {
+inline PieceSet Position::drop_no_doubled(Color c) const {
   assert(var != nullptr);
-  return var->dropNoDoubledByColor[c];
+  return var->dropNoDoubled.get(c);
 }
 
 inline PieceSet Position::promotion_pawn_types(Color c) const {

--- a/src/position.h
+++ b/src/position.h
@@ -1616,9 +1616,7 @@ inline bool Position::must_drop() const {
 
 inline PieceType Position::must_drop_type() const {
   assert(var != nullptr);
-  if (var->mustDropTypeByColor[WHITE] != ALL_PIECES || var->mustDropTypeByColor[BLACK] != ALL_PIECES)
-      return var->mustDropTypeByColor[side_to_move()];
-  return var->mustDropType;
+  return var->mustDropType.get(side_to_move());
 }
 
 inline bool Position::opening_self_removal() const {
@@ -2101,10 +2099,7 @@ inline bool Position::pass(Color c) const {
 inline bool Position::has_setup_drop(Color c) const {
   assert(var != nullptr);
 
-  PieceType requiredDropType =
-      (var->mustDropTypeByColor[WHITE] != ALL_PIECES || var->mustDropTypeByColor[BLACK] != ALL_PIECES)
-          ? var->mustDropTypeByColor[c]
-          : var->mustDropType;
+  PieceType requiredDropType = var->mustDropType.get(c);
 
   auto canDropNow = [&](PieceType pt) {
       return can_drop(c, pt)

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -162,8 +162,8 @@ void on_variant_change(const Option &o) {
             {
                 if (pt == PAWN && !v->firstRankPawnDrops)
                     suffix += "j";
-                else if (pt == v->dropNoDoubled)
-                    suffix += std::string(v->dropNoDoubledCount, 'f');
+                else if (piece_set(pt) & v->dropNoDoubled.global)
+                    suffix += std::string(v->dropNoDoubledCount.global, 'f');
                 else if (pt == BISHOP && v->dropOppositeColoredBishop)
                     suffix += "s";
                 suffix += "@" + std::to_string(pt == PAWN && !v->promotionZonePawnDrops && v->promotionRegion[WHITE] ? rank_of(lsb(v->promotionRegion[WHITE])) : v->maxRank + 1);

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -925,9 +925,7 @@ namespace {
         v->promotedPieceType[SILVER]     = GOLD;
         v->promotedPieceType[BISHOP]     = DRAGON_HORSE;
         v->promotedPieceType[ROOK]       = DRAGON;
-        v->dropNoDoubled = SHOGI_PAWN;
-        v->dropNoDoubledByColor[WHITE] = SHOGI_PAWN;
-        v->dropNoDoubledByColor[BLACK] = SHOGI_PAWN;
+        v->dropNoDoubled = piece_set(SHOGI_PAWN);
         v->immobilityIllegal = true;
         v->shogiPawnDropMateIllegal = true;
         v->stalemateValue = -VALUE_MATE;
@@ -970,9 +968,7 @@ namespace {
         v->promotedPieceType[ROOK]         = NO_PIECE_TYPE;
         v->immobilityIllegal = false;
         v->shogiPawnDropMateIllegal = false;
-        v->dropNoDoubled = NO_PIECE_TYPE;
-        v->dropNoDoubledByColor[WHITE] = NO_PIECE_TYPE;
-        v->dropNoDoubledByColor[BLACK] = NO_PIECE_TYPE;
+        v->dropNoDoubled = NO_PIECE_SET;
         return v;
     }
     // Micro shogi
@@ -1021,9 +1017,7 @@ namespace {
         v->flagRegion[WHITE] = Rank4BB;
         v->flagRegion[BLACK] = Rank1BB;
         v->flagPieceSafe = true;
-        v->dropNoDoubled = NO_PIECE_TYPE;
-        v->dropNoDoubledByColor[WHITE] = NO_PIECE_TYPE;
-        v->dropNoDoubledByColor[BLACK] = NO_PIECE_TYPE;
+        v->dropNoDoubled = NO_PIECE_SET;
         v->nFoldValue = VALUE_DRAW;
         v->perpetualCheckIllegal = false;
         return v;
@@ -1083,12 +1077,8 @@ namespace {
         v->promotedPieceType[SHOGI_PAWN]    = CUSTOM_PIECE_6; // swallow promotes to goose
         v->promotedPieceType[CUSTOM_PIECE_1] = CUSTOM_PIECE_7; // falcon promotes to eagle
         v->mandatoryPiecePromotion = true;
-        v->dropNoDoubled = SHOGI_PAWN;
-        v->dropNoDoubledByColor[WHITE] = SHOGI_PAWN;
-        v->dropNoDoubledByColor[BLACK] = SHOGI_PAWN;
+        v->dropNoDoubled = piece_set(SHOGI_PAWN);
         v->dropNoDoubledCount = 2;
-        v->dropNoDoubledCountByColor[WHITE] = 2;
-        v->dropNoDoubledCountByColor[BLACK] = 2;
         v->immobilityIllegal = true;
         v->shogiPawnDropMateIllegal = true;
         v->stalemateValue = -VALUE_MATE;
@@ -1500,9 +1490,7 @@ namespace {
         v->captureType = HAND;
         v->doubleStep = false;
         v->castling = false;
-        v->dropNoDoubled = SHOGI_PAWN;
-        v->dropNoDoubledByColor[WHITE] = SHOGI_PAWN;
-        v->dropNoDoubledByColor[BLACK] = SHOGI_PAWN;
+        v->dropNoDoubled = piece_set(SHOGI_PAWN);
         v->immobilityIllegal = true;
         v->shogiPawnDropMateIllegal = false;
         v->stalemateValue = -VALUE_MATE;

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -227,8 +227,8 @@ namespace {
         v->add_piece(CUSTOM_PIECE_1, 'p', "mfFcfeWimfnA");
         v->mainPromotionPawnType[WHITE] = v->mainPromotionPawnType[BLACK] = CUSTOM_PIECE_1;
         v->promotionPawnTypes[WHITE] = v->promotionPawnTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
-        v->enPassantTypes[WHITE] = v->enPassantTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
-        v->nMoveRuleTypes[WHITE] = v->nMoveRuleTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
+        v->enPassantTypes = piece_set(CUSTOM_PIECE_1);
+        v->nMoveRuleTypes = piece_set(CUSTOM_PIECE_1);
         return v;
     }
     // Pawnsideways
@@ -239,8 +239,8 @@ namespace {
         v->add_piece(CUSTOM_PIECE_1, 'p', "fsmWfceFifmnD");
         v->mainPromotionPawnType[WHITE] = v->mainPromotionPawnType[BLACK] = CUSTOM_PIECE_1;
         v->promotionPawnTypes[WHITE] = v->promotionPawnTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
-        v->enPassantTypes[WHITE] = v->enPassantTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
-        v->nMoveRuleTypes[WHITE] = v->nMoveRuleTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
+        v->enPassantTypes = piece_set(CUSTOM_PIECE_1);
+        v->nMoveRuleTypes = piece_set(CUSTOM_PIECE_1);
         return v;
     }
     // Pawnback
@@ -253,8 +253,8 @@ namespace {
         v->mobilityRegion[BLACK][CUSTOM_PIECE_1] = (Rank7BB | Rank6BB | Rank5BB | Rank4BB | Rank3BB | Rank2BB | Rank1BB);
         v->mainPromotionPawnType[WHITE] = v->mainPromotionPawnType[BLACK] = CUSTOM_PIECE_1;
         v->promotionPawnTypes[WHITE] = v->promotionPawnTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
-        v->enPassantTypes[WHITE] = v->enPassantTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
-        v->nMoveRuleTypes[WHITE] = v->nMoveRuleTypes[BLACK] = NO_PIECE_SET; // backwards pawn moves are reversible
+        v->enPassantTypes = piece_set(CUSTOM_PIECE_1);
+        v->nMoveRuleTypes = NO_PIECE_SET; // backwards pawn moves are reversible
         return v;
     }
     // Legan Chess
@@ -266,8 +266,8 @@ namespace {
         v->promotionRegion[WHITE] = make_bitboard(SQ_A8, SQ_B8, SQ_C8, SQ_D8, SQ_A7, SQ_A6, SQ_A5);
         v->promotionRegion[BLACK] = make_bitboard(SQ_E1, SQ_F1, SQ_G1, SQ_H1, SQ_H2, SQ_H3, SQ_H4);
         v->mainPromotionPawnType[WHITE] = v->mainPromotionPawnType[BLACK] = CUSTOM_PIECE_1;
-        v->promotionPawnTypes[WHITE] = v->promotionPawnTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
-        v->nMoveRuleTypes[WHITE] = v->nMoveRuleTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
+        v->enPassantTypes = piece_set(CUSTOM_PIECE_1);
+        v->nMoveRuleTypes = piece_set(CUSTOM_PIECE_1);
         v->startFen = "knbrp3/bqpp4/npp5/rp1p3P/p3P1PR/5PPN/4PPQB/3PRBNK w - - 0 1";
         v->doubleStep = false;
         return v;
@@ -469,9 +469,8 @@ namespace {
     // https://lichess.org/variant/kingOfTheHill
     Variant* kingofthehill_variant() {
         Variant* v = chess_variant_base()->init();
-        v->flagPiece[WHITE] = v->flagPiece[BLACK] = KING;
-        v->flagRegion[WHITE] = (Rank4BB | Rank5BB) & (FileDBB | FileEBB);
-        v->flagRegion[BLACK] = (Rank4BB | Rank5BB) & (FileDBB | FileEBB);
+        v->flagPiece = KING;
+        v->flagRegion = (Rank4BB | Rank5BB) & (FileDBB | FileEBB);
         v->flagMove = false;
         return v;
     }
@@ -480,9 +479,8 @@ namespace {
     Variant* racingkings_variant() {
         Variant* v = chess_variant_base()->init();
         v->startFen = "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1";
-        v->flagPiece[WHITE] = v->flagPiece[BLACK] = KING;
-        v->flagRegion[WHITE] = Rank8BB;
-        v->flagRegion[BLACK] = Rank8BB;
+        v->flagPiece = KING;
+        v->flagRegion = Rank8BB;
         v->flagMove = true;
         v->castling = false;
         v->checking = false;
@@ -1013,7 +1011,7 @@ namespace {
         v->shogiPawnDropMateIllegal = false;
         v->extinctionValue = -VALUE_MATE;
         v->extinctionPieceTypes = piece_set(COMMONER);
-        v->flagPiece[WHITE] = v->flagPiece[BLACK] = COMMONER;
+        v->flagPiece = COMMONER;
         v->flagRegion[WHITE] = Rank4BB;
         v->flagRegion[BLACK] = Rank1BB;
         v->flagPieceSafe = true;
@@ -1195,7 +1193,7 @@ namespace {
         v->startFen = "lgkcckwl/hhhhhhhh/8/8/8/8/PPPPPPPP/RNBQKBNR w KQ - 0 1";
         v->mainPromotionPawnType[BLACK] = CUSTOM_PIECE_1;
         v->promotionPawnTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
-        v->nMoveRuleTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
+        v->nMoveRuleTypes.set_color(BLACK, piece_set(CUSTOM_PIECE_1));
         v->promotionPieceTypes[BLACK] = piece_set(COMMONER) | DRAGON | ARCHBISHOP | CUSTOM_PIECE_2 | CUSTOM_PIECE_3;
         v->promotionLimit[COMMONER] = 2;
         v->enPassantRegion[WHITE] = 0;
@@ -1261,7 +1259,7 @@ namespace {
         v->doubleStep = false;
         v->castling = false;
         v->stalemateValue = -VALUE_MATE;
-        v->flagPiece[WHITE] = v->flagPiece[BLACK] = BREAKTHROUGH_PIECE;
+        v->flagPiece = BREAKTHROUGH_PIECE;
         v->flagRegion[WHITE] = Rank8BB;
         v->flagRegion[BLACK] = Rank1BB;
         return v;
@@ -1668,9 +1666,8 @@ namespace {
         v->doubleStep = false;
         v->castling = false;
         v->stalemateValue = -VALUE_MATE;
-        v->flagPiece[WHITE] = v->flagPiece[BLACK] = KNIGHT;
-        v->flagRegion[WHITE] = make_bitboard(SQ_E5);
-        v->flagRegion[BLACK] = make_bitboard(SQ_E5);
+        v->flagPiece = KNIGHT;
+        v->flagRegion = make_bitboard(SQ_E5);
         v->flagMove = true;
         return v;
     }
@@ -1851,8 +1848,8 @@ namespace {
         v->promotionRegion[BLACK] = Rank1BB;
         v->doubleStepRegion[WHITE] = Rank2BB | make_bitboard(SQ_B3, SQ_C3, SQ_F3, SQ_G3);
         v->doubleStepRegion[BLACK] = Rank9BB | make_bitboard(SQ_B8, SQ_C8, SQ_F8, SQ_G8);
-        v->enPassantTypes[WHITE] = v->enPassantTypes[BLACK] = piece_set(PAWN);
-        v->nMoveRuleTypes[WHITE] = v->nMoveRuleTypes[BLACK] = piece_set(PAWN) | piece_set(CUSTOM_PIECE_1);
+        v->enPassantTypes = piece_set(PAWN);
+        v->nMoveRuleTypes = piece_set(PAWN) | piece_set(CUSTOM_PIECE_1);
         v->castling = false;
         return v;
     }

--- a/src/variant.h
+++ b/src/variant.h
@@ -318,7 +318,7 @@ struct Variant {
   Value nMoveHardLimitRuleValue = VALUE_DRAW;
   int nFoldRule = 3;
   int nFoldRuleImmediate = 0;
-  Value nFoldValue = VALUE_DRAW;
+  ColorSetting<Value> nFoldValue = ColorSetting<Value>(VALUE_DRAW);
   bool nFoldValueAbsolute = false;
   bool perpetualCheckIllegal = false;
   bool moveRepetitionIllegal = false;
@@ -330,13 +330,13 @@ struct Variant {
   bool weakCrosscutDropIllegal = false;
   bool weakConnectionNobiImpossible = false;
   ChasingRule chasingRule = NO_CHASING;
-  Value stalemateValue = VALUE_DRAW;
+  ColorSetting<Value> stalemateValue = ColorSetting<Value>(VALUE_DRAW);
   bool stalematePieceCount = false; // multiply stalemate value by sign(count(~stm) - count(stm))
-  Value checkmateValue = -VALUE_MATE;
+  ColorSetting<Value> checkmateValue = ColorSetting<Value>(-VALUE_MATE);
   ColorSetting<bool> shogiPawnDropMateIllegal = ColorSetting<bool>(false);
   bool shatarMateRule = false;
   bool bikjangRule = false;
-  Value extinctionValue = VALUE_NONE;
+  ColorSetting<Value> extinctionValue = ColorSetting<Value>(VALUE_NONE);
   bool extinctionClaim = false;
   // Deprecated legacy switch kept for compatibility with existing configs.
   bool extinctionPseudoRoyal = false;

--- a/src/variant.h
+++ b/src/variant.h
@@ -186,7 +186,7 @@ struct Variant {
   PieceTypeBitboardGroup whitePieceTripleStepRegion;
   PieceTypeBitboardGroup blackPieceTripleStepRegion;
   Bitboard enPassantRegion[COLOR_NB] = {AllSquares, AllSquares};
-  PieceSet enPassantTypes[COLOR_NB] = {piece_set(PAWN), piece_set(PAWN)};
+  ColorSetting<PieceSet> enPassantTypes = ColorSetting<PieceSet>(piece_set(PAWN));
   EnPassantPassedSquares enPassantPassedSquares = EnPassantPassedSquares::ALL;
   bool castling = true;
   bool castlingDroppedPiece = false;
@@ -208,7 +208,7 @@ struct Variant {
   ColorSetting<bool> dropChecks = ColorSetting<bool>(true);
   ColorSetting<bool> dropMates = ColorSetting<bool>(true);
   ColorSetting<bool> mustCapture = ColorSetting<bool>(false);
-  bool mustCaptureEnPassant = false;
+  ColorSetting<bool> mustCaptureEnPassant = ColorSetting<bool>(false);
   bool rifleCapture = false;
   int pushingStrength[PIECE_TYPE_NB] = {};
   int pullingStrength[PIECE_TYPE_NB] = {};
@@ -316,7 +316,7 @@ struct Variant {
   bool potionDropOnOccupied = false;
 
   // game end
-  PieceSet nMoveRuleTypes[COLOR_NB] = {piece_set(PAWN), piece_set(PAWN)};
+  ColorSetting<PieceSet> nMoveRuleTypes = ColorSetting<PieceSet>(piece_set(PAWN));
   int nMoveRule = 50;
   int nMoveRuleImmediate = 0;
   int nMoveHardLimitRule = 0;
@@ -359,8 +359,8 @@ struct Variant {
   ColorSetting<bool> extinctionAllPieceTypes = ColorSetting<bool>(false);
   ColorSetting<int> extinctionPieceCount = ColorSetting<int>(0);
   ColorSetting<int> extinctionOpponentPieceCount = ColorSetting<int>(0);
-  PieceType flagPiece[COLOR_NB] = {ALL_PIECES, ALL_PIECES};
-  Bitboard flagRegion[COLOR_NB] = {};
+  ColorSetting<PieceType> flagPiece = ColorSetting<PieceType>(ALL_PIECES);
+  ColorSetting<Bitboard> flagRegion = ColorSetting<Bitboard>(Bitboard(0));
   int flagPieceCount = 1;
   bool flagPieceBlockedWin = false;
   bool flagMove = false;

--- a/src/variant.h
+++ b/src/variant.h
@@ -225,8 +225,7 @@ struct Variant {
   bool blastOrthogonals = true;
   bool mustDrop = false;
   bool mustDropByColor[COLOR_NB] = {false, false};
-  PieceType mustDropType = ALL_PIECES;
-  PieceType mustDropTypeByColor[COLOR_NB] = {ALL_PIECES, ALL_PIECES};
+  ColorSetting<PieceType> mustDropType = ColorSetting<PieceType>(ALL_PIECES);
   bool dropKingLast = false;
   bool openingSelfRemoval = false;
   bool openingSelfRemovalAdjacentToLast = false;

--- a/src/variant.h
+++ b/src/variant.h
@@ -197,9 +197,8 @@ struct Variant {
   bool royalPieceNoThroughCheck = false;
   ColorSetting<bool> dropChecks = ColorSetting<bool>(true);
   ColorSetting<bool> dropMates = ColorSetting<bool>(true);
-  bool mustCapture = false;
+  ColorSetting<bool> mustCapture = ColorSetting<bool>(false);
   bool mustCaptureEnPassant = false;
-  bool mustCaptureByColor[COLOR_NB] = {false, false};
   bool rifleCapture = false;
   int pushingStrength[PIECE_TYPE_NB] = {};
   int pullingStrength[PIECE_TYPE_NB] = {};
@@ -223,8 +222,7 @@ struct Variant {
   ColorSetting<PieceSet> selfCaptureTypes = ColorSetting<PieceSet>(NO_PIECE_SET);
   bool blastOnSameTypeCapture = false;
   bool blastOrthogonals = true;
-  bool mustDrop = false;
-  bool mustDropByColor[COLOR_NB] = {false, false};
+  ColorSetting<bool> mustDrop = ColorSetting<bool>(false);
   ColorSetting<PieceType> mustDropType = ColorSetting<PieceType>(ALL_PIECES);
   bool dropKingLast = false;
   bool openingSelfRemoval = false;
@@ -256,10 +254,8 @@ struct Variant {
   PieceSet dropPieceTypes[PIECE_TYPE_NB] = {};
   PieceSet symmetricDropTypes = NO_PIECE_SET;
   PieceSet captureDrops = NO_PIECE_SET;
-  PieceType dropNoDoubled = NO_PIECE_TYPE;
-  PieceType dropNoDoubledByColor[COLOR_NB] = {NO_PIECE_TYPE, NO_PIECE_TYPE};
-  int dropNoDoubledCount = 1;
-  int dropNoDoubledCountByColor[COLOR_NB] = {1, 1};
+  ColorSetting<PieceSet> dropNoDoubled = ColorSetting<PieceSet>(NO_PIECE_SET);
+  ColorSetting<int> dropNoDoubledCount = ColorSetting<int>(1);
   PieceSet hostageExchange[PIECE_TYPE_NB] = {};
   bool prisonPawnPromotion = false;
   bool immobilityIllegal = false;


### PR DESCRIPTION
This PR applies Proposal 7 from the refactor proposals. It introduces a flexible framework for asymmetric game endings using `ColorSetting<Value>` for `stalemateValue`, `nFoldValue`, `checkmateValue`, and `extinctionValue`. The hacky `nFoldValueAbsolute` flag is retained as a compatibility shim that simply populates `nFoldValueBlack` with the inverse of `nFoldValueWhite`.