### PR TITLE
[TEST] Add coverage for Racing Kings goal adjudication

### DIFF
--- a/test.py
+++ b/test.py
@@ -1831,6 +1831,11 @@ startFen = 4r3/8/8/8/8/8/8/8[A] w - - 0 1
         self._check_immediate_game_end("ataxx", "PPPpppp/pppPPPp/pPPPPPP/PPPPPPp/ppPPPpp/pPPPPpP/pPPPPPP b - - 99 50", [], True, -sf.VALUE_MATE)
         self._check_immediate_game_end("ataxx", "PPPpppp/pppPPPp/pPP*PPP/PP*P*Pp/ppP*Ppp/pPPPPpP/pPPPPPP b - - 99 50", [], True, -sf.VALUE_MATE)
 
+    def test_racing_kings_goal_adjudication(self):
+        self._check_immediate_game_end("racingkings", "7K/k7/8/8/8/8/8/8 b - - 0 1", [], False)
+        self._check_immediate_game_end("racingkings", "7K/8/k7/8/8/8/8/8 b - - 0 1", [], True, -sf.VALUE_MATE)
+        self._check_immediate_game_end("racingkings", "k6K/8/8/8/8/8/8/8 w - - 0 1", [], True, sf.VALUE_DRAW)
+
     def _check_optional_game_end(self, variant, fen, moves, game_end, game_result=None):
         with self.subTest(variant=variant, fen=fen, game_end=game_end, game_result=game_result):
             result = sf.is_optional_game_end(variant, fen, moves)


### PR DESCRIPTION
Added test cases for the Racing Kings variant goal adjudication, specifically covering the scenarios where White reaches the goal rank and Black has one move to force a draw.

Type: New Coverage
What: Added `test_racing_kings_goal_adjudication` to `test.py`.
Why: The Racing Kings goal logic is a specific edge case where reaching the goal rank by the first player does not immediately end the game if the second player can also reach it on the next move. This logic was previously not explicitly covered in the Python test suite.

---
*PR created automatically by Jules for task [13499842048224937632](https://jules.google.com/task/13499842048224937632) started by @RainRat*