### PR TITLE
Use static constexpr for win rate model coefficients

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -237,8 +237,8 @@ namespace {
      // Coefficients of a 3rd order polynomial fit based on fishtest data
      // for two parameters needed to transform eval to the argument of a
      // logistic function.
-     double as[] = {-3.68389304,  30.07065921, -60.52878723, 149.53378557};
-     double bs[] = {-2.0181857,   15.85685038, -29.83452023,  47.59078827};
+     static constexpr double as[] = {-3.68389304,  30.07065921, -60.52878723, 149.53378557};
+     static constexpr double bs[] = {-2.0181857,   15.85685038, -29.83452023,  47.59078827};
      double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
      double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];
 


### PR DESCRIPTION
In `src/uci.cpp`, the `win_rate_model` function uses two arrays of coefficients for a polynomial fit. These arrays were being initialized on the stack during every function call. By making them `static constexpr`, they are now initialized once at compile-time and stored in the read-only data segment, which is more efficient. No functional changes were introduced.

---
*PR created automatically by Jules for task [12842390778304942393](https://jules.google.com/task/12842390778304942393) started by @RainRat*