### PR TITLE
[DOCS] Add build and usage instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,52 @@
 # Fairy-Stockfish-X
 
+Fairy-Stockfish-X is an experimental version of [Fairy-Stockfish](https://github.com/fairy-stockfish/Fairy-Stockfish). It is used to test new features and support unique chess variants.
+
+## Quick Start
+
+To build the engine, follow these steps:
+
+1. Open your terminal and go to the `src/` directory.
+2. Run the following command:
+   ```bash
+   make -j build ARCH=x86-64-modern
+   ```
+   *Note: If you have a different CPU, you can check other options by running `make help`.*
+
+## Basic Usage
+
+After building, you can start the engine by running:
+```bash
+./stockfish
+```
+
+### Loading Variants
+
+Fairy-Stockfish-X supports many variants through a configuration file. To load them:
+
+1. Tell the engine where your variants file is:
+   ```uci
+   setoption name VariantPath value variants.ini
+   ```
+2. Choose a variant to play:
+   ```uci
+   setoption name UCI_Variant value antichess
+   ```
+3. Use the `d` command to see the current board.
+
+## Python Bindings
+
+You can also use Fairy-Stockfish-X in Python. To build the Python extension, run this in the project root:
+```bash
+python3 setup.py build_ext --inplace
+```
+After building, you can import `pyffish` in your Python scripts.
+
 ## Purpose
 
-Fairy-Stockfish-X is an experimental branch of the Fairy-Stockfish project with the following goals:
+This project has three main goals:
+1. Test new features before they move to the main project.
+2. Provide a place to experiment with new ideas.
+3. Support chess variants that are too unusual for the standard engine.
 
-1. To test and combine various feature suggestions that are not yet ready for the main Fairy-Stockfish codebase.
-2. To provide a platform for iterating on these experimental features.
-3. To serve as a permanent home for chess variants that are considered too unconventional for the mainline code.
-
-For standard Fairy-Stockfish functionality and supported variants, please refer to the [main Fairy-Stockfish repository](https://github.com/fairy-stockfish/Fairy-Stockfish).
+For standard functionality, please visit the [main Fairy-Stockfish repository](https://github.com/fairy-stockfish/Fairy-Stockfish).


### PR DESCRIPTION
* **Type:** Documentation
* **What:** README.md
* **Why:** The previous README was too brief and lacked clear instructions on how to actually build and use the software. These changes provide a clear starting point for new users, explain how to interact with the engine via UCI, and simplify the language for an international audience.

---
*PR created automatically by Jules for task [13893411405922468282](https://jules.google.com/task/13893411405922468282) started by @RainRat*