### PR TITLE
Remove unused variable in Position::set

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1994,7 +1994,6 @@ Position& Position::set(const string& code, Color c, StateInfo* si) {
 
   std::transform(sides[c].begin(), sides[c].end(), sides[c].begin(), tolower);
 
-  string n = std::to_string(8);
   string fenStr =  sides[0] + "///////" + sides[1] + " w - - 0 10";
 
   return set(variants.get("fairy"), fenStr, false, si, nullptr);


### PR DESCRIPTION
Removed the unused local variable 'n' in the Position::set overload for endgame code strings. This variable was initialized but never referenced, making it dead code. This change improves code hygiene without affecting the engine's behavior.

---
*PR created automatically by Jules for task [7556340148956114436](https://jules.google.com/task/7556340148956114436) started by @RainRat*