### PR TITLE
Add discovery 'help' command to UCI loop

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -389,6 +389,26 @@ void UCI::loop(int argc, char* argv[]) {
       else if (token == "position")   position(pos, is, states), banmoves.clear();
       else if (token == "ucinewgame" || token == "usinewgame" || token == "uccinewgame") Search::clear();
       else if (token == "isready")    sync_cout << "readyok" << sync_endl;
+      else if (token == "help")
+          sync_cout << "\nCommands:"
+                    << "\n  uci, usi, ucci, xboard      Switch protocol"
+                    << "\n  isready                     Check if engine is ready"
+                    << "\n  setoption name V value V    Set a UCI option"
+                    << "\n  ucinewgame                  Clear search and hash"
+                    << "\n  position [startpos|fen]     Set up a position"
+                    << "\n  go                          Start searching"
+                    << "\n  stop                        Stop searching"
+                    << "\n  ponderhit                   Switch from ponder to normal search"
+                    << "\n  quit                        Exit the engine"
+                    << "\n\nDebug/Extra commands:"
+                    << "\n  d                           Display current position"
+                    << "\n  eval                        Display static evaluation"
+                    << "\n  bench                       Run internal benchmark"
+                    << "\n  compiler                    Show compiler information"
+                    << "\n  load [file|<<EOF]           Load variant configuration"
+                    << "\n  check [file|<<EOF]          Check variant configuration"
+                    << "\n  flip                        Flip the current position"
+                    << sync_endl;
 
       // Additional custom non-UCI commands, mainly for debugging.
       // Do not use these commands during a search!


### PR DESCRIPTION
### [UI/UX] Add discovery 'help' command to UCI loop

**Context:** CLI
**Problem:** The engine supports many custom and debug commands (e.g., `d` to display the board, `eval` for static evaluation, `bench` for benchmarking, `load` for variant configs) that are not part of the standard UCI protocol. Users often have no way to discover these without digging through source code or external documentation.
**Solution:** Added a `help` command to the main loop in `src/uci.cpp`. This command prints a clean, categorized list of both standard protocol commands and engine-specific tools. It uses the existing `sync_cout` for thread-safe output and maintains the engine's "stock" feel.

**Changes:**
- Modified `src/uci.cpp` to include a `help` command handler in `UCI::loop`.
- The handler prints a categorized list of commands to the terminal.
- Verified with manual testing, internal benchmark, and the full Python test suite.

---
*PR created automatically by Jules for task [11658773514835893906](https://jules.google.com/task/11658773514835893906) started by @RainRat*