### PR TITLE
Remove redundant points_score function in Position class

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -491,7 +491,6 @@ public:
   PointsRule points_rule_captures() const;
   int points_goal() const;
   int points_count(Color c) const;
-  int points_score(Color c) const;
   int points_score_clamped(Color c) const;
   Value points_goal_value() const;
   Value points_goal_simul_value_by_most_points() const;
@@ -2464,12 +2463,8 @@ inline int Position::points_count(Color c) const {
   return st->pointsCount[c];
 }
 
-inline int Position::points_score(Color c) const {
-  return st->pointsCount[c];
-}
-
 inline int Position::points_score_clamped(Color c) const {
-  return std::max(0, std::min(points_score(c), POINTS_SCORE_MAX));
+  return std::max(0, std::min(points_count(c), POINTS_SCORE_MAX));
 }
 
 inline Value Position::points_goal_value() const {


### PR DESCRIPTION
**PR Title:** Remove redundant `points_score` function in `Position` class

**Description:**
* **What:** Removed the redundant `points_score(Color c)` function from the `Position` class in `src/position.h` and updated its only caller, `points_score_clamped(Color c)`, to use `points_count(Color c)` instead.
* **Why:** Both `points_score` and `points_count` were identical wrappers returning the same internal state (`st->pointsCount[c]`). Consolidating them improves code maintainability and readability by eliminating duplication. The external behavior of the engine remains identical, and all tests passed.

---
*PR created automatically by Jules for task [7243839018574204374](https://jules.google.com/task/7243839018574204374) started by @RainRat*