### PR TITLE
[DOCS] Improve README build instructions and prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,24 @@ Fairy-Stockfish-X is an experimental version of [Fairy-Stockfish](https://github
 To build the engine, follow these steps:
 
 1. Open your terminal and go to the `src/` directory.
-2. Run the following command:
+2. Run the build command:
    ```bash
    make -j build ARCH=x86-64-modern
    ```
    *Note: If you have a different CPU, you can check other options by running `make help`.*
+
+### Build Options
+
+You can add flags to the `make` command to enable special features:
+
+- **Large Boards:** For variants like Shogi (up to 12x10), add `largeboards=yes`.
+- **Very Large Boards:** For boards up to 16x16, add `verylargeboards=yes`.
+- **All Variants:** To include unusual variants like Game of the Amazons, add `all=yes`.
+
+Example for Shogi:
+```bash
+make -j build ARCH=x86-64-modern largeboards=yes
+```
 
 ## Basic Usage
 
@@ -36,7 +49,14 @@ Fairy-Stockfish-X supports many variants through a configuration file. To load t
 
 ## Python Bindings
 
-You can also use Fairy-Stockfish-X in Python. To build the Python extension, run this in the project root:
+You can also use Fairy-Stockfish-X in Python.
+
+### Prerequisites
+- Python 3.x
+- `setuptools` (Install via `pip install setuptools`)
+
+### Building the Extension
+To build the Python extension, run this in the project root:
 ```bash
 python3 setup.py build_ext --inplace
 ```


### PR DESCRIPTION
This PR improves the `README.md` by adding critical build information and prerequisites that were previously missing or only documented for developers.

**Changes:**
- Added a "Build Options" section with flags for `largeboards`, `verylargeboards`, and `all`.
- Added a Shogi build example.
- Listed `setuptools` as a prerequisite for Python bindings.
- Refined text for clarity and international accessibility (Plain English).

**Type:** Documentation
**What:** `README.md`
**Why:** Ensures users can build the engine for all supported variants and prevents installation failures for Python bindings.

---
*PR created automatically by Jules for task [8936149682561510181](https://jules.google.com/task/8936149682561510181) started by @RainRat*