### PR TITLE
Remove dead private method is_initial_pawn from Position class

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -665,7 +665,6 @@ private:
   Bitboard compute_evasion_checkers_bb(Color side) const;
   void set_check_info(StateInfo* si) const;
   bool compute_forced_jump_followup(Square s, int step = 0) const;
-  bool is_initial_pawn(Piece pc, Square s) const;
   Key layout_key() const;
   bool violates_same_player_board_repetition(Move m) const;
   Key reserve_key() const;
@@ -3865,10 +3864,6 @@ inline void Position::remove_piece(Square s) {
   //not-moved-piece bitboard must ensure that there is a piece
   this->st->not_moved_pieces[WHITE] &= (~square_bb(s));
   this->st->not_moved_pieces[BLACK] &= (~square_bb(s));
-}
-
-inline bool Position::is_initial_pawn(Piece pc, Square s) const {
-  return type_of(pc) == PAWN && rank_of(s) == relative_rank(color_of(pc), RANK_2, max_rank());
 }
 
 inline void Position::move_piece(Square from, Square to) {


### PR DESCRIPTION
* **What:** Removed the private method `Position::is_initial_pawn` (declaration and inline definition) from `src/position.h`.
* **Why:** This method is dead code and has been superseded by more general variant-aware logic using the `not_moved_pieces` bitboard. Removing it improves code maintainability without changing any external behavior.

---
*PR created automatically by Jules for task [183879627031610185](https://jules.google.com/task/183879627031610185) started by @RainRat*