### PR TITLE
Remove dead code declaration of find_drop_region

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -777,7 +777,6 @@ private:
   PieceType committed_piece_type(Color cl, File fl) const;
   bool has_committed_piece(Color cl, File fl) const;
   PieceType drop_committed_piece(Color cl, File fl);
-  Bitboard find_drop_region(Direction dir, Square s, Bitboard occupied) const;
   void swap_piece(Square from, Square to);
 };
 


### PR DESCRIPTION
* **What:** Removed the private member function declaration `find_drop_region` from the `Position` class in `src/position.h`.
* **Why:** This function was declared but never defined in the source code or used anywhere in the codebase. Removing it improves code hygiene and reduces clutter. This is a non-breaking change as verified by compilation and test suites.

---
*PR created automatically by Jules for task [7889351921082192761](https://jules.google.com/task/7889351921082192761) started by @RainRat*