### PR TITLE
Proposal: Convert Blast Booleans into a unified `blastPattern`

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1346,8 +1346,21 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("blastOnSelfDestruct", v->blastOnSelfDestruct);
     parse_attribute("selfDestructTypes", v->selfDestructTypes, v);
     parse_attribute("blastPromotion", v->blastPromotion);
-    parse_attribute("blastDiagonals", v->blastDiagonals);
-    parse_attribute("blastCenter", v->blastCenter);
+    parse_attribute("blastPattern", v->blastPattern);
+    bool blastDiagonals = true;
+    bool blastCenter = true;
+    bool blastOrthogonals = true;
+    bool hasD = parse_attribute("blastDiagonals", blastDiagonals);
+    bool hasC = parse_attribute("blastCenter", blastCenter);
+    bool hasO = parse_attribute("blastOrthogonals", blastOrthogonals);
+    if (hasD || hasC || hasO)
+    {
+        v->blastPattern = "";
+        if (blastDiagonals && blastOrthogonals) v->blastPattern += "K";
+        else if (blastDiagonals) v->blastPattern += "F";
+        else if (blastOrthogonals) v->blastPattern += "W";
+        if (blastCenter) v->blastPattern += "*";
+    }
     parse_attribute("blastPassiveTypes", v->blastPassiveTypes, v);
     parse_attribute("blastImmuneTypes", v->blastImmuneTypes, v);
     parse_attribute("mutuallyImmuneTypes", v->mutuallyImmuneTypes, v);
@@ -1555,7 +1568,6 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("changingColorPieceTypes", v->changingColorPieceTypes, v);
     parse_color_setting("selfCapture", v->selfCapture);
     parse_color_setting_piece("selfCaptureTypes", v->selfCaptureTypes, v);
-    parse_attribute("blastOrthogonals", v->blastOrthogonals);
     parse_attribute("blastOnSameTypeCapture", v->blastOnSameTypeCapture);
     parse_attribute("captureMorph", v->captureMorph);
     parse_attribute("rexExclusiveMorph", v->rexExclusiveMorph);

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -33,11 +33,10 @@ namespace Stockfish {
 PieceMap pieceMap; // Global object
 
 
-namespace {
-  // Keep legacy/variant-facing aliases here:
-  // L/C both mean camel (3,1), and J/Z both mean zebra (3,2).
-  // In particular, built-in Janggi elephant notation still uses nZ.
-  const std::map<char, std::vector<std::pair<int, int>>> leaperAtoms = {
+// Keep legacy/variant-facing aliases here:
+// L/C both mean camel (3,1), and J/Z both mean zebra (3,2).
+// In particular, built-in Janggi elephant notation still uses nZ.
+const std::map<char, std::vector<std::pair<int, int>>> leaperAtoms = {
       {'W', {std::make_pair(1, 0)}},
       {'F', {std::make_pair(1, 1)}},
       {'D', {std::make_pair(2, 0)}},
@@ -540,6 +539,8 @@ namespace {
       }
       return p.release();
   }
+
+namespace {
   // Special multi-leg betza description for Janggi elephant
   PieceInfo* janggi_elephant_piece() {
       PieceInfo* p = from_betza("nZ", "janggiElephant");

--- a/src/piece.h
+++ b/src/piece.h
@@ -115,6 +115,8 @@ struct PieceInfo {
   }
 };
 
+PieceInfo* from_betza(const std::string& betza, const std::string& name);
+
 struct PieceMap : public std::map<PieceType, const PieceInfo*> {
   PieceMap() { direct.fill(nullptr); }
   void init(const Variant* v = nullptr);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -3329,12 +3329,12 @@ bool Position::legal(Move m) const {
           if ((capture(m) || rifleShot) && blast_on_capture(m))
           {
               moverRemovedByBlast = zero_range_blast_on_capture(m)
-                                 || (blast_center() && effectiveTo == shotSq);
+                                 || (blast_center(shotSq) && effectiveTo == shotSq);
           }
           else if ((blast_on_move() && !capture(m) && !is_self_destruct(m))
                 || (blast_on_self_destruct() && is_self_destruct(m)))
           {
-              moverRemovedByBlast = blast_center();
+              moverRemovedByBlast = blast_center(effectiveTo);
           }
       }
 
@@ -3667,7 +3667,7 @@ bool Position::legal(Move m) const {
           Square blastCenter = (capture(m) || rifleShot) ? shotSq : effectiveTo;
           Bitboard blastRelevant = occupied & ~blast_immune_bb();
           removedByEffects |= blast_pattern(blastCenter) & blastRelevant;
-          if (blast_center())
+          if (blast_center(blastCenter))
               removedByEffects |= square_bb(blastCenter) & blastRelevant;
           if (blast_on_capture(m) && (blast_immune_types() & movePt))
               removedByEffects &= ~square_bb(effectiveTo);

--- a/src/position.h
+++ b/src/position.h
@@ -270,9 +270,7 @@ public:
   bool blast_on_move() const;
   bool blast_on_self_destruct() const;
   bool blast_promotion() const;
-  bool blast_diagonals() const;
-  bool blast_orthogonals() const;
-  bool blast_center() const;
+  bool blast_center(Square s) const;
   bool zero_range_blast_on_capture(Piece mover, Piece captured) const;
   bool zero_range_blast_on_capture(Move m) const;
   PieceSet blast_immune_types() const;
@@ -1043,19 +1041,9 @@ inline bool Position::blast_promotion() const {
   return var->blastPromotion;
 }
 
-inline bool Position::blast_diagonals() const {
+inline bool Position::blast_center(Square s) const {
   assert(var != nullptr);
-  return var->blastDiagonals;
-}
-
-inline bool Position::blast_orthogonals() const {
-  assert(var != nullptr);
-  return var->blastOrthogonals;
-}
-
-inline bool Position::blast_center() const {
-  assert(var != nullptr);
-  return var->blastCenter;
+  return var->blastMask[s] & square_bb(s);
 }
 
 inline bool Position::zero_range_blast_on_capture(Move m) const {
@@ -1064,7 +1052,7 @@ inline bool Position::zero_range_blast_on_capture(Move m) const {
 
 inline bool Position::zero_range_blast_on_capture(Piece mover, Piece captured) const {
   assert(var != nullptr);
-  return blast_on_capture(mover, captured) && blast_center() && !blast_orthogonals() && !blast_diagonals();
+  return blast_on_capture(mover, captured) && var->blastPattern == "*";
 }
 
 inline PieceSet Position::blast_immune_types() const {
@@ -1087,19 +1075,16 @@ inline Bitboard Position::blast_immune_bb() const {
 }
 
 inline Bitboard Position::blast_pattern(Square to) const {
-    Bitboard blastPattern = 0;
-    if (blast_orthogonals())
-        blastPattern |= attacks_bb<WAZIR>(to);
-    if (blast_diagonals())
-        blastPattern |= attacks_bb<KING>(to) & ~attacks_bb<WAZIR>(to);
-    return blastPattern;
+    return var->blastMask[to];
 }
 
 inline Bitboard Position::blast_squares(Square to) const {
     Bitboard blastImmune = blast_immune_bb();
     Bitboard blastPattern = blast_pattern(to);
     Bitboard relevantPieces = (pieces(WHITE) | pieces(BLACK)) ^ pieces(PAWN);
-    Bitboard blastArea = (blastPattern & relevantPieces) | (blast_center() ? square_bb(to) : Bitboard(0));
+    // Pieces on the surrounding blast pattern are only removed if they are not pawns.
+    // The piece at the epicenter (to) is always removed if it was part of the pattern.
+    Bitboard blastArea = (blastPattern & relevantPieces) | (blastPattern & square_bb(to));
 
     return blastArea & (pieces() ^ blastImmune);
 }

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -2469,7 +2469,81 @@ Variant* Variant::conclude() {
       multimoveCycle = 2 * firstMultimove - 1 + 2 * secondMultimove - 1;
       multimoveCycleShift = 2 * firstMultimove - 1;
 
+    init_blast_masks();
+
     return this;
+}
+
+
+void Variant::init_blast_masks() {
+    std::string pattern = blastPattern;
+    bool includeCenter = false;
+    size_t star = pattern.find('*');
+    if (star != std::string::npos)
+    {
+        includeCenter = true;
+        pattern.erase(star, 1);
+    }
+
+    auto safe_destination_no_table = [](Square s, int dr, int df) {
+        int r = int(rank_of(s)) + dr;
+        int f = int(file_of(s)) + df;
+        if (r < 0 || r > int(RANK_MAX) || f < 0 || f > int(FILE_MAX))
+            return Bitboard(0);
+        return Bitboard(1) << make_square(File(f), Rank(r));
+    };
+
+    PieceInfo* pi = from_betza(pattern, "blast");
+    if (!pi)
+        return;
+
+    for (Square s = SQ_A1; s < SQUARE_NB; ++s)
+    {
+        blastMask[s] = includeCenter ? (Bitboard(1) << s) : Bitboard(0);
+        if (pattern.empty())
+            continue;
+
+        // Leapers
+        for (auto const& [d, _] : pi->steps[WHITE][MODALITY_QUIET])
+        {
+            auto [dr, df] = decode_direction(d);
+            blastMask[s] |= safe_destination_no_table(s, dr, df);
+        }
+        for (auto const& [d, _] : pi->steps[WHITE][MODALITY_CAPTURE])
+        {
+            auto [dr, df] = decode_direction(d);
+            blastMask[s] |= safe_destination_no_table(s, dr, df);
+        }
+
+        // Sliders
+        for (auto const& [d, limit] : pi->slider[WHITE][MODALITY_QUIET])
+        {
+            auto [dr, df] = decode_direction(d);
+            Bitboard next = safe_destination_no_table(s, dr, df);
+            int count = 0;
+            while (next)
+            {
+                blastMask[s] |= next;
+                if (limit > 0 && ++count >= limit)
+                    break;
+                next = safe_destination_no_table(lsb(next), dr, df);
+            }
+        }
+        for (auto const& [d, limit] : pi->slider[WHITE][MODALITY_CAPTURE])
+        {
+            auto [dr, df] = decode_direction(d);
+            Bitboard next = safe_destination_no_table(s, dr, df);
+            int count = 0;
+            while (next)
+            {
+                blastMask[s] |= next;
+                if (limit > 0 && ++count >= limit)
+                    break;
+                next = safe_destination_no_table(lsb(next), dr, df);
+            }
+        }
+    }
+    delete pi;
 }
 
 

--- a/src/variant.h
+++ b/src/variant.h
@@ -126,6 +126,7 @@ struct Variant {
   std::map<std::string, PieceType> symbolToPieceType;
   std::string startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
   Bitboard mobilityRegion[COLOR_NB][PIECE_TYPE_NB] = {};
+  Bitboard blastMask[SQUARE_NB] = {};
   ColorSetting<PieceTypeBitboardGroup> promotionRegion = ColorSetting<PieceTypeBitboardGroup>(Rank8BB, Rank1BB);
   ColorSetting<Bitboard> mandatoryPromotionRegion = ColorSetting<Bitboard>(Bitboard(0));
   ColorSetting<PieceType> mainPromotionPawnType = ColorSetting<PieceType>(PAWN);
@@ -151,8 +152,7 @@ struct Variant {
   PieceSet changingColorPieceTypes = NO_PIECE_SET;
   PieceSet selfDestructTypes = NO_PIECE_SET;
   bool blastPromotion = false;
-  bool blastDiagonals = true;
-  bool blastCenter = true;
+  std::string blastPattern = "K*";
   PieceSet blastPassiveTypes = NO_PIECE_SET;
   PieceSet blastImmuneTypes = NO_PIECE_SET;
   PieceSet mutuallyImmuneTypes = NO_PIECE_SET;
@@ -220,7 +220,6 @@ struct Variant {
   ColorSetting<bool> selfCapture = ColorSetting<bool>(false);
   ColorSetting<PieceSet> selfCaptureTypes = ColorSetting<PieceSet>(NO_PIECE_SET);
   bool blastOnSameTypeCapture = false;
-  bool blastOrthogonals = true;
   ColorSetting<bool> mustDrop = ColorSetting<bool>(false);
   ColorSetting<PieceType> mustDropType = ColorSetting<PieceType>(ALL_PIECES);
   bool dropKingLast = false;
@@ -576,6 +575,7 @@ struct Variant {
   }
 
   Variant* conclude();
+  void init_blast_masks();
 
 };
 


### PR DESCRIPTION
This PR introduces a proposal to deprecate the single-purpose blast booleans (`blastDiagonals`, `blastOrthogonals`, and `blastCenter`) in favor of a unified `blastPattern` option using Betza notation or relative bitboard masks. The proposal provides the motivation, design changes, and backward compatibility strategy. I'm opening this PR to solicit feedback on the design before implementing.