### PR TITLE
Fix several move generation bugs and risks

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -645,7 +645,7 @@ namespace {
 
             // An en passant capture cannot resolve a discovered check (unless there non-sliding riders)
             if (Type == EVASIONS && (target & (epSquare + Up)) && !pos.non_sliding_riders())
-                return moveList;
+                continue;
 
             Bitboard b = pawns & pawn_attacks_bb(Them, epSquare);
 
@@ -992,8 +992,8 @@ namespace {
                 moveList = generate_exchanges<Us, Type>(pos, moveList, pop_lsb(ps), target & ~pos.pieces(~Us));
 
         // Castling with non-king piece
-        if constexpr (Type != CAPTURES)
-            if (!restrictToForcedJumper && !pos.count<KING>(Us) && pos.can_castle(Us & ANY_CASTLING))
+        if constexpr (Type != CAPTURES && Type != QUIET_CHECKS)
+            if (!restrictToForcedJumper && !pos.count<KING>(Us) && pos.can_castle(Us == WHITE ? WHITE_CASTLING : BLACK_CASTLING))
             {
                 Square from = pos.castling_king_square(Us);
                 for(CastlingRights cr : { Us & KING_SIDE, Us & QUEEN_SIDE } )
@@ -1039,6 +1039,8 @@ namespace {
                 {
                     Square from = pop_lsb(froms);
                     Bitboard b = (pos.moves_from(Us, extraPt, from) | pos.attacks_from(Us, extraPt, from)) & target & ~pos.pieces(Us);
+                    if (Type == QUIET_CHECKS)
+                        b &= pos.check_squares(extraPt);
                     while (b)
                         *moveList++ = make<SPECIAL>(from, pop_lsb(b), extraPt);
                 }
@@ -1060,6 +1062,8 @@ namespace {
                 {
                     Square from = pop_lsb(froms);
                     Bitboard b = pos.clone_targets_from(Us, from) & cloneTargets;
+                    if (Type == QUIET_CHECKS)
+                        b &= pos.check_squares(pt);
                     while (b)
                         *moveList++ = make<SPECIAL>(from, pop_lsb(b));
                 }
@@ -1178,7 +1182,7 @@ namespace {
             *moveList++ = make<SPECIAL>(ksq != SQ_NONE ? ksq : lsb(pos.board_bb()),
                                         ksq != SQ_NONE ? ksq : lsb(pos.board_bb()));
 
-        if (!restrictToForcedJumper && (Type == QUIETS || Type == NON_EVASIONS) && pos.can_castle(Us & ANY_CASTLING))
+        if (!restrictToForcedJumper && (Type == QUIETS || Type == NON_EVASIONS) && pos.can_castle(Us == WHITE ? WHITE_CASTLING : BLACK_CASTLING))
             for (CastlingRights cr : { Us & KING_SIDE, Us & QUEEN_SIDE } )
                 if (!pos.castling_impeded(cr) && pos.can_castle(cr))
                     moveList = make_move_and_gating<CASTLING>(pos, moveList, Us,ksq, pos.castling_rook_square(cr));
@@ -1254,11 +1258,19 @@ namespace {
             Bitboard gateMask = square_bb(gate);
             ScopedSpellContext guard(Bitboard(0), gateMask);
 
+#ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
+            std::unique_ptr<ExtMove[]> jumpMoves(new ExtMove[MOVEGEN_OVERFLOW_CAPACITY]);
+            ExtMove* jumpEnd = generate_all_impl<Us, Type>(pos, jumpMoves.get());
+            assert(jumpEnd - jumpMoves.get() <= MOVEGEN_OVERFLOW_CAPACITY);
+
+            for (ExtMove* it = jumpMoves.get(); it != jumpEnd; ++it)
+#else
             ExtMove jumpMoves[MOVEGEN_OVERFLOW_CAPACITY];
             ExtMove* jumpEnd = generate_all_impl<Us, Type>(pos, jumpMoves);
             assert(jumpEnd - jumpMoves <= MOVEGEN_OVERFLOW_CAPACITY);
 
             for (ExtMove* it = jumpMoves; it != jumpEnd; ++it)
+#endif
             {
                 if (cur >= maxEnd)
                     return maxEnd;

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -124,12 +124,12 @@ struct MoveList {
   }
 
 private:
-    ExtMove* last;
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
     std::unique_ptr<ExtMove[]> moveList;
 #else
     ExtMove moveList[MOVEGEN_OVERFLOW_CAPACITY];
 #endif
+    ExtMove* last;
 };
 
 } // namespace Stockfish


### PR DESCRIPTION
This PR fixes several bugs and potential issues in the move generation logic:

### 1. Fragile Castling Rights Selection (Bug 1)
In 'generate_all_impl', 'Us & ANY_CASTLING' was used as a shortcut. For Black, this results in '1' which corresponds to 'WHITE_OO'. The code now uses an explicit check on the side to move to ensure the correct castling rights are selected.

### 2. Early Abort in En-Passant Evasion Path (Bug 2)
In 'generate_pawn_moves' for the non-wrapping topology branch, 'return moveList' was incorrectly used when an en-passant capture could not resolve a discovered check. This would abort the generation of ALL subsequent en-passant moves and any other moves in this function. This has been corrected to 'continue', which is the behavior used in the wrapping branch.

### 3. QUIET_CHECKS Overgeneration (Bug 3)
Corrected several cases where 'QUIET_CHECKS' incorrectly generated moves that do not give check, or moves (like castling) that should be excluded from quiet checks entirely according to the generator documentation.

### 4. Stack Buffer Overflow Risk in Potion Moves (Bug 4)
In 'generate_potion_moves', 'jumpMoves' was always allocated on the stack (up to 2 MB depending on configuration). This has been modified to use heap allocation when 'USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST' is defined, aligning with the safety settings used in the rest of the engine.

### 5. MoveList Initialization Order (Bug 8)
Fixed a bug in 'MoveList' where 'last' was declared before 'moveList', leading to 'last' being initialized using an uninitialized 'moveList' pointer in the constructor's initializer list. Swapping the declaration order ensures safe initialization.