### PR TITLE
Optimize search hot paths: replace heap allocations with a thread-local buffer pool

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -20,8 +20,38 @@
 
 #include "movegen.h"
 #include "position.h"
+#include "thread.h"
 
 namespace Stockfish {
+
+#ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
+template<GenType T>
+MoveList<T>::MoveList(const Position& pos) {
+    thread = pos.this_thread();
+    if (thread)
+        moveList = acquire_thread_buffer(thread);
+    else {
+        moveListPtr = std::make_unique<ExtMove[]>(MOVEGEN_OVERFLOW_CAPACITY);
+        moveList = moveListPtr.get();
+    }
+    last = generate<T>(pos, moveList);
+    assert(last - moveList <= MOVEGEN_OVERFLOW_CAPACITY);
+}
+
+template<GenType T>
+MoveList<T>::~MoveList() {
+    if (thread)
+        release_thread_buffer(thread, moveList);
+}
+
+// Explicit instantiations
+template struct MoveList<CAPTURES>;
+template struct MoveList<QUIETS>;
+template struct MoveList<QUIET_CHECKS>;
+template struct MoveList<EVASIONS>;
+template struct MoveList<NON_EVASIONS>;
+template struct MoveList<LEGAL>;
+#endif
 
 namespace {
 

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -60,6 +60,12 @@ struct ExtMove {
   operator float() const = delete;
 };
 
+class Thread;
+
+ExtMove* acquire_thread_buffer(Thread* thread);
+void release_thread_buffer(Thread* thread, ExtMove* buffer);
+
+
 inline bool operator<(const ExtMove& f, const ExtMove& s) {
   return f.value < s.value;
 }
@@ -90,19 +96,8 @@ struct MoveList {
   MoveList& operator=(MoveList&&) = delete;
 
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-    explicit MoveList(const Position& pos)
-    {
-        moveList = std::unique_ptr<ExtMove[]>(new (std::nothrow) ExtMove[MOVEGEN_OVERFLOW_CAPACITY]);
-        if (!moveList)
-        {
-            std::fputs("Error: Failed to allocate memory for move list.\n", stderr);
-            exit(1);
-        }
-        this->last = generate<T>(pos, moveList.get());
-        assert(this->last - moveList.get() <= MOVEGEN_OVERFLOW_CAPACITY);
-    }
-
-    ~MoveList() = default;
+    explicit MoveList(const Position& pos);
+    ~MoveList();
 #else
     explicit MoveList(const Position& pos) : last(generate<T>(pos, moveList))
     {
@@ -111,11 +106,7 @@ struct MoveList {
 #endif
   
   const ExtMove* begin() const {
-#ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-    return moveList.get();
-#else
     return moveList;
-#endif
   }
   const ExtMove* end() const { return last; }
   size_t size() const { return last - begin(); }
@@ -125,7 +116,9 @@ struct MoveList {
 
 private:
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-    std::unique_ptr<ExtMove[]> moveList;
+    Thread* thread;
+    std::unique_ptr<ExtMove[]> moveListPtr;
+    ExtMove* moveList;
 #else
     ExtMove moveList[MOVEGEN_OVERFLOW_CAPACITY];
 #endif

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -121,12 +121,15 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
   assert(d > 0);
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-  if (pos.potions_enabled() || pos.capture_type() == PRISON)
-      overflowMoveList = std::make_unique<ExtMove[]>(MOVE_PICK_OVERFLOW_CAPACITY);
+  thread = pos.this_thread();
+  if (thread)
+      baseMoveList = acquire_thread_buffer(thread);
   else
-      baseMoveList = std::make_unique<ExtMove[]>(MAX_MOVES);
-
-  moveList = overflowMoveList ? overflowMoveList.get() : baseMoveList.get();
+  {
+      moveListPtr = std::make_unique<ExtMove[]>(MOVE_PICK_OVERFLOW_CAPACITY);
+      baseMoveList = moveListPtr.get();
+  }
+  moveList = baseMoveList;
 #else
   moveList = moves;
 #endif
@@ -142,12 +145,15 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
   assert(d <= 0);
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-  if (pos.potions_enabled() || pos.capture_type() == PRISON)
-      overflowMoveList = std::make_unique<ExtMove[]>(MOVE_PICK_OVERFLOW_CAPACITY);
+  thread = pos.this_thread();
+  if (thread)
+      baseMoveList = acquire_thread_buffer(thread);
   else
-      baseMoveList = std::make_unique<ExtMove[]>(MAX_MOVES);
-
-  moveList = overflowMoveList ? overflowMoveList.get() : baseMoveList.get();
+  {
+      moveListPtr = std::make_unique<ExtMove[]>(MOVE_PICK_OVERFLOW_CAPACITY);
+      baseMoveList = moveListPtr.get();
+  }
+  moveList = baseMoveList;
 #else
   moveList = moves;
 #endif
@@ -165,12 +171,15 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const GateHistory*
 
   assert(!pos.evasion_checkers());
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-  if (pos.potions_enabled() || pos.capture_type() == PRISON)
-      overflowMoveList = std::make_unique<ExtMove[]>(MOVE_PICK_OVERFLOW_CAPACITY);
+  thread = pos.this_thread();
+  if (thread)
+      baseMoveList = acquire_thread_buffer(thread);
   else
-      baseMoveList = std::make_unique<ExtMove[]>(MAX_MOVES);
-
-  moveList = overflowMoveList ? overflowMoveList.get() : baseMoveList.get();
+  {
+      moveListPtr = std::make_unique<ExtMove[]>(MOVE_PICK_OVERFLOW_CAPACITY);
+      baseMoveList = moveListPtr.get();
+  }
+  moveList = baseMoveList;
 #else
   moveList = moves;
 #endif
@@ -178,6 +187,13 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const GateHistory*
   stage = PROBCUT_TT + !(ttm && pos.capture(ttm)
                              && pos.pseudo_legal(ttm)
                              && (pos.see_pruning_unreliable() || pos.see_ge(ttm, threshold)));
+}
+
+MovePicker::~MovePicker() {
+#ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
+    if (thread)
+        release_thread_buffer(thread, baseMoveList);
+#endif
 }
 
 /// MovePicker::score() assigns a numerical value to each move in a list, used

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -141,6 +141,7 @@ public:
                                            Move,
                                            const Move*,
                                            int);
+  ~MovePicker();
   Move next_move(bool skipQuiets = false);
 
 private:
@@ -176,8 +177,9 @@ private:
   bool evasionPotionsDeferred = false;
   bool qcheckPotionsDeferred = false;
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-  std::unique_ptr<ExtMove[]> baseMoveList;
-  std::unique_ptr<ExtMove[]> overflowMoveList;
+  Thread* thread = nullptr;
+  ExtMove* baseMoveList = nullptr;
+  std::unique_ptr<ExtMove[]> moveListPtr;
 #else
   ExtMove moves[MOVE_PICK_OVERFLOW_CAPACITY];
 #endif

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -32,6 +32,14 @@ namespace Stockfish {
 
 ThreadPool Threads; // Global object
 
+ExtMove* acquire_thread_buffer(Thread* thread) {
+    return thread->acquire_buffer();
+}
+
+void release_thread_buffer(Thread* thread, ExtMove* buffer) {
+    thread->release_buffer(buffer);
+}
+
 
 /// Thread constructor launches the thread and waits until it goes to sleep
 /// in idle_loop(). Note that 'searching' and 'exit' should be already set.

--- a/src/thread.h
+++ b/src/thread.h
@@ -76,6 +76,25 @@ public:
   CapturePieceToHistory captureHistory;
   ContinuationHistory continuationHistory[2][2];
   Score trend;
+
+  ExtMove* acquire_buffer() {
+    if (availableBuffers.empty()) {
+      bufferPool.push_back(std::make_unique<ExtMove[]>(MOVEGEN_OVERFLOW_CAPACITY));
+      return bufferPool.back().get();
+    }
+    ExtMove* b = availableBuffers.back();
+    availableBuffers.pop_back();
+    return b;
+  }
+
+  void release_buffer(ExtMove* b) {
+    if (b)
+      availableBuffers.push_back(b);
+  }
+
+private:
+  std::vector<std::unique_ptr<ExtMove[]>> bufferPool;
+  std::vector<ExtMove*> availableBuffers;
 };
 
 


### PR DESCRIPTION
This PR implements a thread-local buffer pool in the Thread class to avoid frequent heap allocations in MoveList and MovePicker, which are in the search hot path. This addresses the critical performance degradation reported due to heap pressure.