### PR TITLE
Fix Magic Bitboard Global State

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -49,57 +49,13 @@ Bitboard BoardSizeBB[FILE_NB][RANK_NB];
 RiderType AttackRiderTypes[PIECE_TYPE_NB];
 RiderType MoveRiderTypes[2][PIECE_TYPE_NB];
 
-Magic RookMagicsH[SQUARE_NB];
-Magic RookMagicsV[SQUARE_NB];
-Magic BishopMagics[SQUARE_NB];
-Magic CannonMagicsH[SQUARE_NB];
-Magic CannonMagicsV[SQUARE_NB];
-Magic HorseMagics[SQUARE_NB];
-Magic JanggiElephantMagics[SQUARE_NB];
-Magic CannonDiagMagics[SQUARE_NB];
-Magic NightriderMagics[SQUARE_NB];
-Magic GrasshopperMagicsH[SQUARE_NB];
-Magic GrasshopperMagicsV[SQUARE_NB];
-Magic GrasshopperMagicsD[SQUARE_NB];
-
-Magic* magics[] = {BishopMagics, RookMagicsH, RookMagicsV, CannonMagicsH, CannonMagicsV,
-                   BishopMagics, HorseMagics, BishopMagics, JanggiElephantMagics, CannonDiagMagics, NightriderMagics,
-                   GrasshopperMagicsH, GrasshopperMagicsV, GrasshopperMagicsD};
+thread_local const MagicGeometry* current_magic_geometry = nullptr;
 
 namespace {
 
 // Some magics need to be split in order to reduce memory consumption.
 // Otherwise on a 12x10 board they can be >100 MB.
 #if !defined(VERY_LARGE_BOARDS)
-#ifdef LARGEBOARDS
-  Bitboard RookTableH[0x11800];  // To store horizontal rook attacks
-  Bitboard RookTableV[0x4800];  // To store vertical rook attacks
-  Bitboard BishopTable[0x33C00]; // To store bishop attacks
-  Bitboard CannonTableH[0x11800];  // To store horizontal cannon attacks
-  Bitboard CannonTableV[0x4800];  // To store vertical cannon attacks
-  Bitboard HorseTable[0x500];  // To store horse attacks
-  Bitboard JanggiElephantTable[0x1C000];  // To store janggi elephant attacks
-  Bitboard CannonDiagTable[0x33C00]; // To store diagonal cannon attacks
-  // Nightrider masks trim terminal leap squares; 12x10 max needs 0xD200 entries.
-  Bitboard NightriderTable[0xD200]; // To store nightrider attacks
-  Bitboard GrasshopperTableH[0x11800];  // To store horizontal grasshopper attacks
-  Bitboard GrasshopperTableV[0x4800];  // To store vertical grasshopper attacks
-  Bitboard GrasshopperTableD[0x33C00]; // To store diagonal grasshopper attacks
-#else
-  Bitboard RookTableH[0xA00];  // To store horizontal rook attacks
-  Bitboard RookTableV[0xA00];  // To store vertical rook attacks
-  Bitboard BishopTable[0x1480]; // To store bishop attacks
-  Bitboard CannonTableH[0xA00];  // To store horizontal cannon attacks
-  Bitboard CannonTableV[0xA00];  // To store vertical cannon attacks
-  Bitboard HorseTable[0x240];  // To store horse attacks
-  Bitboard JanggiElephantTable[0x5C00];  // To store janggi elephant attacks
-  Bitboard CannonDiagTable[0x1480]; // To store diagonal cannon attacks
-  // Nightrider masks trim terminal leap squares; 8x8 max needs 0x500 entries.
-  Bitboard NightriderTable[0x500]; // To store nightrider attacks
-  Bitboard GrasshopperTableH[0xA00];  // To store horizontal grasshopper attacks
-  Bitboard GrasshopperTableV[0xA00];  // To store vertical grasshopper attacks
-  Bitboard GrasshopperTableD[0x1480]; // To store diagonal grasshopper attacks
-#endif
 #endif
 
   // Rider directions
@@ -838,8 +794,8 @@ void Bitboards::init() {
           {
               if (PseudoAttacks[WHITE][pt][s1] & s2)
               {
-                  LineBB[s1][s2]    = (attacks_bb(WHITE, pt, s1, 0) & attacks_bb(WHITE, pt, s2, 0)) | s1 | s2;
-                  BetweenBB[s1][s2] = (attacks_bb(WHITE, pt, s1, square_bb(s2)) & attacks_bb(WHITE, pt, s2, square_bb(s1)));
+                  LineBB[s1][s2]    = (attacks_bb(WHITE, pt, s1, 0, current_magic_geometry) & attacks_bb(WHITE, pt, s2, 0, current_magic_geometry)) | s1 | s2;
+                  BetweenBB[s1][s2] = (attacks_bb(WHITE, pt, s1, square_bb(s2), current_magic_geometry) & attacks_bb(WHITE, pt, s2, square_bb(s1), current_magic_geometry));
               }
               BetweenBB[s1][s2] |= s2;
           }
@@ -850,27 +806,7 @@ namespace {
 
 #if !defined(VERY_LARGE_BOARDS)
 
-  File CurrentMagicMaxFile = FILE_MAX;
-  Rank CurrentMagicMaxRank = RANK_MAX;
-  std::atomic<bool> MagicsInitialized { false };
-  std::atomic<uint16_t> CurrentMagicBoardKey { 0 };
-
-  struct MagicNumberCache {
-      std::array<Bitboard, SQUARE_NB> rookH {};
-      std::array<Bitboard, SQUARE_NB> rookV {};
-      std::array<Bitboard, SQUARE_NB> bishop {};
-      std::array<Bitboard, SQUARE_NB> cannonH {};
-      std::array<Bitboard, SQUARE_NB> cannonV {};
-      std::array<Bitboard, SQUARE_NB> horse {};
-      std::array<Bitboard, SQUARE_NB> janggiElephant {};
-      std::array<Bitboard, SQUARE_NB> cannonDiag {};
-      std::array<Bitboard, SQUARE_NB> nightrider {};
-      std::array<Bitboard, SQUARE_NB> grasshopperH {};
-      std::array<Bitboard, SQUARE_NB> grasshopperV {};
-      std::array<Bitboard, SQUARE_NB> grasshopperD {};
-  };
-
-  std::unordered_map<uint16_t, MagicNumberCache> MagicByBoardSize;
+  std::unordered_map<uint16_t, std::shared_ptr<const MagicGeometry>> MagicByBoardSize;
   std::vector<uint16_t> MagicCacheLru;
   std::mutex MagicInitMutex;
   constexpr size_t MAX_MAGIC_CACHE_ENTRIES = 16;
@@ -884,8 +820,8 @@ namespace {
           out[s] = in[s].magic;
   }
 
-  inline Bitboard active_magic_board() {
-      return BoardSizeBB[CurrentMagicMaxFile][CurrentMagicMaxRank];
+  inline Bitboard active_magic_board(File maxFile, Rank maxRank) {
+      return BoardSizeBB[maxFile][maxRank];
   }
 
   // init_magics() computes all rook and bishop attacks at startup. Magic
@@ -894,7 +830,7 @@ namespace {
   // called "fancy" approach.
 
   template <MovementType MT, bool TrimRiderTerminal = false>
-  void init_magic_table(Bitboard table[], Magic magics[], const std::map<Direction, int>& directions, const Bitboard* magicsInit = nullptr) {
+  void init_magic_table(Bitboard table[], Magic magics[], const std::map<Direction, int>& directions, File maxFile, Rank maxRank, const Bitboard* magicsInit = nullptr) {
 
     // Optimal PRNG seeds to pick the correct magics in the shortest time
 #ifdef LARGEBOARDS
@@ -916,8 +852,8 @@ namespace {
     for (Square s = SQ_A1; s <= SQ_MAX; ++s)
     {
         // Board edges are not considered in the relevant occupancies
-        edges = ((Rank1BB | rank_bb(CurrentMagicMaxRank)) & ~rank_bb(s))
-              | ((FileABB | file_bb(CurrentMagicMaxFile)) & ~file_bb(s));
+        edges = ((Rank1BB | rank_bb(maxRank)) & ~rank_bb(s))
+              | ((FileABB | file_bb(maxFile)) & ~file_bb(s));
 
         // Given a square 's', the mask is the bitboard of sliding attacks from
         // 's' computed on an empty board. The index must be big enough to contain
@@ -930,14 +866,14 @@ namespace {
         {
             // For leap-riders (e.g. nightrider), occupancy on the final square
             // of each ray cannot affect attacks, so it is not a relevant bit.
-            Bitboard emptyAttack = sliding_attack<RIDER>(directions, s, 0) & active_magic_board();
+            Bitboard emptyAttack = sliding_attack<RIDER>(directions, s, 0) & active_magic_board(maxFile, maxRank);
             m.mask = emptyAttack & ~rider_terminal_squares(directions, s);
         }
         else
         {
             m.mask = (MT == LAME_LEAPER ? lame_leaper_path(directions, s)
                                         : sliding_attack<MT == HOPPER ? HOPPER_RANGE : MT>(directions, s, 0))
-                   & active_magic_board() & ~edges;
+                   & active_magic_board(maxFile, maxRank) & ~edges;
         }
 #ifdef LARGEBOARDS
         m.shift = 128 - popcount(m.mask);
@@ -955,7 +891,7 @@ namespace {
         do {
             occupancy[size] = b;
             reference[size] = (MT == LAME_LEAPER ? lame_leaper_attack(directions, s, b) : sliding_attack<MT>(directions, s, b))
-                            & active_magic_board();
+                            & active_magic_board(maxFile, maxRank);
 
             if (HasPext)
                 m.attacks[pext(b, m.mask)] = reference[size];
@@ -1021,23 +957,13 @@ namespace {
 #endif
 }
 
-void Bitboards::init_magics(File maxFile, Rank maxRank) {
+std::shared_ptr<const MagicGeometry> Bitboards::init_magics(File maxFile, Rank maxRank) {
 #if !defined(VERY_LARGE_BOARDS)
   const uint16_t boardKey = magic_board_key(maxFile, maxRank);
-  if (MagicsInitialized.load(std::memory_order_acquire)
-      && boardKey == CurrentMagicBoardKey.load(std::memory_order_relaxed))
-      return;
 
   std::lock_guard<std::mutex> lock(MagicInitMutex);
-  if (MagicsInitialized.load(std::memory_order_relaxed)
-      && maxFile == CurrentMagicMaxFile && maxRank == CurrentMagicMaxRank)
-      return;
-
-  CurrentMagicMaxFile = maxFile;
-  CurrentMagicMaxRank = maxRank;
   const auto cacheIt = MagicByBoardSize.find(boardKey);
-  const MagicNumberCache* cache = cacheIt == MagicByBoardSize.end() ? nullptr : &cacheIt->second;
-  if (cache)
+  if (cacheIt != MagicByBoardSize.end())
   {
       auto it = std::find(MagicCacheLru.begin(), MagicCacheLru.end(), boardKey);
       if (it != MagicCacheLru.end())
@@ -1045,64 +971,82 @@ void Bitboards::init_magics(File maxFile, Rank maxRank) {
           MagicCacheLru.erase(it);
           MagicCacheLru.push_back(boardKey);
       }
+      current_magic_geometry = cacheIt->second.get();
+      return cacheIt->second;
   }
 
-#ifdef PRECOMPUTED_MAGICS
-  init_magic_table<RIDER>(RookTableH, RookMagicsH, RookDirectionsH, cache ? cache->rookH.data() : RookMagicHInit);
-  init_magic_table<RIDER>(RookTableV, RookMagicsV, RookDirectionsV, cache ? cache->rookV.data() : RookMagicVInit);
-  init_magic_table<RIDER>(BishopTable, BishopMagics, BishopDirections, cache ? cache->bishop.data() : BishopMagicInit);
-  init_magic_table<HOPPER>(CannonTableH, CannonMagicsH, RookDirectionsH, cache ? cache->cannonH.data() : CannonMagicHInit);
-  init_magic_table<HOPPER>(CannonTableV, CannonMagicsV, RookDirectionsV, cache ? cache->cannonV.data() : CannonMagicVInit);
-  init_magic_table<LAME_LEAPER>(HorseTable, HorseMagics, HorseDirections, cache ? cache->horse.data() : HorseMagicInit);
-  init_magic_table<LAME_LEAPER>(JanggiElephantTable, JanggiElephantMagics, JanggiElephantDirections, cache ? cache->janggiElephant.data() : JanggiElephantMagicInit);
-  init_magic_table<HOPPER>(CannonDiagTable, CannonDiagMagics, BishopDirections, cache ? cache->cannonDiag.data() : CannonDiagMagicInit);
-  init_magic_table<RIDER, true>(NightriderTable, NightriderMagics, HorseDirections, cache ? cache->nightrider.data() : NightriderMagicInit);
-  init_magic_table<HOPPER>(GrasshopperTableH, GrasshopperMagicsH, GrasshopperDirectionsH, cache ? cache->grasshopperH.data() : GrasshopperMagicHInit);
-  init_magic_table<HOPPER>(GrasshopperTableV, GrasshopperMagicsV, GrasshopperDirectionsV, cache ? cache->grasshopperV.data() : GrasshopperMagicVInit);
-  init_magic_table<HOPPER>(GrasshopperTableD, GrasshopperMagicsD, GrasshopperDirectionsD, cache ? cache->grasshopperD.data() : GrasshopperMagicDInit);
+  std::shared_ptr<MagicGeometry> mg = std::make_shared<MagicGeometry>();
+
+#ifdef LARGEBOARDS
+  mg->RookTableH.resize(0x11800);
+  mg->RookTableV.resize(0x4800);
+  mg->BishopTable.resize(0x33C00);
+  mg->CannonTableH.resize(0x11800);
+  mg->CannonTableV.resize(0x4800);
+  mg->HorseTable.resize(0x500);
+  mg->JanggiElephantTable.resize(0x1C000);
+  mg->CannonDiagTable.resize(0x33C00);
+  mg->NightriderTable.resize(0xD200);
+  mg->GrasshopperTableH.resize(0x11800);
+  mg->GrasshopperTableV.resize(0x4800);
+  mg->GrasshopperTableD.resize(0x33C00);
 #else
-  init_magic_table<RIDER>(RookTableH, RookMagicsH, RookDirectionsH, cache ? cache->rookH.data() : nullptr);
-  init_magic_table<RIDER>(RookTableV, RookMagicsV, RookDirectionsV, cache ? cache->rookV.data() : nullptr);
-  init_magic_table<RIDER>(BishopTable, BishopMagics, BishopDirections, cache ? cache->bishop.data() : nullptr);
-  init_magic_table<HOPPER>(CannonTableH, CannonMagicsH, RookDirectionsH, cache ? cache->cannonH.data() : nullptr);
-  init_magic_table<HOPPER>(CannonTableV, CannonMagicsV, RookDirectionsV, cache ? cache->cannonV.data() : nullptr);
-  init_magic_table<LAME_LEAPER>(HorseTable, HorseMagics, HorseDirections, cache ? cache->horse.data() : nullptr);
-  init_magic_table<LAME_LEAPER>(JanggiElephantTable, JanggiElephantMagics, JanggiElephantDirections, cache ? cache->janggiElephant.data() : nullptr);
-  init_magic_table<HOPPER>(CannonDiagTable, CannonDiagMagics, BishopDirections, cache ? cache->cannonDiag.data() : nullptr);
-  init_magic_table<RIDER, true>(NightriderTable, NightriderMagics, HorseDirections, cache ? cache->nightrider.data() : nullptr);
-  init_magic_table<HOPPER>(GrasshopperTableH, GrasshopperMagicsH, GrasshopperDirectionsH, cache ? cache->grasshopperH.data() : nullptr);
-  init_magic_table<HOPPER>(GrasshopperTableV, GrasshopperMagicsV, GrasshopperDirectionsV, cache ? cache->grasshopperV.data() : nullptr);
-  init_magic_table<HOPPER>(GrasshopperTableD, GrasshopperMagicsD, GrasshopperDirectionsD, cache ? cache->grasshopperD.data() : nullptr);
+  mg->RookTableH.resize(0xA00);
+  mg->RookTableV.resize(0xA00);
+  mg->BishopTable.resize(0x1480);
+  mg->CannonTableH.resize(0xA00);
+  mg->CannonTableV.resize(0xA00);
+  mg->HorseTable.resize(0x240);
+  mg->JanggiElephantTable.resize(0x5C00);
+  mg->CannonDiagTable.resize(0x1480);
+  mg->NightriderTable.resize(0x500);
+  mg->GrasshopperTableH.resize(0xA00);
+  mg->GrasshopperTableV.resize(0xA00);
+  mg->GrasshopperTableD.resize(0x1480);
 #endif
 
-  if (!cache) {
-      if (MagicByBoardSize.size() >= MAX_MAGIC_CACHE_ENTRIES && !MagicCacheLru.empty())
-      {
-          MagicByBoardSize.erase(MagicCacheLru.front());
-          MagicCacheLru.erase(MagicCacheLru.begin());
-      }
-      MagicNumberCache fresh {};
-      snapshot_magic_numbers(fresh.rookH, RookMagicsH);
-      snapshot_magic_numbers(fresh.rookV, RookMagicsV);
-      snapshot_magic_numbers(fresh.bishop, BishopMagics);
-      snapshot_magic_numbers(fresh.cannonH, CannonMagicsH);
-      snapshot_magic_numbers(fresh.cannonV, CannonMagicsV);
-      snapshot_magic_numbers(fresh.horse, HorseMagics);
-      snapshot_magic_numbers(fresh.janggiElephant, JanggiElephantMagics);
-      snapshot_magic_numbers(fresh.cannonDiag, CannonDiagMagics);
-      snapshot_magic_numbers(fresh.nightrider, NightriderMagics);
-      snapshot_magic_numbers(fresh.grasshopperH, GrasshopperMagicsH);
-      snapshot_magic_numbers(fresh.grasshopperV, GrasshopperMagicsV);
-      snapshot_magic_numbers(fresh.grasshopperD, GrasshopperMagicsD);
-      MagicByBoardSize.emplace(boardKey, std::move(fresh));
-      MagicCacheLru.push_back(boardKey);
-  }
+#ifdef PRECOMPUTED_MAGICS
+  init_magic_table<RIDER>(mg->RookTableH.data(), mg->RookMagicsH, RookDirectionsH, maxFile, maxRank, RookMagicHInit);
+  init_magic_table<RIDER>(mg->RookTableV.data(), mg->RookMagicsV, RookDirectionsV, maxFile, maxRank, RookMagicVInit);
+  init_magic_table<RIDER>(mg->BishopTable.data(), mg->BishopMagics, BishopDirections, maxFile, maxRank, BishopMagicInit);
+  init_magic_table<HOPPER>(mg->CannonTableH.data(), mg->CannonMagicsH, RookDirectionsH, maxFile, maxRank, CannonMagicHInit);
+  init_magic_table<HOPPER>(mg->CannonTableV.data(), mg->CannonMagicsV, RookDirectionsV, maxFile, maxRank, CannonMagicVInit);
+  init_magic_table<LAME_LEAPER>(mg->HorseTable.data(), mg->HorseMagics, HorseDirections, maxFile, maxRank, HorseMagicInit);
+  init_magic_table<LAME_LEAPER>(mg->JanggiElephantTable.data(), mg->JanggiElephantMagics, JanggiElephantDirections, maxFile, maxRank, JanggiElephantMagicInit);
+  init_magic_table<HOPPER>(mg->CannonDiagTable.data(), mg->CannonDiagMagics, BishopDirections, maxFile, maxRank, CannonDiagMagicInit);
+  init_magic_table<RIDER, true>(mg->NightriderTable.data(), mg->NightriderMagics, HorseDirections, maxFile, maxRank, NightriderMagicInit);
+  init_magic_table<HOPPER>(mg->GrasshopperTableH.data(), mg->GrasshopperMagicsH, GrasshopperDirectionsH, maxFile, maxRank, GrasshopperMagicHInit);
+  init_magic_table<HOPPER>(mg->GrasshopperTableV.data(), mg->GrasshopperMagicsV, GrasshopperDirectionsV, maxFile, maxRank, GrasshopperMagicVInit);
+  init_magic_table<HOPPER>(mg->GrasshopperTableD.data(), mg->GrasshopperMagicsD, GrasshopperDirectionsD, maxFile, maxRank, GrasshopperMagicDInit);
+#else
+  init_magic_table<RIDER>(mg->RookTableH.data(), mg->RookMagicsH, RookDirectionsH, maxFile, maxRank, nullptr);
+  init_magic_table<RIDER>(mg->RookTableV.data(), mg->RookMagicsV, RookDirectionsV, maxFile, maxRank, nullptr);
+  init_magic_table<RIDER>(mg->BishopTable.data(), mg->BishopMagics, BishopDirections, maxFile, maxRank, nullptr);
+  init_magic_table<HOPPER>(mg->CannonTableH.data(), mg->CannonMagicsH, RookDirectionsH, maxFile, maxRank, nullptr);
+  init_magic_table<HOPPER>(mg->CannonTableV.data(), mg->CannonMagicsV, RookDirectionsV, maxFile, maxRank, nullptr);
+  init_magic_table<LAME_LEAPER>(mg->HorseTable.data(), mg->HorseMagics, HorseDirections, maxFile, maxRank, nullptr);
+  init_magic_table<LAME_LEAPER>(mg->JanggiElephantTable.data(), mg->JanggiElephantMagics, JanggiElephantDirections, maxFile, maxRank, nullptr);
+  init_magic_table<HOPPER>(mg->CannonDiagTable.data(), mg->CannonDiagMagics, BishopDirections, maxFile, maxRank, nullptr);
+  init_magic_table<RIDER, true>(mg->NightriderTable.data(), mg->NightriderMagics, HorseDirections, maxFile, maxRank, nullptr);
+  init_magic_table<HOPPER>(mg->GrasshopperTableH.data(), mg->GrasshopperMagicsH, GrasshopperDirectionsH, maxFile, maxRank, nullptr);
+  init_magic_table<HOPPER>(mg->GrasshopperTableV.data(), mg->GrasshopperMagicsV, GrasshopperDirectionsV, maxFile, maxRank, nullptr);
+  init_magic_table<HOPPER>(mg->GrasshopperTableD.data(), mg->GrasshopperMagicsD, GrasshopperDirectionsD, maxFile, maxRank, nullptr);
+#endif
 
-  CurrentMagicBoardKey.store(boardKey, std::memory_order_relaxed);
-  MagicsInitialized.store(true, std::memory_order_release);
+  if (MagicByBoardSize.size() >= MAX_MAGIC_CACHE_ENTRIES && !MagicCacheLru.empty())
+  {
+      MagicByBoardSize.erase(MagicCacheLru.front());
+      MagicCacheLru.erase(MagicCacheLru.begin());
+  }
+  MagicByBoardSize.emplace(boardKey, mg);
+  MagicCacheLru.push_back(boardKey);
+
+  current_magic_geometry = mg.get();
+  return mg;
 #else
   (void) maxFile;
   (void) maxRank;
+  return nullptr;
 #endif
 }
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -22,10 +22,87 @@
 #include <array>
 #include <utility>
 #include <string>
+#include <vector>
+#include <memory>
 
 #include "types.h"
 
 namespace Stockfish {
+
+/// Magic holds all magic bitboards relevant data for a single square
+struct Magic {
+  Bitboard  mask;
+  Bitboard  magic;
+  Bitboard* attacks;
+  unsigned  shift;
+
+  // Compute the attack's index using the 'magic bitboards' approach
+  unsigned index(Bitboard occupied) const {
+
+    if (HasPext)
+        return unsigned(pext(occupied, mask));
+
+#ifdef LARGEBOARDS
+    return unsigned(((occupied & mask) * magic) >> shift);
+#else
+    if (Is64Bit)
+        return unsigned(((occupied & mask) * magic) >> shift);
+
+    unsigned lo = unsigned(occupied) & unsigned(mask);
+    unsigned hi = unsigned(occupied >> 32) & unsigned(mask >> 32);
+    return (lo * unsigned(magic) ^ hi * unsigned(magic >> 32)) >> shift;
+#endif
+  }
+};
+
+struct MagicGeometry {
+  Magic RookMagicsH[SQUARE_NB];
+  Magic RookMagicsV[SQUARE_NB];
+  Magic BishopMagics[SQUARE_NB];
+  Magic CannonMagicsH[SQUARE_NB];
+  Magic CannonMagicsV[SQUARE_NB];
+  Magic HorseMagics[SQUARE_NB];
+  Magic JanggiElephantMagics[SQUARE_NB];
+  Magic CannonDiagMagics[SQUARE_NB];
+  Magic NightriderMagics[SQUARE_NB];
+  Magic GrasshopperMagicsH[SQUARE_NB];
+  Magic GrasshopperMagicsV[SQUARE_NB];
+  Magic GrasshopperMagicsD[SQUARE_NB];
+
+  std::vector<Bitboard> RookTableH;
+  std::vector<Bitboard> RookTableV;
+  std::vector<Bitboard> BishopTable;
+  std::vector<Bitboard> CannonTableH;
+  std::vector<Bitboard> CannonTableV;
+  std::vector<Bitboard> HorseTable;
+  std::vector<Bitboard> JanggiElephantTable;
+  std::vector<Bitboard> CannonDiagTable;
+  std::vector<Bitboard> NightriderTable;
+  std::vector<Bitboard> GrasshopperTableH;
+  std::vector<Bitboard> GrasshopperTableV;
+  std::vector<Bitboard> GrasshopperTableD;
+
+  Magic* magics[14];
+
+  MagicGeometry() {
+    magics[0] = BishopMagics;
+    magics[1] = RookMagicsH;
+    magics[2] = RookMagicsV;
+    magics[3] = CannonMagicsH;
+    magics[4] = CannonMagicsV;
+    magics[5] = BishopMagics;
+    magics[6] = HorseMagics;
+    magics[7] = BishopMagics;
+    magics[8] = JanggiElephantMagics;
+    magics[9] = CannonDiagMagics;
+    magics[10] = NightriderMagics;
+    magics[11] = GrasshopperMagicsH;
+    magics[12] = GrasshopperMagicsV;
+    magics[13] = GrasshopperMagicsD;
+  }
+};
+
+extern thread_local const MagicGeometry* current_magic_geometry;
 
 namespace Bitbases {
 
@@ -37,7 +114,7 @@ bool probe(Square wksq, Square wpsq, Square bksq, Color us);
 namespace Bitboards {
 
 void init_pieces();
-void init_magics(File maxFile, Rank maxRank);
+std::shared_ptr<const MagicGeometry> init_magics(File maxFile, Rank maxRank);
 void init();
 std::string pretty(Bitboard b);
 
@@ -145,47 +222,6 @@ constexpr std::array<std::pair<int, int>, 8> RoseSteps = {{
 int popcount(Bitboard b); // required for 128 bit pext
 #endif
 
-/// Magic holds all magic bitboards relevant data for a single square
-struct Magic {
-  Bitboard  mask;
-  Bitboard  magic;
-  Bitboard* attacks;
-  unsigned  shift;
-
-  // Compute the attack's index using the 'magic bitboards' approach
-  unsigned index(Bitboard occupied) const {
-
-    if (HasPext)
-        return unsigned(pext(occupied, mask));
-
-#ifdef LARGEBOARDS
-    return unsigned(((occupied & mask) * magic) >> shift);
-#else
-    if (Is64Bit)
-        return unsigned(((occupied & mask) * magic) >> shift);
-#endif
-
-    unsigned lo = unsigned(occupied) & unsigned(mask);
-    unsigned hi = unsigned(occupied >> 32) & unsigned(mask >> 32);
-    return (lo * unsigned(magic) ^ hi * unsigned(magic >> 32)) >> shift;
-  }
-};
-
-extern Magic RookMagicsH[SQUARE_NB];
-extern Magic RookMagicsV[SQUARE_NB];
-extern Magic BishopMagics[SQUARE_NB];
-extern Magic CannonMagicsH[SQUARE_NB];
-extern Magic CannonMagicsV[SQUARE_NB];
-extern Magic HorseMagics[SQUARE_NB];
-extern Magic JanggiElephantMagics[SQUARE_NB];
-extern Magic CannonDiagMagics[SQUARE_NB];
-extern Magic NightriderMagics[SQUARE_NB];
-extern Magic GrasshopperMagicsH[SQUARE_NB];
-extern Magic GrasshopperMagicsV[SQUARE_NB];
-extern Magic GrasshopperMagicsD[SQUARE_NB];
-
-extern Magic* magics[];
-
 constexpr Bitboard make_bitboard() { return 0; }
 
 template<typename ...Squares>
@@ -269,7 +305,7 @@ inline Bitboard safe_destination_tuple_bb(Square s, int dr, int df) {
   return square_bb(make_square(File(f), Rank(r)));
 }
 
-inline Bitboard rose_attacks_bb(Square from, Bitboard occupied) {
+inline Bitboard rose_attacks_bb(Square from, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
   Bitboard attack = 0;
 
   for (int start = 0; start < 8; ++start)
@@ -870,7 +906,8 @@ inline Bitboard rider_attacks_bb(Square s, Bitboard occupied) {
 
 inline Square lsb(Bitboard b);
 #else
-inline Bitboard fixed_step_rider_attacks(Square s, Bitboard occupied, int stepF, int stepR) {
+inline Bitboard fixed_step_rider_attacks(Square s, Bitboard occupied, int stepF, int stepR, const MagicGeometry* mg = current_magic_geometry) {
+  (void)mg;
   Bitboard attack = 0;
   int f = int(file_of(s));
   int r = int(rank_of(s));
@@ -890,7 +927,8 @@ inline Bitboard fixed_step_rider_attacks(Square s, Bitboard occupied, int stepF,
   return attack;
 }
 
-inline Bitboard ski_slider_attacks(Square s, Bitboard occupied, int stepF, int stepR) {
+inline Bitboard ski_slider_attacks(Square s, Bitboard occupied, int stepF, int stepR, const MagicGeometry* mg = current_magic_geometry) {
+  (void)mg;
   int f = int(file_of(s)) + stepF;
   int r = int(rank_of(s)) + stepR;
   if (f < int(FILE_A) || f > int(FILE_MAX) || r < int(RANK_1) || r > int(RANK_MAX))
@@ -912,7 +950,7 @@ inline Bitboard ski_slider_attacks(Square s, Bitboard occupied, int stepF, int s
 }
 
 template<RiderType R>
-inline Bitboard rider_attacks_bb(Square s, Bitboard occupied) {
+inline Bitboard rider_attacks_bb(Square s, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
 
   static_assert(R != NO_RIDER && !(R & (R - 1))); // exactly one bit
   if constexpr (R == RIDER_GRIFFON_NH || R == RIDER_GRIFFON_SH || R == RIDER_GRIFFON_EV || R == RIDER_GRIFFON_WV) {
@@ -995,26 +1033,26 @@ inline Bitboard rider_attacks_bb(Square s, Bitboard occupied) {
   if constexpr (R == RIDER_ROSE)
       return rose_attacks_bb(s, occupied);
 
-  const Magic& m =  R == RIDER_ROOK_H ? RookMagicsH[s]
-                  : R == RIDER_ROOK_V ? RookMagicsV[s]
-                  : R == RIDER_CANNON_H ? CannonMagicsH[s]
-                  : R == RIDER_CANNON_V ? CannonMagicsV[s]
-                  : R == RIDER_LAME_DABBABA ? BishopMagics[s]
-                  : R == RIDER_HORSE ? HorseMagics[s]
-                  : R == RIDER_ELEPHANT ? BishopMagics[s]
-                  : R == RIDER_JANGGI_ELEPHANT ? JanggiElephantMagics[s]
-                  : R == RIDER_CANNON_DIAG ? CannonDiagMagics[s]
-                  : R == RIDER_NIGHTRIDER ? NightriderMagics[s]
-                  : R == RIDER_GRASSHOPPER_H ? GrasshopperMagicsH[s]
-                  : R == RIDER_GRASSHOPPER_V ? GrasshopperMagicsV[s]
-                  : R == RIDER_GRASSHOPPER_D ? GrasshopperMagicsD[s]
-                  : BishopMagics[s];
+  const Magic& m =  R == RIDER_ROOK_H ? mg->RookMagicsH[s]
+                  : R == RIDER_ROOK_V ? mg->RookMagicsV[s]
+                  : R == RIDER_CANNON_H ? mg->CannonMagicsH[s]
+                  : R == RIDER_CANNON_V ? mg->CannonMagicsV[s]
+                  : R == RIDER_LAME_DABBABA ? mg->BishopMagics[s]
+                  : R == RIDER_HORSE ? mg->HorseMagics[s]
+                  : R == RIDER_ELEPHANT ? mg->BishopMagics[s]
+                  : R == RIDER_JANGGI_ELEPHANT ? mg->JanggiElephantMagics[s]
+                  : R == RIDER_CANNON_DIAG ? mg->CannonDiagMagics[s]
+                  : R == RIDER_NIGHTRIDER ? mg->NightriderMagics[s]
+                  : R == RIDER_GRASSHOPPER_H ? mg->GrasshopperMagicsH[s]
+                  : R == RIDER_GRASSHOPPER_V ? mg->GrasshopperMagicsV[s]
+                  : R == RIDER_GRASSHOPPER_D ? mg->GrasshopperMagicsD[s]
+                  : mg->BishopMagics[s];
   return m.attacks[m.index(occupied)];
 }
 
 inline Square lsb(Bitboard b);
 
-inline Bitboard rider_attacks_bb(RiderType R, Square s, Bitboard occupied) {
+inline Bitboard rider_attacks_bb(RiderType R, Square s, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
 
   assert(R != NO_RIDER && !(R & (R - 1))); // exactly one bit
   if (R == RIDER_LAME_DABBABA)
@@ -1040,15 +1078,15 @@ inline Bitboard rider_attacks_bb(RiderType R, Square s, Bitboard occupied) {
             | ski_slider_attacks(s, occupied, -1, -1);
   if (R == RIDER_ROSE)
       return rose_attacks_bb(s, occupied);
-  if (R == RIDER_GRIFFON_NH) return rider_attacks_bb<RIDER_GRIFFON_NH>(s, occupied);
-  if (R == RIDER_GRIFFON_SH) return rider_attacks_bb<RIDER_GRIFFON_SH>(s, occupied);
-  if (R == RIDER_GRIFFON_EV) return rider_attacks_bb<RIDER_GRIFFON_EV>(s, occupied);
-  if (R == RIDER_GRIFFON_WV) return rider_attacks_bb<RIDER_GRIFFON_WV>(s, occupied);
-  if (R == RIDER_MANTICORE_NE) return rider_attacks_bb<RIDER_MANTICORE_NE>(s, occupied);
-  if (R == RIDER_MANTICORE_NW) return rider_attacks_bb<RIDER_MANTICORE_NW>(s, occupied);
-  if (R == RIDER_MANTICORE_SE) return rider_attacks_bb<RIDER_MANTICORE_SE>(s, occupied);
-  if (R == RIDER_MANTICORE_SW) return rider_attacks_bb<RIDER_MANTICORE_SW>(s, occupied);
-  const Magic& m = magics[lsb(R)][s]; // re-use Bitboard lsb for riders
+  if (R == RIDER_GRIFFON_NH) return rider_attacks_bb<RIDER_GRIFFON_NH>(s, occupied, mg);
+  if (R == RIDER_GRIFFON_SH) return rider_attacks_bb<RIDER_GRIFFON_SH>(s, occupied, mg);
+  if (R == RIDER_GRIFFON_EV) return rider_attacks_bb<RIDER_GRIFFON_EV>(s, occupied, mg);
+  if (R == RIDER_GRIFFON_WV) return rider_attacks_bb<RIDER_GRIFFON_WV>(s, occupied, mg);
+  if (R == RIDER_MANTICORE_NE) return rider_attacks_bb<RIDER_MANTICORE_NE>(s, occupied, mg);
+  if (R == RIDER_MANTICORE_NW) return rider_attacks_bb<RIDER_MANTICORE_NW>(s, occupied, mg);
+  if (R == RIDER_MANTICORE_SE) return rider_attacks_bb<RIDER_MANTICORE_SE>(s, occupied, mg);
+  if (R == RIDER_MANTICORE_SW) return rider_attacks_bb<RIDER_MANTICORE_SW>(s, occupied, mg);
+  const Magic& m = mg->magics[lsb(R)][s]; // re-use Bitboard lsb for riders
   return m.attacks[m.index(occupied)];
 }
 #endif
@@ -1071,15 +1109,15 @@ inline Bitboard attacks_bb(Square s) {
 /// Sliding piece attacks do not continue past an occupied square.
 
 template<PieceType Pt>
-inline Bitboard attacks_bb(Square s, Bitboard occupied) {
+inline Bitboard attacks_bb(Square s, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
 
   assert((Pt != PAWN) && (is_ok(s)));
 
   switch (Pt)
   {
-  case BISHOP: return rider_attacks_bb<RIDER_BISHOP>(s, occupied);
-  case ROOK  : return rider_attacks_bb<RIDER_ROOK_H>(s, occupied) | rider_attacks_bb<RIDER_ROOK_V>(s, occupied);
-  case QUEEN : return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
+  case BISHOP: return rider_attacks_bb<RIDER_BISHOP>(s, occupied, mg);
+  case ROOK  : return rider_attacks_bb<RIDER_ROOK_H>(s, occupied, mg) | rider_attacks_bb<RIDER_ROOK_V>(s, occupied, mg);
+  case QUEEN : return attacks_bb<BISHOP>(s, occupied, mg) | attacks_bb<ROOK>(s, occupied, mg);
   default    : return PseudoAttacks[WHITE][Pt][s];
   }
 }
@@ -1093,12 +1131,12 @@ inline RiderType pop_rider(RiderType& r) {
   return r2;
 }
 
-inline Bitboard attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
+inline Bitboard attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
   assert(pt != NO_PIECE_TYPE);
   Bitboard b = LeaperAttacks[c][pt][s];
   RiderType r = AttackRiderTypes[pt];
   while (r)
-      b |= rider_attacks_bb(pop_rider(r), s, occupied);
+      b |= rider_attacks_bb(pop_rider(r), s, occupied, mg);
   b |= leap_rider_attacks_bb(pt, c, s, occupied);
   b |= tuple_rider_attacks_bb(pt, c, s, occupied);
   return b & PseudoAttacks[c][pt][s];
@@ -1106,12 +1144,12 @@ inline Bitboard attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
 
 
 template <bool Initial=false>
-inline Bitboard moves_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
+inline Bitboard moves_bb(Color c, PieceType pt, Square s, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
   assert(pt != NO_PIECE_TYPE);
   Bitboard b = LeaperMoves[Initial][c][pt][s];
   RiderType r = MoveRiderTypes[Initial][pt];
   while (r)
-      b |= rider_attacks_bb(pop_rider(r), s, occupied);
+      b |= rider_attacks_bb(pop_rider(r), s, occupied, mg);
   b |= leap_rider_moves_bb(pt, Initial, c, s, occupied);
   b |= tuple_rider_moves_bb(pt, Initial, c, s, occupied);
   return b & PseudoMoves[Initial][c][pt][s];

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -305,7 +305,7 @@ inline Bitboard safe_destination_tuple_bb(Square s, int dr, int df) {
   return square_bb(make_square(File(f), Rank(r)));
 }
 
-inline Bitboard rose_attacks_bb(Square from, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
+inline Bitboard rose_attacks_bb(Square from, Bitboard occupied, const MagicGeometry* /*mg*/ = current_magic_geometry) {
   Bitboard attack = 0;
 
   for (int start = 0; start < 8; ++start)

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -674,7 +674,7 @@ ScaleFactor Endgame<KQKRPs>::operator()(const Position& pos) const {
       &&  relative_rank(weakSide, strongKing, pos.max_rank()) >= RANK_4
       &&  relative_rank(weakSide,   weakRook, pos.max_rank()) == RANK_3
       && (  pos.pieces(weakSide, PAWN)
-          & attacks_bb<KING>(weakKing)
+          & pos.attacks_bb<KING>(weakKing)
           & pawn_attacks_bb(strongSide, weakRook)))
           return SCALE_FACTOR_DRAW;
 
@@ -825,7 +825,7 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
       // the corner
       if (   pawnRank == RANK_6
           && distance(strongPawn + 2 * push, weakKing) <= 1
-          && (attacks_bb<BISHOP>(weakBishop) & (strongPawn + push))
+          && (pos.attacks_bb<BISHOP>(weakBishop) & (strongPawn + push))
           && distance<File>(weakBishop, strongPawn) >= 2)
           return ScaleFactor(8);
   }
@@ -965,14 +965,14 @@ ScaleFactor Endgame<KBPPKB>::operator()(const Position& pos) const {
     if (   weakKing == blockSq1
         && opposite_colors(weakKing, strongBishop)
         && (   weakBishop == blockSq2
-            || (attacks_bb<BISHOP>(blockSq2, pos.pieces()) & pos.pieces(weakSide, BISHOP))
+            || (pos.attacks_bb<BISHOP>(blockSq2, pos.pieces()) & pos.pieces(weakSide, BISHOP))
             || distance<Rank>(strongPawn1, strongPawn2) >= 2))
         return SCALE_FACTOR_DRAW;
 
     else if (   weakKing == blockSq2
              && opposite_colors(weakKing, strongBishop)
              && (   weakBishop == blockSq1
-                 || (attacks_bb<BISHOP>(blockSq1, pos.pieces()) & pos.pieces(weakSide, BISHOP))))
+                 || (pos.attacks_bb<BISHOP>(blockSq1, pos.pieces()) & pos.pieces(weakSide, BISHOP))))
         return SCALE_FACTOR_DRAW;
     else
         return SCALE_FACTOR_NONE;
@@ -1079,8 +1079,8 @@ Value Endgame<KN, EG_EVAL_ANTI>::operator()(const Position& pos) const {
 
   Square KSq = pos.square<COMMONER>(strongSide);
   Square NSq = pos.square<KNIGHT>(weakSide);
-  Bitboard kingAttacks = attacks_bb<KING>(KSq) & pos.board_bb();
-  Bitboard knightAttacks = attacks_bb<KNIGHT>(NSq) & pos.board_bb();
+  Bitboard kingAttacks = pos.attacks_bb<KING>(KSq) & pos.board_bb();
+  Bitboard knightAttacks = pos.attacks_bb<KNIGHT>(NSq) & pos.board_bb();
   bool strongSideToMove = pos.side_to_move() == strongSide;
 
   // Loss in 1 play
@@ -1188,7 +1188,7 @@ Value Endgame<KQK, EG_EVAL_ATOMIC>::operator()(const Position& pos) const {
       return VALUE_DRAW;
   // If the weaker side is to move and there is a way to connect kings, it is a draw
   if (   pos.side_to_move() == weakSide
-      && (attacks_bb<KING>(winnerKSq) & attacks_bb<KING>(loserKSq) & ~pos.pieces()))
+      && (pos.attacks_bb<KING>(winnerKSq) & pos.attacks_bb<KING>(loserKSq) & ~pos.pieces()))
       return VALUE_DRAW;
 
   Value result =  Value(push_to_edge(loserKSq, pos))
@@ -1317,7 +1317,7 @@ Value Endgame<KQK, EG_EVAL_RK>::operator()(const Position& pos) const {
 
   if (   rank_of(weakKing) < rank_of(strongQueen)
       || rank_of(weakKing) + (weakSide == pos.side_to_move()) < penultimate
-      || (goalRank & attacks_bb<QUEEN>(strongQueen, pos.pieces()) & ~(attacks_bb<QUEEN>(weakKing) | attacks_bb<SHOGI_KNIGHT>(weakKing))))
+      || (goalRank & pos.attacks_bb<QUEEN>(strongQueen, pos.pieces()) & ~(pos.attacks_bb<QUEEN>(weakKing) | pos.attacks_bb<SHOGI_KNIGHT>(weakKing))))
       result = VALUE_KNOWN_WIN + 100 * rank_of(strongKing);
   else
       result = -VALUE_KNOWN_WIN;
@@ -1339,7 +1339,7 @@ Value Endgame<KRK, EG_EVAL_RK>::operator()(const Position& pos) const {
 
   if (   rank_of(weakKing) < rank_of(strongRook)
       || rank_of(weakKing) + (weakSide == pos.side_to_move()) < penultimate
-      || (goalRank & attacks_bb<ROOK>(strongRook, pos.pieces()) & ~(attacks_bb<QUEEN>(weakKing) | attacks_bb<SHOGI_KNIGHT>(weakKing))))
+      || (goalRank & pos.attacks_bb<ROOK>(strongRook, pos.pieces()) & ~(pos.attacks_bb<QUEEN>(weakKing) | pos.attacks_bb<SHOGI_KNIGHT>(weakKing))))
       result = VALUE_KNOWN_WIN + 100 * rank_of(strongKing);
   else
       result = -VALUE_KNOWN_WIN;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -608,7 +608,7 @@ namespace {
             rankLo = rankHi = pos.max_rank();
         Square s = make_square(std::clamp(file_of(ksq), fileLo, fileHi),
                                std::clamp(rank_of(ksq), rankLo, rankHi));
-        kingRing[Us] = attacks_bb<KING>(s) | s;
+        kingRing[Us] = pos.attacks_bb<KING>(s) | s;
     }
 
     kingAttackersCount[Them] = popcount(kingRing[Us] & (pe->pawn_attacks(Them) | shift<Down>(pos.pieces(Them, SHOGI_PAWN))));
@@ -644,8 +644,8 @@ namespace {
         Square s = pop_lsb(b1);
 
         // Find attacked squares, including x-ray attacks for bishops and rooks
-        b = Pt == BISHOP ? attacks_bb<BISHOP>(s, pos.pieces() ^ pos.pieces(QUEEN))
-          : Pt ==   ROOK && !pos.diagonal_lines() ? attacks_bb<  ROOK>(s, pos.pieces() ^ pos.pieces(QUEEN) ^ pos.pieces(Us, ROOK))
+        b = Pt == BISHOP ? pos.attacks_bb<BISHOP>(s, pos.pieces() ^ pos.pieces(QUEEN))
+          : Pt ==   ROOK && !pos.diagonal_lines() ? pos.attacks_bb<  ROOK>(s, pos.pieces() ^ pos.pieces(QUEEN) ^ pos.pieces(Us, ROOK))
                          : pos.attacks_from(Us, Pt, s);
 
         // Restrict mobility to actual squares of board
@@ -668,7 +668,7 @@ namespace {
         else if (Pt == ROOK && (file_bb(s) & kingRing[Them]))
             score += RookOnKingRing;
 
-        else if (Pt == BISHOP && (attacks_bb<BISHOP>(s, pos.pieces(PAWN)) & kingRing[Them]))
+        else if (Pt == BISHOP && (pos.attacks_bb<BISHOP>(s, pos.pieces(PAWN)) & kingRing[Them]))
             score += BishopOnKingRing;
 
         if (Pt > QUEEN)
@@ -762,10 +762,10 @@ namespace {
                                      * (!(attackedBy[Us][PAWN] & s) + popcount(blocked & centerFiles));
 
                 // Penalty for all enemy pawns x-rayed
-                score -= BishopXRayPawns * popcount(attacks_bb<BISHOP>(s) & pos.pieces(Them, PAWN));
+                score -= BishopXRayPawns * popcount(pos.attacks_bb<BISHOP>(s) & pos.pieces(Them, PAWN));
 
                 // Bonus for bishop on a long diagonal which can "see" both center squares
-                if (more_than_one(attacks_bb<BISHOP>(s, pos.pieces(PAWN)) & scaled_center_squares(pos)))
+                if (more_than_one(pos.attacks_bb<BISHOP>(s, pos.pieces(PAWN)) & scaled_center_squares(pos)))
                     score += LongDiagonalBishop;
 
                 // An important Chess960 pattern: a cornered bishop blocked by a friendly
@@ -919,8 +919,8 @@ namespace {
     if (!pos.check_counting() || pos.checks_remaining(Them) > 1)
     safe &= ~attackedBy[Us][ALL_PIECES] | (weak & attackedBy2[Them]);
 
-    b1 = attacks_bb<ROOK  >(ksq, pos.pieces() ^ pos.pieces(Us, QUEEN));
-    b2 = attacks_bb<BISHOP>(ksq, pos.pieces() ^ pos.pieces(Us, QUEEN));
+    b1 = pos.attacks_bb<ROOK  >(ksq, pos.pieces() ^ pos.pieces(Us, QUEEN));
+    b2 = pos.attacks_bb<BISHOP>(ksq, pos.pieces() ^ pos.pieces(Us, QUEEN));
 
     std::function <Bitboard (Color, PieceType)> get_attacks = [this](Color c, PieceType pt) {
         return attackedBy[c][pt] | (pos.piece_drops() && pos.count_in_hand(c, pt) > 0 ? pos.drop_region(c, pt) & ~pos.pieces() : Bitboard(0));
@@ -946,7 +946,7 @@ namespace {
         case ROOK:
         case BISHOP:
         case KNIGHT:
-            knightChecks = attacks_bb(Us, pt, ksq, pos.pieces() ^ pos.pieces(Us, QUEEN)) & get_attacks(Them, pt) & pos.board_bb();
+            knightChecks = pos.attacks_bb(Us, pt, ksq, pos.pieces() ^ pos.pieces(Us, QUEEN)) & get_attacks(Them, pt) & pos.board_bb();
             if (knightChecks & safe)
                 kingDanger += SafeCheck[pt][more_than_one(knightChecks & safe)];
             else
@@ -955,7 +955,7 @@ namespace {
         case PAWN:
             if (pos.piece_drops() && pos.count_in_hand(Them, pt) > 0)
             {
-                pawnChecks = attacks_bb(Us, pt, ksq, pos.pieces()) & ~pos.pieces() & pos.board_bb();
+                pawnChecks = pos.attacks_bb(Us, pt, ksq, pos.pieces()) & ~pos.pieces() & pos.board_bb();
                 if (pawnChecks & safe)
                     kingDanger += SafeCheck[PAWN][more_than_one(pawnChecks & safe)];
                 else
@@ -965,7 +965,7 @@ namespace {
         case SHOGI_PAWN:
             if (pos.promoted_piece_type(pt))
             {
-                otherChecks = attacks_bb(Us, pos.promoted_piece_type(pt), ksq, pos.pieces()) & attackedBy[Them][pt]
+                otherChecks = pos.attacks_bb(Us, pos.promoted_piece_type(pt), ksq, pos.pieces()) & attackedBy[Them][pt]
                                  & pos.promotion_zone(Them, pt) & pos.board_bb();
                 if (otherChecks & safe)
                     kingDanger += SafeCheck[FAIRY_PIECES][more_than_one(otherChecks & safe)];
@@ -976,7 +976,7 @@ namespace {
         case KING:
             break;
         default:
-            otherChecks = attacks_bb(Us, pt, ksq, pos.pieces()) & get_attacks(Them, pt) & pos.board_bb();
+            otherChecks = pos.attacks_bb(Us, pt, ksq, pos.pieces()) & get_attacks(Them, pt) & pos.board_bb();
             if (otherChecks & safe)
                 kingDanger += SafeCheck[FAIRY_PIECES][more_than_one(otherChecks & safe)];
             else
@@ -990,7 +990,7 @@ namespace {
         for (PieceSet ps = pos.piece_types(); ps;)
         {
             PieceType pt = pop_lsb(ps);
-            if (pos.count_in_hand(Them, pt) <= 0 && (attacks_bb(Us, pt, ksq, pos.pieces()) & safe & pos.drop_region(Them, pt) & ~pos.pieces()))
+            if (pos.count_in_hand(Them, pt) <= 0 && (pos.attacks_bb(Us, pt, ksq, pos.pieces()) & safe & pos.drop_region(Them, pt) & ~pos.pieces()))
             {
                 kingDanger += VirtualCheck * 500 / (500 + EvalPieceValue[MG][pt]);
                 // Presumably a mate threat
@@ -1197,12 +1197,12 @@ namespace {
               & ~pos.pieces(Us, PAWN)
               & ~stronglyProtected;
 
-        b = attackedBy[Us][KNIGHT] & attacks_bb<KNIGHT>(s);
+        b = attackedBy[Us][KNIGHT] & pos.attacks_bb<KNIGHT>(s);
 
         score += KnightOnQueen * popcount(b & safe) * (1 + queenImbalance);
 
-        b =  (attackedBy[Us][BISHOP] & attacks_bb<BISHOP>(s, pos.pieces()))
-           | (attackedBy[Us][ROOK  ] & attacks_bb<ROOK  >(s, pos.pieces()));
+        b =  (attackedBy[Us][BISHOP] & pos.attacks_bb<BISHOP>(s, pos.pieces()))
+           | (attackedBy[Us][ROOK  ] & pos.attacks_bb<ROOK  >(s, pos.pieces()));
 
         score += SliderOnQueen * popcount(b & safe & attackedBy2[Us]) * (1 + queenImbalance);
     }
@@ -1678,7 +1678,7 @@ namespace {
             Bitboard edgePieces = pos.pieces(Us) & edges;
             while (edgePieces)
             {
-                Bitboard connectedEdge = attacks_bb(Us, ROOK, pop_lsb(edgePieces), ~(pos.pieces(Us) & edges)) & edges;
+                Bitboard connectedEdge = pos.attacks_bb(Us, ROOK, pop_lsb(edgePieces), ~(pos.pieces(Us) & edges)) & edges;
                 if (!more_than_one(connectedEdge & ~pos.pieces(Us)))
                     score += make_score(300, 300);
                 else if (!(connectedEdge & ~pos.pieces()))
@@ -1694,7 +1694,7 @@ namespace {
             Square s = pop_lsb(drops);
             if (pos.flip_enclosed_pieces() == REVERSI)
             {
-                Bitboard b = attacks_bb(Them, QUEEN, s, ~pos.pieces(Us)) & ~PseudoAttacks[Them][KING][s] & pos.pieces(Them);
+                Bitboard b = pos.attacks_bb(Them, QUEEN, s, ~pos.pieces(Us)) & ~PseudoAttacks[Them][KING][s] & pos.pieces(Them);
                 while(b)
                     unstable |= between_bb(s, pop_lsb(b));
             }
@@ -1799,7 +1799,7 @@ namespace {
                 && pos.count<PAWN>(strongSide) - pos.count<PAWN>(~strongSide) <= 1
                 && bool(kingFlank & pos.pieces(strongSide, PAWN)) != bool(queenFlank & pos.pieces(strongSide, PAWN))
                 && pos.count<KING>(~strongSide)
-                && (attacks_bb<KING>(pos.square<KING>(~strongSide)) & pos.pieces(~strongSide, PAWN)))
+                && (pos.attacks_bb<KING>(pos.square<KING>(~strongSide)) & pos.pieces(~strongSide, PAWN)))
             sf = 36;
         // For queen vs no queen endgames use scale factor
         // based on number of minors of side that doesn't have queen.

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -617,7 +617,7 @@ namespace {
                 while (b)
                 {
                     Square to = pop_lsb(b);
-                    if (!(attacks_bb(Us, pt, to, pos.pieces() ^ from) & pos.pieces(Them)))
+                    if (!(pos.attacks_bb(Us, pt, to, pos.pieces() ^ from) & pos.pieces(Them)))
                         *moveList++ = make<PROMOTION>(from, to, pt);
                 }
             }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -518,14 +518,14 @@ namespace {
     return pos.attacks_from(c, pt, sq, syntheticOccupancy);
   }
 
-  Bitboard rose_revealed_blockers(Square target, Square attackerSq, Bitboard occupied) {
+  Bitboard rose_revealed_blockers(Square target, Square attackerSq, Bitboard occupied, const MagicGeometry* mg) {
     Bitboard blockers = 0;
     Bitboard candidates = rose_between_union_bb(target, attackerSq, Bitboard(0)) & occupied & ~square_bb(attackerSq);
 
     while (candidates)
     {
         Square blocker = pop_lsb(candidates);
-        if (rose_attacks_bb(attackerSq, occupied ^ square_bb(blocker)) & target)
+        if (rose_attacks_bb(attackerSq, occupied ^ square_bb(blocker), mg) & target)
             blockers |= blocker;
     }
 
@@ -1045,7 +1045,7 @@ void Position::init() {
       Piece pc = make_piece(c, pop_lsb(ps));
       for (Square s1 = SQ_A1; s1 <= SQ_MAX; ++s1)
           for (Square s2 = Square(s1 + 1); s2 <= SQ_MAX; ++s2)
-              if ((type_of(pc) != PAWN) && (attacks_bb(c, type_of(pc), s1, 0) & s2))
+              if ((type_of(pc) != PAWN) && (::Stockfish::attacks_bb(c, type_of(pc), s1, 0) & s2))
               {
                   Move move = make_move(s1, s2);
                   Key key = Zobrist::psq[pc][s1] ^ Zobrist::psq[pc][s2] ^ Zobrist::side;
@@ -1750,10 +1750,10 @@ void Position::set_check_info(StateInfo* si) const {
   {
       const bool hasKing = ksq != SQ_NONE;
       const Bitboard pawnAttacks = hasKing ? pawn_attacks_bb(~sideToMove, ksq) : Bitboard(0);
-      const Bitboard knightAttacks = hasKing ? attacks_bb<KNIGHT>(ksq) : Bitboard(0);
-      const Bitboard bishopAttacks = hasKing ? attacks_bb<BISHOP>(ksq, occupied) : Bitboard(0);
-      const Bitboard rookAttacks = hasKing ? attacks_bb<ROOK>(ksq, occupied) : Bitboard(0);
-      const Bitboard kingAttacks = hasKing ? attacks_bb<KING>(ksq) : Bitboard(0);
+      const Bitboard knightAttacks = hasKing ? this->attacks_bb<KNIGHT>(ksq) : Bitboard(0);
+      const Bitboard bishopAttacks = hasKing ? this->attacks_bb<BISHOP>(ksq, occupied) : Bitboard(0);
+      const Bitboard rookAttacks = hasKing ? this->attacks_bb<ROOK>(ksq, occupied) : Bitboard(0);
+      const Bitboard kingAttacks = hasKing ? this->attacks_bb<KING>(ksq) : Bitboard(0);
       const Bitboard queenAttacks = bishopAttacks | rookAttacks;
 
       si->checkSquares[PAWN] = pawnAttacks;
@@ -2339,7 +2339,7 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
     PieceType sniperType = type_of(sniper);
     if (AttackRiderTypes[sniperType] & RIDER_ROSE)
     {
-        Bitboard b = rose_revealed_blockers(s, sniperSq, occupancy);
+        Bitboard b = rose_revealed_blockers(s, sniperSq, occupancy, magic_geometry());
         if (b && !more_than_one(b))
             pinners |= pieces(c) & sniperSq;
         blockers |= b;

--- a/src/position.h
+++ b/src/position.h
@@ -498,6 +498,35 @@ public:
 
   CheckCount checks_remaining(Color c) const;
   MaterialCounting material_counting() const;
+
+  template<PieceType Pt>
+  Bitboard attacks_bb(Square s, Bitboard occupied = 0) const {
+    return Stockfish::attacks_bb<Pt>(s, occupied, magic_geometry());
+  }
+
+  template<RiderType R>
+  Bitboard rider_attacks_bb(Square s, Bitboard occupied = 0) const {
+    return Stockfish::rider_attacks_bb<R>(s, occupied, magic_geometry());
+  }
+
+  Bitboard rider_attacks_bb(RiderType R, Square s, Bitboard occupied = 0) const {
+    return Stockfish::rider_attacks_bb(R, s, occupied, magic_geometry());
+  }
+
+  Bitboard attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied) const {
+    return Stockfish::attacks_bb(c, pt, s, occupied, magic_geometry());
+  }
+
+  template <bool Initial=false>
+  Bitboard moves_bb(Color c, PieceType pt, Square s, Bitboard occupied) const {
+    return Stockfish::moves_bb<Initial>(c, pt, s, occupied, magic_geometry());
+  }
+
+  const MagicGeometry* magic_geometry() const {
+      if (!variant()->magicGeometry)
+          const_cast<Variant*>(variant())->magicGeometry = Stockfish::Bitboards::init_magics(variant()->maxFile, variant()->maxRank);
+      return variant()->magicGeometry.get();
+  }
   CountingRule counting_rule() const;
 
   // Variant-specific properties
@@ -3295,26 +3324,26 @@ inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s, Bitboard
           b = pawn_attacks_bb(c, s);
           break;
       case KNIGHT:
-          b = attacks_bb<KNIGHT>(s);
+          b = this->attacks_bb<KNIGHT>(s);
           break;
       case BISHOP:
-          b = attacks_bb<BISHOP>(s, occupancy);
+          b = this->attacks_bb<BISHOP>(s, occupancy);
           break;
       case ROOK:
-          b = attacks_bb<ROOK>(s, occupancy);
+          b = this->attacks_bb<ROOK>(s, occupancy);
           break;
       case QUEEN:
-          b = attacks_bb<BISHOP>(s, occupancy) | attacks_bb<ROOK>(s, occupancy);
+          b = this->attacks_bb<BISHOP>(s, occupancy) | this->attacks_bb<ROOK>(s, occupancy);
           break;
       case KING:
       case COMMONER:
-          b = attacks_bb<KING>(s);
+          b = this->attacks_bb<KING>(s);
           break;
       case ARCHBISHOP:
-          b = attacks_bb<BISHOP>(s, occupancy) | attacks_bb<KNIGHT>(s);
+          b = this->attacks_bb<BISHOP>(s, occupancy) | this->attacks_bb<KNIGHT>(s);
           break;
       case CHANCELLOR:
-          b = attacks_bb<ROOK>(s, occupancy) | attacks_bb<KNIGHT>(s);
+          b = this->attacks_bb<ROOK>(s, occupancy) | this->attacks_bb<KNIGHT>(s);
           break;
       case IMMOBILE_PIECE:
           b = Bitboard(0);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -70,8 +70,8 @@ std::set<string, UCI::CaseInsensitiveLess> standard_variants = {
 };
 
 void init_variant(const Variant* v) {
-    if (Options.count("DynamicMagicsByBoardSize") && bool(Options["DynamicMagicsByBoardSize"]))
-        Bitboards::init_magics(v->maxFile, v->maxRank);
+    if (!v->magicGeometry)
+        const_cast<Variant*>(v)->magicGeometry = Bitboards::init_magics(v->maxFile, v->maxRank);
     pieceMap.init(v);
     Bitboards::init_pieces();
 }

--- a/src/variant.h
+++ b/src/variant.h
@@ -309,6 +309,9 @@ struct Variant {
   int nFoldRule = 3;
   int nFoldRuleImmediate = 0;
   ColorSetting<Value> nFoldValue = ColorSetting<Value>(VALUE_DRAW);
+
+  std::shared_ptr<const MagicGeometry> magicGeometry;
+
   bool nFoldValueAbsolute = false;
   bool perpetualCheckIllegal = false;
   bool moveRepetitionIllegal = false;

--- a/tests/concurrent-variant-magics.sh
+++ b/tests/concurrent-variant-magics.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+error() {
+  echo "concurrent-variant-magics test failed on line $1"
+  [[ -n "${TMP_VARIANT_PATH:-}" ]] && rm -f "${TMP_VARIANT_PATH}"
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+ENGINE=${1:-./stockfish}
+
+TMP_VARIANT_PATH=$(mktemp /tmp/fsx-concurrent-magics-XXXXXX.ini)
+cat >"${TMP_VARIANT_PATH}" <<'INI'
+[v8x8:chess]
+maxFile = 8
+maxRank = 8
+
+[v6x6:chess]
+maxFile = 6
+maxRank = 6
+INI
+
+# We want to verify that after initializing a 6x6 variant, the 8x8 variant still works correctly
+# and its magic bitboards haven't been corrupted by the global state of the 6x6 variant.
+# One way to check is using 'd' command to see board representation or 'go perft' for move counts.
+# For 8x8 chess startpos, perft 1 is 20.
+# For 6x6 chess startpos (if it fits), let's see.
+
+out=$(cat <<CMDS | "${ENGINE}"
+uci
+setoption name VariantPath value ${TMP_VARIANT_PATH}
+setoption name UCI_Variant value v8x8
+position startpos
+go perft 1
+setoption name UCI_Variant value v6x6
+position startpos
+go perft 1
+setoption name UCI_Variant value v8x8
+position startpos
+go perft 1
+quit
+CMDS
+)
+
+# 8x8 startpos perft 1 is 20 moves
+# If magics were corrupted, it might give different results.
+echo "${out}"
+count8x8=$(echo "${out}" | grep "Nodes searched" | head -n 1 | awk '{print $3}')
+count6x6=$(echo "${out}" | grep "Nodes searched" | head -n 2 | tail -n 1 | awk '{print $3}')
+count8x8_again=$(echo "${out}" | grep "Nodes searched" | tail -n 1 | awk '{print $3}')
+
+echo "v8x8 moves: ${count8x8}"
+echo "v6x6 moves: ${count6x6}"
+echo "v8x8 again moves: ${count8x8_again}"
+
+if [ "${count8x8}" != "20" ]; then
+    echo "Initial v8x8 perft count incorrect: ${count8x8}"
+    exit 1
+fi
+
+if [ "${count8x8_again}" != "20" ]; then
+    echo "Subsequent v8x8 perft count incorrect after variant switch: ${count8x8_again}"
+    exit 1
+fi
+
+rm -f "${TMP_VARIANT_PATH}"
+unset TMP_VARIANT_PATH
+
+echo "concurrent-variant-magics tests passed"


### PR DESCRIPTION
Magic tables rely on global mutable state. This is brittle for variants switching within the same process. This PR moves attack tables into immutable per-geometry bundles or geometry-owned cache objects.