### PR TITLE
Fix multi-step logic for pawns on wrapping boards

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -3393,11 +3393,12 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
             {
                 b |= to;
                 if ((double_step_region(c, pt) & s)
+                    && (not_moved_pieces(c) & s)
                     && wrapped_destination_square(to, 0, forward, max_file(), max_rank(), wrapFile, wrapRank, to)
                     && !(occupancy & to))
                     b |= to;
             }
-            if ((triple_step_region(c, pt) & s))
+            if ((triple_step_region(c, pt) & s) && (not_moved_pieces(c) & s))
             {
                 Square s1 = SQ_NONE, s2 = SQ_NONE, s3 = SQ_NONE;
                 if (wrapped_destination_square(s, 0, forward, max_file(), max_rank(), wrapFile, wrapRank, s1)

--- a/tests/wrapping-topology.sh
+++ b/tests/wrapping-topology.sh
@@ -177,6 +177,29 @@ assert not sf.gives_check("cyl-checkmove", fen, [])
 assert sf.gives_check("cyl-checkmove", fen, ["g1a1"])
 PY
 
+# Test for wrapped pawn double step logic
+cat >"${TMP_VARIANT_PATH}" <<'INI'
+[tor-pawn-repro:chess]
+toroidal = true
+castling = false
+mandatoryPawnPromotion = false
+startFen = 8/6k1/8/8/8/8/P7/4K3 w - - 0 1
+INI
+
+tor_pawn_repro_output=$(cat <<CMDS | "${ENGINE}" 2>&1
+uci
+setoption name VariantPath value ${TMP_VARIANT_PATH}
+setoption name UCI_Variant tor-pawn-repro
+position startpos moves a2a3 g7g6 a3a4 g6g5 a4a5 g5g4 a5a6 g4h3 a6a7 h3g2 a7a8 g2h1 a8a1 h1g2 a1a2 g2g1
+go perft 1
+quit
+CMDS
+)
+if echo "${tor_pawn_repro_output}" | grep -q "a2a4: 1"; then
+  echo "wrapping topology test failed: wrapped pawn allowed illegal double step"
+  exit 1
+fi
+
 rm -f "${TMP_VARIANT_PATH}"
 unset TMP_VARIANT_PATH
 


### PR DESCRIPTION
### Problem
In `Position::moves_from`, the logic for wrapped pawns allowed double and triple steps based solely on whether the pawn was in the `double_step_region` or `triple_step_region`. On toroidal or cylindrical boards, a pawn could move forward, wrap around the board, and return to its starting rank, thereby incorrectly regaining its multi-step ability despite having already moved.

### Fix
Added a check against `not_moved_pieces(c)` in `src/position.h` to ensure that double and triple steps are only available to pawns that have not yet moved, consistent with standard chess rules and the engine's logic for non-wrapped boards.

### Validation
- Created a toroidal variant and verified that a pawn moving from A2, wrapping around the board, and returning to A2 was correctly restricted to a single step.
- Added a regression test to `tests/wrapping-topology.sh`.
