### PR TITLE
Optimize QSearch Game End Check

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -3801,6 +3801,43 @@ bool Position::legal(Move m) const {
 }
 
 
+/// Position::has_legal_move() tests whether there is at least one legal move
+
+bool Position::has_legal_move() const {
+
+  if (is_immediate_game_end())
+      return false;
+
+  ExtMove moveList[MOVEGEN_OVERFLOW_CAPACITY];
+  ExtMove* end;
+
+  const bool useWrappedFallback = topology_wraps() && evasion_checkers();
+  const bool useNonEvasions = anti_royal_types() || useWrappedFallback;
+
+  if (evasion_checkers() && !useNonEvasions)
+  {
+      end = generate<EVASIONS>(*this, moveList);
+      for (ExtMove* it = moveList; it != end; ++it)
+          if (legal(*it) && !virtual_drop(*it))
+              return true;
+  }
+  else
+  {
+      end = generate<CAPTURES>(*this, moveList);
+      for (ExtMove* it = moveList; it != end; ++it)
+          if (legal(*it) && !virtual_drop(*it))
+              return true;
+
+      end = generate<QUIETS>(*this, moveList);
+      for (ExtMove* it = moveList; it != end; ++it)
+          if (legal(*it) && !virtual_drop(*it))
+              return true;
+  }
+
+  return false;
+}
+
+
 /// Position::pseudo_legal() takes a random move and tests whether the move is
 /// pseudo legal. It is used to validate moves from TT that can be corrupted
 /// due to SMP concurrent access or hash position key aliasing.

--- a/src/position.h
+++ b/src/position.h
@@ -621,6 +621,7 @@ public:
   Thread* this_thread() const;
   bool is_immediate_game_end() const;
   bool is_immediate_game_end(Value& result, int ply = 0) const;
+  bool has_legal_move() const;
   bool is_optional_game_end() const;
   bool is_optional_game_end(Value& result, int ply = 0, int countStarted = 0) const;
   bool is_game_end(Value& result, int ply = 0) const;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1849,14 +1849,7 @@ moves_loop: // When in check, search starts from here
     // stalemate or no-move outcomes are decisive even outside check.
     if (bestMove == MOVE_NONE)
     {
-        bool hasLegalMove = false;
-        for (auto it = MoveList<LEGAL>(pos).begin(); it != MoveList<LEGAL>(pos).end(); ++it)
-        {
-            hasLegalMove = true;
-            break;
-        }
-
-        if (!hasLegalMove)
+        if (!pos.has_legal_move())
         {
             Value result;
             if (pos.is_game_end(result, ss->ply))


### PR DESCRIPTION
Implement Position::has_legal_move() to avoid full legal move generation in QSearch game end checks.