### PR TITLE
Edit PR #122: Unified attack engine and magic bitboard simplification

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -47,7 +47,35 @@ Bitboard BoardSizeBB[FILE_NB][RANK_NB];
 RiderType AttackRiderTypes[PIECE_TYPE_NB];
 RiderType MoveRiderTypes[2][PIECE_TYPE_NB];
 
-const MagicGeometry* current_magic_geometry = nullptr;
+Magic RookMagicsH[SQUARE_NB];
+Magic RookMagicsV[SQUARE_NB];
+Magic BishopMagics[SQUARE_NB];
+Magic CannonMagicsH[SQUARE_NB];
+Magic CannonMagicsV[SQUARE_NB];
+Magic HorseMagics[SQUARE_NB];
+Magic JanggiElephantMagics[SQUARE_NB];
+Magic CannonDiagMagics[SQUARE_NB];
+Magic NightriderMagics[SQUARE_NB];
+Magic GrasshopperMagicsH[SQUARE_NB];
+Magic GrasshopperMagicsV[SQUARE_NB];
+Magic GrasshopperMagicsD[SQUARE_NB];
+
+Magic* magics[] = {BishopMagics, RookMagicsH, RookMagicsV, CannonMagicsH, CannonMagicsV,
+                   BishopMagics, HorseMagics, BishopMagics, JanggiElephantMagics, CannonDiagMagics, NightriderMagics,
+                   GrasshopperMagicsH, GrasshopperMagicsV, GrasshopperMagicsD};
+
+std::vector<Bitboard> RookTableH;
+std::vector<Bitboard> RookTableV;
+std::vector<Bitboard> BishopTable;
+std::vector<Bitboard> CannonTableH;
+std::vector<Bitboard> CannonTableV;
+std::vector<Bitboard> HorseTable;
+std::vector<Bitboard> JanggiElephantTable;
+std::vector<Bitboard> CannonDiagTable;
+std::vector<Bitboard> NightriderTable;
+std::vector<Bitboard> GrasshopperTableH;
+std::vector<Bitboard> GrasshopperTableV;
+std::vector<Bitboard> GrasshopperTableD;
 
 namespace {
 
@@ -735,8 +763,8 @@ void Bitboards::init() {
           {
               if (PseudoAttacks[WHITE][pt][s1] & s2)
               {
-                  LineBB[s1][s2]    = (attacks_bb(WHITE, pt, s1, 0, current_magic_geometry) & attacks_bb(WHITE, pt, s2, 0, current_magic_geometry)) | s1 | s2;
-                  BetweenBB[s1][s2] = (attacks_bb(WHITE, pt, s1, square_bb(s2), current_magic_geometry) & attacks_bb(WHITE, pt, s2, square_bb(s1), current_magic_geometry));
+                  LineBB[s1][s2]    = (attacks_bb(WHITE, pt, s1, 0) & attacks_bb(WHITE, pt, s2, 0)) | square_bb(s1) | square_bb(s2);
+                  BetweenBB[s1][s2] = (attacks_bb(WHITE, pt, s1, square_bb(s2)) & attacks_bb(WHITE, pt, s2, square_bb(s1)));
               }
               BetweenBB[s1][s2] |= s2;
           }
@@ -747,10 +775,31 @@ namespace {
 
 #if !defined(VERY_LARGE_BOARDS)
 
-  std::unordered_map<uint16_t, std::shared_ptr<const MagicGeometry>> MagicByBoardSize;
+  struct MagicNumberCache {
+      std::array<Bitboard, SQUARE_NB> rookH {};
+      std::array<Bitboard, SQUARE_NB> rookV {};
+      std::array<Bitboard, SQUARE_NB> bishop {};
+      std::array<Bitboard, SQUARE_NB> cannonH {};
+      std::array<Bitboard, SQUARE_NB> cannonV {};
+      std::array<Bitboard, SQUARE_NB> horse {};
+      std::array<Bitboard, SQUARE_NB> janggiElephant {};
+      std::array<Bitboard, SQUARE_NB> cannonDiag {};
+      std::array<Bitboard, SQUARE_NB> nightrider {};
+      std::array<Bitboard, SQUARE_NB> grasshopperH {};
+      std::array<Bitboard, SQUARE_NB> grasshopperV {};
+      std::array<Bitboard, SQUARE_NB> grasshopperD {};
+  };
+
+  std::unordered_map<uint16_t, MagicNumberCache> MagicByBoardSize;
   std::vector<uint16_t> MagicCacheLru;
   std::mutex MagicInitMutex;
   constexpr size_t MAX_MAGIC_CACHE_ENTRIES = 16;
+  uint16_t CurrentMagicBoardKey = 0;
+
+  inline void snapshot_magic_numbers(std::array<Bitboard, SQUARE_NB>& out, const Magic in[]) {
+      for (Square s = SQ_A1; s <= SQ_MAX; ++s)
+          out[s] = in[s].magic;
+  }
 
   inline uint16_t magic_board_key(File f, Rank r) {
       return (uint16_t(f) << 8) | uint16_t(r);
@@ -893,13 +942,19 @@ namespace {
 #endif
 }
 
-std::shared_ptr<const MagicGeometry> Bitboards::init_magics(File maxFile, Rank maxRank) {
+void Bitboards::init_magics(File maxFile, Rank maxRank) {
 #if !defined(VERY_LARGE_BOARDS)
   const uint16_t boardKey = magic_board_key(maxFile, maxRank);
 
   std::lock_guard<std::mutex> lock(MagicInitMutex);
+  if (boardKey == CurrentMagicBoardKey)
+      return;
+
+  CurrentMagicBoardKey = boardKey;
+
   const auto cacheIt = MagicByBoardSize.find(boardKey);
-  if (cacheIt != MagicByBoardSize.end())
+  const MagicNumberCache* cache = cacheIt == MagicByBoardSize.end() ? nullptr : &cacheIt->second;
+  if (cache)
   {
       auto it = std::find(MagicCacheLru.begin(), MagicCacheLru.end(), boardKey);
       if (it != MagicCacheLru.end())
@@ -907,85 +962,91 @@ std::shared_ptr<const MagicGeometry> Bitboards::init_magics(File maxFile, Rank m
           MagicCacheLru.erase(it);
           MagicCacheLru.push_back(boardKey);
       }
-      current_magic_geometry = cacheIt->second.get();
-      return cacheIt->second;
   }
 
-  std::shared_ptr<MagicGeometry> mg = std::make_shared<MagicGeometry>();
-
 #ifdef LARGEBOARDS
-  mg->RookTableH.resize(0x11800);
-  mg->RookTableV.resize(0x4800);
-  mg->BishopTable.resize(0x33C00);
-  mg->CannonTableH.resize(0x11800);
-  mg->CannonTableV.resize(0x4800);
-  mg->HorseTable.resize(0x500);
-  mg->JanggiElephantTable.resize(0x1C000);
-  mg->CannonDiagTable.resize(0x33C00);
-  mg->NightriderTable.resize(0xD200);
-  mg->GrasshopperTableH.resize(0x11800);
-  mg->GrasshopperTableV.resize(0x4800);
-  mg->GrasshopperTableD.resize(0x33C00);
+  RookTableH.resize(0x11800);
+  RookTableV.resize(0x4800);
+  BishopTable.resize(0x33C00);
+  CannonTableH.resize(0x11800);
+  CannonTableV.resize(0x4800);
+  HorseTable.resize(0x500);
+  JanggiElephantTable.resize(0x1C000);
+  CannonDiagTable.resize(0x33C00);
+  NightriderTable.resize(0xD200);
+  GrasshopperTableH.resize(0x11800);
+  GrasshopperTableV.resize(0x4800);
+  GrasshopperTableD.resize(0x33C00);
 #else
-  mg->RookTableH.resize(0xA00);
-  mg->RookTableV.resize(0xA00);
-  mg->BishopTable.resize(0x1480);
-  mg->CannonTableH.resize(0xA00);
-  mg->CannonTableV.resize(0xA00);
-  mg->HorseTable.resize(0x240);
-  mg->JanggiElephantTable.resize(0x5C00);
-  mg->CannonDiagTable.resize(0x1480);
-  mg->NightriderTable.resize(0x500);
-  mg->GrasshopperTableH.resize(0xA00);
-  mg->GrasshopperTableV.resize(0xA00);
-  mg->GrasshopperTableD.resize(0x1480);
+  RookTableH.resize(0xA00);
+  RookTableV.resize(0xA00);
+  BishopTable.resize(0x1480);
+  CannonTableH.resize(0xA00);
+  CannonTableV.resize(0xA00);
+  HorseTable.resize(0x240);
+  JanggiElephantTable.resize(0x5C00);
+  CannonDiagTable.resize(0x1480);
+  NightriderTable.resize(0x500);
+  GrasshopperTableH.resize(0xA00);
+  GrasshopperTableV.resize(0xA00);
+  GrasshopperTableD.resize(0x1480);
 #endif
 
 #ifdef PRECOMPUTED_MAGICS
-  init_magic_table<RIDER>(mg->RookTableH.data(), mg->RookMagicsH, RookDirectionsH, maxFile, maxRank, RookMagicHInit);
-  init_magic_table<RIDER>(mg->RookTableV.data(), mg->RookMagicsV, RookDirectionsV, maxFile, maxRank, RookMagicVInit);
-  init_magic_table<RIDER>(mg->BishopTable.data(), mg->BishopMagics, BishopDirections, maxFile, maxRank, BishopMagicInit);
-  init_magic_table<HOPPER>(mg->CannonTableH.data(), mg->CannonMagicsH, RookDirectionsH, maxFile, maxRank, CannonMagicHInit);
-  init_magic_table<HOPPER>(mg->CannonTableV.data(), mg->CannonMagicsV, RookDirectionsV, maxFile, maxRank, CannonMagicVInit);
-  init_magic_table<LAME_LEAPER>(mg->HorseTable.data(), mg->HorseMagics, HorseDirections, maxFile, maxRank, HorseMagicInit);
-  init_magic_table<LAME_LEAPER>(mg->JanggiElephantTable.data(), mg->JanggiElephantMagics, JanggiElephantDirections, maxFile, maxRank, JanggiElephantMagicInit);
-  init_magic_table<HOPPER>(mg->CannonDiagTable.data(), mg->CannonDiagMagics, BishopDirections, maxFile, maxRank, CannonDiagMagicInit);
-  init_magic_table<RIDER, true>(mg->NightriderTable.data(), mg->NightriderMagics, HorseDirections, maxFile, maxRank, NightriderMagicInit);
-  init_magic_table<HOPPER>(mg->GrasshopperTableH.data(), mg->GrasshopperMagicsH, GrasshopperDirectionsH, maxFile, maxRank, GrasshopperMagicHInit);
-  init_magic_table<HOPPER>(mg->GrasshopperTableV.data(), mg->GrasshopperMagicsV, GrasshopperDirectionsV, maxFile, maxRank, GrasshopperMagicVInit);
-  init_magic_table<HOPPER>(mg->GrasshopperTableD.data(), mg->GrasshopperMagicsD, GrasshopperDirectionsD, maxFile, maxRank, GrasshopperMagicDInit);
+  init_magic_table<RIDER>( RookTableH.data(), RookMagicsH, RookDirectionsH, maxFile, maxRank, cache ? cache->rookH.data() : RookMagicHInit);
+  init_magic_table<RIDER>( RookTableV.data(), RookMagicsV, RookDirectionsV, maxFile, maxRank, cache ? cache->rookV.data() : RookMagicVInit);
+  init_magic_table<RIDER>( BishopTable.data(), BishopMagics, BishopDirections, maxFile, maxRank, cache ? cache->bishop.data() : BishopMagicInit);
+  init_magic_table<HOPPER>( CannonTableH.data(), CannonMagicsH, RookDirectionsH, maxFile, maxRank, cache ? cache->cannonH.data() : CannonMagicHInit);
+  init_magic_table<HOPPER>( CannonTableV.data(), CannonMagicsV, RookDirectionsV, maxFile, maxRank, cache ? cache->cannonV.data() : CannonMagicVInit);
+  init_magic_table<LAME_LEAPER>( HorseTable.data(), HorseMagics, HorseDirections, maxFile, maxRank, cache ? cache->horse.data() : HorseMagicInit);
+  init_magic_table<LAME_LEAPER>( JanggiElephantTable.data(), JanggiElephantMagics, JanggiElephantDirections, maxFile, maxRank, cache ? cache->janggiElephant.data() : JanggiElephantMagicInit);
+  init_magic_table<HOPPER>( CannonDiagTable.data(), CannonDiagMagics, BishopDirections, maxFile, maxRank, cache ? cache->cannonDiag.data() : CannonDiagMagicInit);
+  init_magic_table<RIDER, true>( NightriderTable.data(), NightriderMagics, HorseDirections, maxFile, maxRank, cache ? cache->nightrider.data() : NightriderMagicInit);
+  init_magic_table<HOPPER>( GrasshopperTableH.data(), GrasshopperMagicsH, GrasshopperDirectionsH, maxFile, maxRank, cache ? cache->grasshopperH.data() : GrasshopperMagicHInit);
+  init_magic_table<HOPPER>( GrasshopperTableV.data(), GrasshopperMagicsV, GrasshopperDirectionsV, maxFile, maxRank, cache ? cache->grasshopperV.data() : GrasshopperMagicVInit);
+  init_magic_table<HOPPER>( GrasshopperTableD.data(), GrasshopperMagicsD, GrasshopperDirectionsD, maxFile, maxRank, cache ? cache->grasshopperD.data() : GrasshopperMagicDInit);
 #else
-  init_magic_table<RIDER>(mg->RookTableH.data(), mg->RookMagicsH, RookDirectionsH, maxFile, maxRank, nullptr);
-  init_magic_table<RIDER>(mg->RookTableV.data(), mg->RookMagicsV, RookDirectionsV, maxFile, maxRank, nullptr);
-  init_magic_table<RIDER>(mg->BishopTable.data(), mg->BishopMagics, BishopDirections, maxFile, maxRank, nullptr);
-  init_magic_table<HOPPER>(mg->CannonTableH.data(), mg->CannonMagicsH, RookDirectionsH, maxFile, maxRank, nullptr);
-  init_magic_table<HOPPER>(mg->CannonTableV.data(), mg->CannonMagicsV, RookDirectionsV, maxFile, maxRank, nullptr);
-  init_magic_table<LAME_LEAPER>(mg->HorseTable.data(), mg->HorseMagics, HorseDirections, maxFile, maxRank, nullptr);
-  init_magic_table<LAME_LEAPER>(mg->JanggiElephantTable.data(), mg->JanggiElephantMagics, JanggiElephantDirections, maxFile, maxRank, nullptr);
-  init_magic_table<HOPPER>(mg->CannonDiagTable.data(), mg->CannonDiagMagics, BishopDirections, maxFile, maxRank, nullptr);
-  init_magic_table<RIDER, true>(mg->NightriderTable.data(), mg->NightriderMagics, HorseDirections, maxFile, maxRank, nullptr);
-  init_magic_table<HOPPER>(mg->GrasshopperTableH.data(), mg->GrasshopperMagicsH, GrasshopperDirectionsH, maxFile, maxRank, nullptr);
-  init_magic_table<HOPPER>(mg->GrasshopperTableV.data(), mg->GrasshopperMagicsV, GrasshopperDirectionsV, maxFile, maxRank, nullptr);
-  init_magic_table<HOPPER>(mg->GrasshopperTableD.data(), mg->GrasshopperMagicsD, GrasshopperDirectionsD, maxFile, maxRank, nullptr);
+  init_magic_table<RIDER>( RookTableH.data(), RookMagicsH, RookDirectionsH, maxFile, maxRank, cache ? cache->rookH.data() : nullptr);
+  init_magic_table<RIDER>( RookTableV.data(), RookMagicsV, RookDirectionsV, maxFile, maxRank, cache ? cache->rookV.data() : nullptr);
+  init_magic_table<RIDER>( BishopTable.data(), BishopMagics, BishopDirections, maxFile, maxRank, cache ? cache->bishop.data() : nullptr);
+  init_magic_table<HOPPER>( CannonTableH.data(), CannonMagicsH, RookDirectionsH, maxFile, maxRank, cache ? cache->cannonH.data() : nullptr);
+  init_magic_table<HOPPER>( CannonTableV.data(), CannonMagicsV, RookDirectionsV, maxFile, maxRank, cache ? cache->cannonV.data() : nullptr);
+  init_magic_table<LAME_LEAPER>( HorseTable.data(), HorseMagics, HorseDirections, maxFile, maxRank, cache ? cache->horse.data() : nullptr);
+  init_magic_table<LAME_LEAPER>( JanggiElephantTable.data(), JanggiElephantMagics, JanggiElephantDirections, maxFile, maxRank, cache ? cache->janggiElephant.data() : nullptr);
+  init_magic_table<HOPPER>( CannonDiagTable.data(), CannonDiagMagics, BishopDirections, maxFile, maxRank, cache ? cache->cannonDiag.data() : nullptr);
+  init_magic_table<RIDER, true>( NightriderTable.data(), NightriderMagics, HorseDirections, maxFile, maxRank, cache ? cache->nightrider.data() : nullptr);
+  init_magic_table<HOPPER>( GrasshopperTableH.data(), GrasshopperMagicsH, GrasshopperDirectionsH, maxFile, maxRank, cache ? cache->grasshopperH.data() : nullptr);
+  init_magic_table<HOPPER>( GrasshopperTableV.data(), GrasshopperMagicsV, GrasshopperDirectionsV, maxFile, maxRank, cache ? cache->grasshopperV.data() : nullptr);
+  init_magic_table<HOPPER>( GrasshopperTableD.data(), GrasshopperMagicsD, GrasshopperDirectionsD, maxFile, maxRank, cache ? cache->grasshopperD.data() : nullptr);
 #endif
 
-  if (MagicByBoardSize.size() >= MAX_MAGIC_CACHE_ENTRIES && !MagicCacheLru.empty())
-  {
-      MagicByBoardSize.erase(MagicCacheLru.front());
-      MagicCacheLru.erase(MagicCacheLru.begin());
+  if (!cache) {
+      if (MagicByBoardSize.size() >= MAX_MAGIC_CACHE_ENTRIES && !MagicCacheLru.empty())
+      {
+          MagicByBoardSize.erase(MagicCacheLru.front());
+          MagicCacheLru.erase(MagicCacheLru.begin());
+      }
+      MagicNumberCache fresh {};
+      snapshot_magic_numbers(fresh.rookH, RookMagicsH);
+      snapshot_magic_numbers(fresh.rookV, RookMagicsV);
+      snapshot_magic_numbers(fresh.bishop, BishopMagics);
+      snapshot_magic_numbers(fresh.cannonH, CannonMagicsH);
+      snapshot_magic_numbers(fresh.cannonV, CannonMagicsV);
+      snapshot_magic_numbers(fresh.horse, HorseMagics);
+      snapshot_magic_numbers(fresh.janggiElephant, JanggiElephantMagics);
+      snapshot_magic_numbers(fresh.cannonDiag, CannonDiagMagics);
+      snapshot_magic_numbers(fresh.nightrider, NightriderMagics);
+      snapshot_magic_numbers(fresh.grasshopperH, GrasshopperMagicsH);
+      snapshot_magic_numbers(fresh.grasshopperV, GrasshopperMagicsV);
+      snapshot_magic_numbers(fresh.grasshopperD, GrasshopperMagicsD);
+      MagicByBoardSize.emplace(boardKey, std::move(fresh));
+      MagicCacheLru.push_back(boardKey);
   }
-  MagicByBoardSize.emplace(boardKey, mg);
-  MagicCacheLru.push_back(boardKey);
-
-  current_magic_geometry = mg.get();
-  return mg;
 #else
   (void) maxFile;
   (void) maxRank;
-  return nullptr;
 #endif
 }
-
 
 void Bitboards::init_wrapped_rays(File maxFile, Rank maxRank, bool wrapFile, bool wrapRank) {
     if (!wrapFile && !wrapRank)
@@ -1018,4 +1079,5 @@ void Bitboards::init_wrapped_rays(File maxFile, Rank maxRank, bool wrapFile, boo
         }
     }
 }
+
 } // namespace Stockfish

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -55,54 +55,20 @@ struct Magic {
   }
 };
 
-struct MagicGeometry {
-  Magic RookMagicsH[SQUARE_NB];
-  Magic RookMagicsV[SQUARE_NB];
-  Magic BishopMagics[SQUARE_NB];
-  Magic CannonMagicsH[SQUARE_NB];
-  Magic CannonMagicsV[SQUARE_NB];
-  Magic HorseMagics[SQUARE_NB];
-  Magic JanggiElephantMagics[SQUARE_NB];
-  Magic CannonDiagMagics[SQUARE_NB];
-  Magic NightriderMagics[SQUARE_NB];
-  Magic GrasshopperMagicsH[SQUARE_NB];
-  Magic GrasshopperMagicsV[SQUARE_NB];
-  Magic GrasshopperMagicsD[SQUARE_NB];
+extern Magic RookMagicsH[SQUARE_NB];
+extern Magic RookMagicsV[SQUARE_NB];
+extern Magic BishopMagics[SQUARE_NB];
+extern Magic CannonMagicsH[SQUARE_NB];
+extern Magic CannonMagicsV[SQUARE_NB];
+extern Magic HorseMagics[SQUARE_NB];
+extern Magic JanggiElephantMagics[SQUARE_NB];
+extern Magic CannonDiagMagics[SQUARE_NB];
+extern Magic NightriderMagics[SQUARE_NB];
+extern Magic GrasshopperMagicsH[SQUARE_NB];
+extern Magic GrasshopperMagicsV[SQUARE_NB];
+extern Magic GrasshopperMagicsD[SQUARE_NB];
 
-  std::vector<Bitboard> RookTableH;
-  std::vector<Bitboard> RookTableV;
-  std::vector<Bitboard> BishopTable;
-  std::vector<Bitboard> CannonTableH;
-  std::vector<Bitboard> CannonTableV;
-  std::vector<Bitboard> HorseTable;
-  std::vector<Bitboard> JanggiElephantTable;
-  std::vector<Bitboard> CannonDiagTable;
-  std::vector<Bitboard> NightriderTable;
-  std::vector<Bitboard> GrasshopperTableH;
-  std::vector<Bitboard> GrasshopperTableV;
-  std::vector<Bitboard> GrasshopperTableD;
-
-  Magic* magics[14];
-
-  MagicGeometry() {
-    magics[0] = BishopMagics;
-    magics[1] = RookMagicsH;
-    magics[2] = RookMagicsV;
-    magics[3] = CannonMagicsH;
-    magics[4] = CannonMagicsV;
-    magics[5] = BishopMagics;
-    magics[6] = HorseMagics;
-    magics[7] = BishopMagics;
-    magics[8] = JanggiElephantMagics;
-    magics[9] = CannonDiagMagics;
-    magics[10] = NightriderMagics;
-    magics[11] = GrasshopperMagicsH;
-    magics[12] = GrasshopperMagicsV;
-    magics[13] = GrasshopperMagicsD;
-  }
-};
-
-extern const MagicGeometry* current_magic_geometry;
+extern Magic* magics[];
 
 namespace Bitbases {
 
@@ -114,7 +80,7 @@ bool probe(Square wksq, Square wpsq, Square bksq, Color us);
 namespace Bitboards {
 
 void init_pieces();
-std::shared_ptr<const MagicGeometry> init_magics(File maxFile, Rank maxRank);
+void init_magics(File maxFile, Rank maxRank);
 void init_wrapped_rays(File maxFile, Rank maxRank, bool wrapFile, bool wrapRank);
 void init();
 std::string pretty(Bitboard b);
@@ -307,7 +273,7 @@ inline Bitboard safe_destination_tuple(Square s, int dr, int df) {
   return square_bb(make_square(File(f), Rank(r)));
 }
 
-inline Bitboard rose_attacks_bb(Square from, Bitboard occupied, const MagicGeometry* /*mg*/ = current_magic_geometry) {
+inline Bitboard rose_attacks_bb(Square from, Bitboard occupied) {
   Bitboard attack = 0;
 
   for (int start = 0; start < 8; ++start)
@@ -899,19 +865,18 @@ inline int edge_distance(Rank r, Rank maxRank = RANK_8) { return std::min(r, Ran
 
 #ifdef VERY_LARGE_BOARDS
 Bitboard rider_attacks_bb(
-    RiderType R, Square s, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry);
+    RiderType R, Square s, Bitboard occupied);
 
 template<RiderType R>
 inline Bitboard rider_attacks_bb(
-    Square s, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
+    Square s, Bitboard occupied) {
   static_assert(R != NO_RIDER && !(R & (R - 1))); // exactly one bit
-  return rider_attacks_bb(R, s, occupied, mg);
+  return rider_attacks_bb(R, s, occupied);
 }
 
 inline Square lsb(Bitboard b);
 #else
-inline Bitboard fixed_step_rider_attacks(Square s, Bitboard occupied, int stepF, int stepR, const MagicGeometry* mg = current_magic_geometry) {
-  (void)mg;
+inline Bitboard fixed_step_rider_attacks(Square s, Bitboard occupied, int stepF, int stepR) {
   Bitboard attack = 0;
   int f = int(file_of(s));
   int r = int(rank_of(s));
@@ -931,8 +896,7 @@ inline Bitboard fixed_step_rider_attacks(Square s, Bitboard occupied, int stepF,
   return attack;
 }
 
-inline Bitboard fixed_step_lame_rider_attacks(Square s, Bitboard occupied, int stepF, int stepR, const MagicGeometry* mg = current_magic_geometry) {
-  (void)mg;
+inline Bitboard fixed_step_lame_rider_attacks(Square s, Bitboard occupied, int stepF, int stepR) {
   assert((stepF % 2 == 0) && (stepR % 2 == 0));
   Bitboard attack = 0;
   int f = int(file_of(s));
@@ -960,8 +924,7 @@ inline Bitboard fixed_step_lame_rider_attacks(Square s, Bitboard occupied, int s
   return attack;
 }
 
-inline Bitboard ski_slider_attacks(Square s, Bitboard occupied, int stepF, int stepR, const MagicGeometry* mg = current_magic_geometry) {
-  (void)mg;
+inline Bitboard ski_slider_attacks(Square s, Bitboard occupied, int stepF, int stepR) {
   int f = int(file_of(s)) + stepF;
   int r = int(rank_of(s)) + stepR;
   if (f < int(FILE_A) || f > int(FILE_MAX) || r < int(RANK_1) || r > int(RANK_MAX))
@@ -983,7 +946,7 @@ inline Bitboard ski_slider_attacks(Square s, Bitboard occupied, int stepF, int s
 }
 
 template<RiderType R>
-inline Bitboard rider_attacks_bb(Square s, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
+inline Bitboard rider_attacks_bb(Square s, Bitboard occupied) {
 
   static_assert(R != NO_RIDER && !(R & (R - 1))); // exactly one bit
   if constexpr (R == RIDER_GRIFFON_NH || R == RIDER_GRIFFON_SH || R == RIDER_GRIFFON_EV || R == RIDER_GRIFFON_WV) {
@@ -1066,32 +1029,32 @@ inline Bitboard rider_attacks_bb(Square s, Bitboard occupied, const MagicGeometr
   if constexpr (R == RIDER_ROSE)
       return rose_attacks_bb(s, occupied);
 
-  const Magic& m =  R == RIDER_ROOK_H ? mg->RookMagicsH[s]
-                  : R == RIDER_ROOK_V ? mg->RookMagicsV[s]
-                  : R == RIDER_CANNON_H ? mg->CannonMagicsH[s]
-                  : R == RIDER_CANNON_V ? mg->CannonMagicsV[s]
-                  : R == RIDER_LAME_DABBABA ? mg->BishopMagics[s]
-                  : R == RIDER_HORSE ? mg->HorseMagics[s]
-                  : R == RIDER_ELEPHANT ? mg->BishopMagics[s]
-                  : R == RIDER_JANGGI_ELEPHANT ? mg->JanggiElephantMagics[s]
-                  : R == RIDER_CANNON_DIAG ? mg->CannonDiagMagics[s]
-                  : R == RIDER_NIGHTRIDER ? mg->NightriderMagics[s]
-                  : R == RIDER_GRASSHOPPER_H ? mg->GrasshopperMagicsH[s]
-                  : R == RIDER_GRASSHOPPER_V ? mg->GrasshopperMagicsV[s]
-                  : R == RIDER_GRASSHOPPER_D ? mg->GrasshopperMagicsD[s]
-                  : mg->BishopMagics[s];
+  const Magic& m =  R == RIDER_ROOK_H ? RookMagicsH[s]
+                  : R == RIDER_ROOK_V ? RookMagicsV[s]
+                  : R == RIDER_CANNON_H ? CannonMagicsH[s]
+                  : R == RIDER_CANNON_V ? CannonMagicsV[s]
+                  : R == RIDER_LAME_DABBABA ? BishopMagics[s]
+                  : R == RIDER_HORSE ? HorseMagics[s]
+                  : R == RIDER_ELEPHANT ? BishopMagics[s]
+                  : R == RIDER_JANGGI_ELEPHANT ? JanggiElephantMagics[s]
+                  : R == RIDER_CANNON_DIAG ? CannonDiagMagics[s]
+                  : R == RIDER_NIGHTRIDER ? NightriderMagics[s]
+                  : R == RIDER_GRASSHOPPER_H ? GrasshopperMagicsH[s]
+                  : R == RIDER_GRASSHOPPER_V ? GrasshopperMagicsV[s]
+                  : R == RIDER_GRASSHOPPER_D ? GrasshopperMagicsD[s]
+                  : BishopMagics[s];
   return m.attacks[m.index(occupied)];
 }
 
 inline Square lsb(Bitboard b);
 
-inline Bitboard rider_attacks_bb(RiderType R, Square s, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
+inline Bitboard rider_attacks_bb(RiderType R, Square s, Bitboard occupied) {
 
   assert(R != NO_RIDER && !(R & (R - 1))); // exactly one bit
   if (R == RIDER_LAME_DABBABA)
-      return rider_attacks_bb<RIDER_LAME_DABBABA>(s, occupied, mg);
+      return rider_attacks_bb<RIDER_LAME_DABBABA>(s, occupied);
   if (R == RIDER_ELEPHANT)
-      return rider_attacks_bb<RIDER_ELEPHANT>(s, occupied, mg);
+      return rider_attacks_bb<RIDER_ELEPHANT>(s, occupied);
   if (R == RIDER_SKI_ROOK_H)
       return  ski_slider_attacks(s, occupied,  1, 0)
             | ski_slider_attacks(s, occupied, -1, 0);
@@ -1105,15 +1068,15 @@ inline Bitboard rider_attacks_bb(RiderType R, Square s, Bitboard occupied, const
             | ski_slider_attacks(s, occupied, -1, -1);
   if (R == RIDER_ROSE)
       return rose_attacks_bb(s, occupied);
-  if (R == RIDER_GRIFFON_NH) return rider_attacks_bb<RIDER_GRIFFON_NH>(s, occupied, mg);
-  if (R == RIDER_GRIFFON_SH) return rider_attacks_bb<RIDER_GRIFFON_SH>(s, occupied, mg);
-  if (R == RIDER_GRIFFON_EV) return rider_attacks_bb<RIDER_GRIFFON_EV>(s, occupied, mg);
-  if (R == RIDER_GRIFFON_WV) return rider_attacks_bb<RIDER_GRIFFON_WV>(s, occupied, mg);
-  if (R == RIDER_MANTICORE_NE) return rider_attacks_bb<RIDER_MANTICORE_NE>(s, occupied, mg);
-  if (R == RIDER_MANTICORE_NW) return rider_attacks_bb<RIDER_MANTICORE_NW>(s, occupied, mg);
-  if (R == RIDER_MANTICORE_SE) return rider_attacks_bb<RIDER_MANTICORE_SE>(s, occupied, mg);
-  if (R == RIDER_MANTICORE_SW) return rider_attacks_bb<RIDER_MANTICORE_SW>(s, occupied, mg);
-  const Magic& m = mg->magics[lsb(R)][s]; // re-use Bitboard lsb for riders
+  if (R == RIDER_GRIFFON_NH) return rider_attacks_bb<RIDER_GRIFFON_NH>(s, occupied);
+  if (R == RIDER_GRIFFON_SH) return rider_attacks_bb<RIDER_GRIFFON_SH>(s, occupied);
+  if (R == RIDER_GRIFFON_EV) return rider_attacks_bb<RIDER_GRIFFON_EV>(s, occupied);
+  if (R == RIDER_GRIFFON_WV) return rider_attacks_bb<RIDER_GRIFFON_WV>(s, occupied);
+  if (R == RIDER_MANTICORE_NE) return rider_attacks_bb<RIDER_MANTICORE_NE>(s, occupied);
+  if (R == RIDER_MANTICORE_NW) return rider_attacks_bb<RIDER_MANTICORE_NW>(s, occupied);
+  if (R == RIDER_MANTICORE_SE) return rider_attacks_bb<RIDER_MANTICORE_SE>(s, occupied);
+  if (R == RIDER_MANTICORE_SW) return rider_attacks_bb<RIDER_MANTICORE_SW>(s, occupied);
+  const Magic& m = magics[lsb(R)][s]; // re-use Bitboard lsb for riders
   return m.attacks[m.index(occupied)];
 }
 #endif
@@ -1136,15 +1099,15 @@ inline Bitboard attacks_bb(Square s) {
 /// Sliding piece attacks do not continue past an occupied square.
 
 template<PieceType Pt>
-inline Bitboard attacks_bb(Square s, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
+inline Bitboard attacks_bb(Square s, Bitboard occupied) {
 
   assert((Pt != PAWN) && (is_ok(s)));
 
   switch (Pt)
   {
-  case BISHOP: return rider_attacks_bb<RIDER_BISHOP>(s, occupied, mg);
-  case ROOK  : return rider_attacks_bb<RIDER_ROOK_H>(s, occupied, mg) | rider_attacks_bb<RIDER_ROOK_V>(s, occupied, mg);
-  case QUEEN : return attacks_bb<BISHOP>(s, occupied, mg) | attacks_bb<ROOK>(s, occupied, mg);
+  case BISHOP: return rider_attacks_bb<RIDER_BISHOP>(s, occupied);
+  case ROOK  : return rider_attacks_bb<RIDER_ROOK_H>(s, occupied) | rider_attacks_bb<RIDER_ROOK_V>(s, occupied);
+  case QUEEN : return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
   default    : return PseudoAttacks[WHITE][Pt][s];
   }
 }
@@ -1158,12 +1121,12 @@ inline RiderType pop_rider(RiderType& r) {
   return r2;
 }
 
-inline Bitboard attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
+inline Bitboard attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
   assert(pt != NO_PIECE_TYPE);
   Bitboard b = LeaperAttacks[c][pt][s];
   RiderType r = AttackRiderTypes[pt];
   while (r)
-      b |= rider_attacks_bb(pop_rider(r), s, occupied, mg);
+      b |= rider_attacks_bb(pop_rider(r), s, occupied);
   b |= leap_rider_attacks_bb(pt, c, s, occupied);
   b |= tuple_rider_attacks_bb(pt, c, s, occupied);
   return b & PseudoAttacks[c][pt][s];
@@ -1171,12 +1134,12 @@ inline Bitboard attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied, c
 
 
 template <bool Initial=false>
-inline Bitboard moves_bb(Color c, PieceType pt, Square s, Bitboard occupied, const MagicGeometry* mg = current_magic_geometry) {
+inline Bitboard moves_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
   assert(pt != NO_PIECE_TYPE);
   Bitboard b = LeaperMoves[Initial][c][pt][s];
   RiderType r = MoveRiderTypes[Initial][pt];
   while (r)
-      b |= rider_attacks_bb(pop_rider(r), s, occupied, mg);
+      b |= rider_attacks_bb(pop_rider(r), s, occupied);
   b |= leap_rider_moves_bb(pt, Initial, c, s, occupied);
   b |= tuple_rider_moves_bb(pt, Initial, c, s, occupied);
   return b & PseudoMoves[Initial][c][pt][s];

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -183,7 +183,7 @@ namespace {
 
   template<GenType Type>
   ExtMove* emit_promotion_variants(const Position& pos, ExtMove* moveList, Color us, Square from, Square to) {
-      if constexpr (Type != CAPTURES && Type != QUIETS && Type != EVASIONS && Type != NON_EVASIONS)
+      if constexpr (Type != CAPTURES && Type != QUIETS && Type != EVASIONS && Type != NON_EVASIONS && Type != QUIET_CHECKS)
           return moveList;
 
       for (PieceSet promotions = pos.promotion_piece_types(us, to); promotions;)
@@ -436,219 +436,83 @@ namespace {
 
   template<Color Us, GenType Type>
   ExtMove* generate_pawn_moves(const Position& pos, ExtMove* moveList, PawnGenSpec spec) {
-    [[maybe_unused]] constexpr bool GeneratesCaptures = Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS;
-    [[maybe_unused]] constexpr bool GeneratesQuiets = Type != CAPTURES;
-    [[maybe_unused]] constexpr bool QuietChecks = Type == QUIET_CHECKS;
 
     Bitboard target = spec.target;
     Bitboard fromMask = spec.fromMask;
 
-    if (!pos.pieces(Us, PAWN))
-        return moveList;
+    Bitboard initialBB = pos.pieces(Us, PAWN) & fromMask & pos.not_moved_pieces(Us);
+    Bitboard normalBB = (pos.pieces(Us, PAWN) & fromMask) ^ initialBB;
+    Bitboard frozen = pos.freeze_squares();
 
-    constexpr Color     Them     = ~Us;
-    constexpr Direction Up       = pawn_push(Us);
-    constexpr Direction UpRight  = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
-    constexpr Direction UpLeft   = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
+    auto generate_impl = [&](Square from, bool initial) {
+        if (frozen & from)
+            return;
 
-    const Bitboard promotionZone = pos.promotion_zone(Us, PAWN);
-    const Bitboard standardPromotionZone = pos.sittuyin_promotion() ? Bitboard(0) : promotionZone;
-    const Bitboard doubleStepRegion = pos.double_step_region(Us, PAWN);
-    const Bitboard tripleStepRegion = pos.triple_step_region(Us, PAWN);
+        Bitboard attacks = initial ? pos.attacks_from<true>(Us, PAWN, from) : pos.attacks_from<false>(Us, PAWN, from);
+        Bitboard quiets = initial ? pos.moves_from<true>(Us, PAWN, from) : pos.moves_from<false>(Us, PAWN, from);
+        Bitboard capturable = (pos.pieces() & ~pos.pieces(Us)) | pos.dead_squares();
+        if (pos.self_capture(PAWN))
+            capturable |= pos.pieces(Us) & ~pos.pieces(Us, KING);
 
-    const Bitboard frozen     = pos.freeze_squares();
-    const Bitboard pawns      = pos.pieces(Us, PAWN) & fromMask & ~frozen;
-    const Bitboard neutral    = pos.dead_squares();
-    const Bitboard movable    = pos.board_bb(Us, PAWN) & ~pos.pieces();
-    const Bitboard friendlyCapturable = pos.pieces(Us) & ~pos.pieces(Us, KING);
-    const Bitboard capturable = pos.board_bb(Us, PAWN)
-                              & (pos.self_capture(PAWN) ? (pos.pieces(Them) | friendlyCapturable | neutral)
-                                                    :  (pos.pieces(Them) | neutral));
+        Bitboard captureSquares = (Type == QUIETS || Type == QUIET_CHECKS) ? 0 : (attacks & capturable) & (Type == EVASIONS ? target : AllSquares);
+        Bitboard quietSquares   = (quiets & ~pos.pieces()) & (Type == EVASIONS ? target : AllSquares);
+        Bitboard epSquares = (Type == QUIETS || Type == QUIET_CHECKS) ? 0 : ((pos.en_passant_types(Us) & piece_set(PAWN)) ? (attacks & pos.ep_squares() & ~pos.pieces() & (Type == EVASIONS ? target : AllSquares)) : Bitboard(0));
+        Bitboard b1 = (captureSquares | quietSquares) & ~epSquares;
 
-    target = Type == EVASIONS ? target : AllSquares;
-
-    if (pos.topology_wraps())
-    {
+        Bitboard promotion_zone = pos.promotion_zone(Us, PAWN);
         Bitboard mandatoryPromotionZone = pos.mandatory_promotion_zone(Us, PAWN);
-        if (pos.mandatory_pawn_promotion())
-            mandatoryPromotionZone |= standardPromotionZone;
+        Bitboard pawnPromotions = (pos.promotion_pawn_types(Us) & piece_set(PAWN))
+                                ? (b1 & promotion_zone)
+                                : Bitboard(0);
 
-        auto has_promotion_for = [&](Square to) { return has_any_promotion(pos, Us, to); };
-
-        auto emit_promotions = [&](Square from, Square to) {
-            moveList = emit_promotion_variants<Type>(pos, moveList, Us, from, to);
-        };
-
-        Bitboard remaining = pawns;
-        while (remaining)
+        if (Type == QUIET_CHECKS)
         {
-            Square from = pop_lsb(remaining);
-            Bitboard quiets = pos.moves_from(Us, PAWN, from) & target;
-            Bitboard attacks = pos.attacks_from(Us, PAWN, from) & capturable & target;
-            Bitboard epSquares = pos.attacks_from(Us, PAWN, from) & pos.ep_squares() & ~pos.pieces() & target;
-            Bitboard quietPromotions = quiets & standardPromotionZone;
-            Bitboard capturePromotions = attacks & standardPromotionZone;
-
-            if (mandatoryPromotionZone)
-            {
-                Bitboard blocked = 0;
-                for (Bitboard candidates = (quiets | attacks) & mandatoryPromotionZone; candidates; )
-                {
-                    Square to = pop_lsb(candidates);
-                    if (!has_promotion_for(to))
-                        blocked |= to;
-                }
-                quiets &= ~blocked;
-                attacks &= ~blocked;
-                quietPromotions &= ~blocked;
-                capturePromotions &= ~blocked;
-                quiets &= ~mandatoryPromotionZone;
-                attacks &= ~mandatoryPromotionZone;
-            }
-
-            if (QuietChecks)
-                quiets &= pos.check_squares(PAWN);
-
-            if (GeneratesQuiets)
-                while (quiets)
-                    moveList = make_move_and_gating<NORMAL>(pos, moveList, Us, from, pop_lsb(quiets));
-
-            if (GeneratesCaptures)
-            {
-                while (attacks)
-                    moveList = make_move_and_gating<NORMAL>(pos, moveList, Us, from, pop_lsb(attacks));
-                while (epSquares)
-                {
-                    Square epSquare = pop_lsb(epSquares);
-                    if (Type == EVASIONS && (target & (epSquare + Up)) && !pos.non_sliding_riders())
-                        continue;
-                    moveList = make_move_and_gating<EN_PASSANT>(pos, moveList, Us, from, epSquare);
-                }
-            }
-
-            if (GeneratesQuiets)
-                while (quietPromotions)
-                    emit_promotions(from, pop_lsb(quietPromotions));
-            if (GeneratesCaptures)
-                while (capturePromotions)
-                    emit_promotions(from, pop_lsb(capturePromotions));
+            Bitboard nonPromotions = b1 & ~(promotion_zone | pawnPromotions);
+            nonPromotions &= pos.check_squares(PAWN);
+            b1 = nonPromotions | (b1 & (promotion_zone | pawnPromotions));
         }
 
-        return moveList;
-    }
+        if (mandatoryPromotionZone)
+            b1 &= ~mandatoryPromotionZone;
+        if (pawnPromotions && pos.mandatory_pawn_promotion())
+            b1 &= ~pawnPromotions;
 
-    // Define single and double push, left and right capture, as well as respective promotion moves
-    const Bitboard unmovedPawns = pawns & pos.not_moved_pieces(Us);
-
-    Bitboard b1 = shift<Up>(pawns) & movable & target;
-    Bitboard b2 = shift<Up>(shift<Up>(unmovedPawns & doubleStepRegion) & movable) & movable & target;
-    Bitboard b3 = shift<Up>(shift<Up>(shift<Up>(unmovedPawns & tripleStepRegion) & movable) & movable) & movable & target;
-    Bitboard brc = shift<UpRight>(pawns) & capturable & target;
-    Bitboard blc = shift<UpLeft >(pawns) & capturable & target;
-
-    Bitboard b1p = b1 & standardPromotionZone;
-    Bitboard b2p = b2 & standardPromotionZone;
-    Bitboard b3p = b3 & standardPromotionZone;
-    Bitboard brcp = brc & standardPromotionZone;
-    Bitboard blcp = blc & standardPromotionZone;
-    Bitboard rifleBrcp = pos.rifle_capture(make_piece(Us, PAWN)) ? brcp : Bitboard(0);
-    Bitboard rifleBlcp = pos.rifle_capture(make_piece(Us, PAWN)) ? blcp : Bitboard(0);
-    if (pos.rifle_capture(make_piece(Us, PAWN)))
-    {
-        brcp = 0;
-        blcp = 0;
-    }
-
-    Bitboard mandatoryPromotionZone = pos.mandatory_promotion_zone(Us, PAWN);
-    if (pos.mandatory_pawn_promotion()) {
-        mandatoryPromotionZone |= standardPromotionZone;
-    }
-
-    auto has_promotion_for = [&](Square to) { return has_any_promotion(pos, Us, to); };
-
-    auto emit_normal_moves = [&](Bitboard bb, Direction delta) {
-        while (bb)
+        while (b1)
         {
-            Square to = pop_lsb(bb);
-            moveList = make_move_and_gating<NORMAL>(pos, moveList, Us, to - delta, to);
+            Square to = pop_lsb(b1);
+            if (Type == EVASIONS || (Type == CAPTURES && (captureSquares & to)) || Type != CAPTURES)
+                moveList = make_move_and_gating<NORMAL>(pos, moveList, Us, from, to);
+        }
+
+        if (Type == EVASIONS || Type == CAPTURES || Type == NON_EVASIONS)
+        {
+            while (epSquares)
+                moveList = make_move_and_gating<EN_PASSANT>(pos, moveList, Us, from, pop_lsb(epSquares));
+        }
+
+        if (pawnPromotions)
+        {
+            while (pawnPromotions)
+            {
+                Square to = pop_lsb(pawnPromotions);
+                moveList = emit_promotion_variants<Type>(pos, moveList, Us, from, to);
+            }
         }
     };
 
-    auto filter_promotion_targets = [&](Bitboard bb) {
-        Bitboard filtered = 0;
-        while (bb)
-        {
-            Square to = pop_lsb(bb);
-            if (has_promotion_for(to))
-                filtered |= to;
-        }
-        return filtered;
-    };
+    while (initialBB)
+        generate_impl(pop_lsb(initialBB), true);
 
-    if (mandatoryPromotionZone)
+    while (normalBB)
+        generate_impl(pop_lsb(normalBB), false);
+
+    if (pos.sittuyin_promotion() && (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS))
     {
-        b1 &= ~mandatoryPromotionZone;
-        b2 &= ~mandatoryPromotionZone;
-        b3 &= ~mandatoryPromotionZone;
-        brc &= ~mandatoryPromotionZone;
-        blc &= ~mandatoryPromotionZone;
-        b1p = filter_promotion_targets(b1p);
-        b2p = filter_promotion_targets(b2p);
-        b3p = filter_promotion_targets(b3p);
-        brcp = filter_promotion_targets(brcp);
-        blcp = filter_promotion_targets(blcp);
-    }
-
-    Square ksq = pos.royal_square(Them);
-    if (QuietChecks && ksq != SQ_NONE)
-    {
-        // To make a quiet check, you either make a direct check by pushing a pawn
-        // or push a blocker pawn that is not on the same file as the enemy king.
-        // Discovered check promotion has been already generated amongst the captures.
-        Bitboard dcCandidatePawns = pos.blockers_for_king(Them) & ~file_bb(ksq);
-        b1 &= pawn_attacks_bb(Them, ksq) | shift<   Up>(dcCandidatePawns);
-        b2 &= pawn_attacks_bb(Them, ksq) | shift<Up+Up>(dcCandidatePawns);
-        b3 &= pawn_attacks_bb(Them, ksq) | shift<Up+Up+Up>(dcCandidatePawns);
-    }
-
-    // Single and double pawn pushes, no promotions
-    if (GeneratesQuiets)
-    {
-        emit_normal_moves(b1, Up);
-        emit_normal_moves(b2, Up + Up);
-        emit_normal_moves(b3, Up + Up + Up);
-    }
-
-    // Promotions and underpromotions
-    if (GeneratesCaptures)
-    {
-        while (brcp)
-            moveList = make_promotions<Us, Type, UpRight>(pos, moveList, pop_lsb(brcp));
-
-        while (blcp)
-            moveList = make_promotions<Us, Type, UpLeft >(pos, moveList, pop_lsb(blcp));
-    }
-
-    while (b1p)
-        moveList = make_promotions<Us, Type, Up     >(pos, moveList, pop_lsb(b1p));
-
-    while (b2p)
-        moveList = make_promotions<Us, Type, Up+Up  >(pos, moveList, pop_lsb(b2p));
-
-    while (b3p)
-        moveList = make_promotions<Us, Type, Up+Up+Up>(pos, moveList, pop_lsb(b3p));
-
-    if (GeneratesCaptures)
-    {
-        emit_normal_moves(rifleBrcp, UpRight);
-        emit_normal_moves(rifleBlcp, UpLeft);
-    }
-
-    // Sittuyin promotions
-    if (pos.sittuyin_promotion() && GeneratesCaptures)
-    {
+        Bitboard pawns = pos.pieces(Us, PAWN) & fromMask & ~frozen;
+        Bitboard promotionZone = pos.promotion_zone(Us, PAWN);
         // Pawns need to be in promotion zone if there is more than one pawn
         Bitboard promotionPawns = pos.count<PAWN>(Us) > 1 ? pawns & promotionZone : pawns;
+        Bitboard localTarget = Type == EVASIONS ? target : AllSquares;
         while (promotionPawns)
         {
             Square from = pop_lsb(promotionPawns);
@@ -657,38 +521,14 @@ namespace {
                 PieceType pt = pop_msb(ps);
                 if (!pos.promotion_allowed(Us, pt))
                     continue;
-                Bitboard b = ((pos.attacks_from(Us, pt, from) & ~(pos.pieces() | pos.dead_squares())) | from) & target;
+                Bitboard b = ((pos.attacks_from(Us, pt, from) & ~(pos.pieces() | pos.dead_squares())) | from) & localTarget;
                 while (b)
                 {
                     Square to = pop_lsb(b);
-                    if (!(pos.attacks_bb(Us, pt, to, pos.pieces() ^ from) & pos.pieces(Them)))
+                    if (!(pos.attacks_bb(Us, pt, to, pos.pieces() ^ from) & pos.pieces(~Us)))
                         *moveList++ = make<PROMOTION>(from, to, pt);
                 }
             }
-        }
-    }
-
-    // Standard and en passant captures
-    if (GeneratesCaptures)
-    {
-        emit_normal_moves(brc, UpRight);
-        emit_normal_moves(blc, UpLeft);
-
-        for (Bitboard epSquares = pos.ep_squares() & ~(pos.pieces() | pos.dead_squares()); epSquares; )
-        {
-            Square epSquare = pop_lsb(epSquares);
-
-            // An en passant capture cannot resolve a discovered check (unless there non-sliding riders)
-            if (Type == EVASIONS && (target & (epSquare + Up)) && !pos.non_sliding_riders())
-                continue;
-
-            Bitboard b = pawns & pawn_attacks_bb(Them, epSquare);
-
-            // En passant square is already disabled for non-fairy variants if there is no attacker
-            assert(b || !pos.fast_attacks());
-
-            while (b)
-                moveList = make_move_and_gating<EN_PASSANT>(pos, moveList, Us, pop_lsb(b), epSquare);
         }
     }
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -634,14 +634,14 @@ namespace {
     return pos.attacks_from(c, pt, sq, syntheticOccupancy);
   }
 
-  Bitboard rose_revealed_blockers(Square target, Square attackerSq, Bitboard occupied, const MagicGeometry* mg) {
+  Bitboard rose_revealed_blockers(Square target, Square attackerSq, Bitboard occupied) {
     Bitboard blockers = 0;
     Bitboard candidates = rose_between_union_bb(target, attackerSq, Bitboard(0)) & occupied & ~square_bb(attackerSq);
 
     while (candidates)
     {
         Square blocker = pop_lsb(candidates);
-        if (rose_attacks_bb(attackerSq, occupied ^ square_bb(blocker), mg) & target)
+        if (rose_attacks_bb(attackerSq, occupied ^ square_bb(blocker)) & target)
             blockers |= blocker;
     }
 
@@ -2456,7 +2456,7 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
     PieceType sniperType = type_of(sniper);
     if (AttackRiderTypes[sniperType] & RIDER_ROSE)
     {
-        Bitboard b = rose_revealed_blockers(s, sniperSq, occupancy, magic_geometry());
+        Bitboard b = rose_revealed_blockers(s, sniperSq, occupancy);
         if (b && !more_than_one(b))
             pinners |= pieces(c) & sniperSq;
         blockers |= b;

--- a/src/position.h
+++ b/src/position.h
@@ -531,34 +531,27 @@ public:
 
   template<PieceType Pt>
   Bitboard attacks_bb(Square s, Bitboard occupied = 0) const {
-    return Stockfish::attacks_bb<Pt>(s, occupied, magic_geometry());
+    return Stockfish::attacks_bb<Pt>(s, occupied);
   }
 
   template<RiderType R>
   Bitboard rider_attacks_bb(Square s, Bitboard occupied = 0) const {
-    return Stockfish::rider_attacks_bb<R>(s, occupied, magic_geometry());
+    return Stockfish::rider_attacks_bb<R>(s, occupied);
   }
 
   Bitboard rider_attacks_bb(RiderType R, Square s, Bitboard occupied = 0) const {
-    return Stockfish::rider_attacks_bb(R, s, occupied, magic_geometry());
+    return Stockfish::rider_attacks_bb(R, s, occupied);
   }
 
   Bitboard attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied) const {
-    return Stockfish::attacks_bb(c, pt, s, occupied, magic_geometry());
+    return Stockfish::attacks_bb(c, pt, s, occupied);
   }
 
   template <bool Initial=false>
   Bitboard moves_bb(Color c, PieceType pt, Square s, Bitboard occupied) const {
-    return Stockfish::moves_bb<Initial>(c, pt, s, occupied, magic_geometry());
+    return Stockfish::moves_bb<Initial>(c, pt, s, occupied);
   }
 
-  const MagicGeometry* magic_geometry() const {
-      if (!variant()->magicGeometry)
-          const_cast<Variant*>(variant())->magicGeometry = Stockfish::Bitboards::init_magics(
-              variant()->cylindrical || variant()->toroidal ? variant()->maxFile : FILE_MAX,
-              variant()->cylindrical || variant()->toroidal ? variant()->maxRank : RANK_MAX);
-      return variant()->magicGeometry.get();
-  }
   CountingRule counting_rule() const;
 
   // Variant-specific properties
@@ -580,6 +573,8 @@ public:
   Bitboard pieces(Color c, PieceType pt1, PieceType pt2, PieceType pt3) const;
   Bitboard major_pieces(Color c) const;
   Bitboard non_sliding_riders() const;
+  Bitboard line_bb(Square s1, Square s2) const;
+  Bitboard between_bb(Square s1, Square s2, PieceType pt = NO_PIECE_TYPE) const;
   Piece piece_on(Square s) const;
   Piece unpromoted_piece_on(Square s) const;
   Bitboard ep_squares() const;
@@ -615,13 +610,18 @@ public:
   Bitboard attackers_to(Square s, Bitboard occupied) const;
   Bitboard attackers_to(Square s, Bitboard occupied, Color c) const;
   Bitboard attackers_to(Square s, Bitboard occupied, Color c, Bitboard janggiCannons) const;
-  Bitboard janggi_cannon_attackers_to_king(Square s, Bitboard occupied, Color c) const;
   Bitboard attackers_to_king(Square s, Color c) const;
   Bitboard attackers_to_king(Square s, Bitboard occupied, Color c) const;
   Bitboard attackers_to_king(Square s, Bitboard occupied, Color c, Bitboard janggiCannons, PieceType pt = NO_PIECE_TYPE) const;
+  Bitboard janggi_cannon_attackers_to_king(Square s, Bitboard occupied, Color c) const;
+  template <bool Initial=false>
   Bitboard attacks_from(Color c, PieceType pt, Square s) const;
+  template <bool Initial=false>
   Bitboard attacks_from(Color c, PieceType pt, Square s, Bitboard occupancy) const;
+  template <bool Initial=false>
   Bitboard moves_from(Color c, PieceType pt, Square s) const;
+  template <bool Initial=false>
+  Bitboard moves_from(Color c, PieceType pt, Square s, Bitboard occupancy) const;
   Bitboard universal_hopper_potential_bb(PieceType pt, Square s) const;
   Bitboard push_targets_from(Color c, PieceType pt, Square s) const;
   Bitboard slider_blockers(Bitboard sliders, Square s, Bitboard& pinners, Color c) const;
@@ -806,10 +806,11 @@ private:
                                          bool includeOwnBlockedAttacks,
                                          AdvanceFn advance,
                                          MidpointFn midpoint) const;
+  template <bool Initial=false>
   Bitboard special_rider_bb(const PieceInfo* pi, MoveModality modality,
                             Square sq, Bitboard occupied,
                             Bitboard boardMask, Bitboard ownPieces,
-                            Color c, bool initial, bool captureMode,
+                            Color c, bool captureMode,
                             bool includeOwnBlockedAttacks = false) const;
   Bitboard universal_hopper_bb(const std::map<Direction, PieceInfo::HopperProfile>& profiles,
                                Square sq, Bitboard occupied,
@@ -2742,6 +2743,15 @@ inline Bitboard Position::non_sliding_riders() const {
   return st->nonSlidingRiders;
 }
 
+inline Bitboard Position::line_bb(Square s1, Square s2) const {
+  return Stockfish::line_bb(s1, s2);
+}
+
+inline Bitboard Position::between_bb(Square s1, Square s2, PieceType pt) const {
+  return pt == NO_PIECE_TYPE ? Stockfish::between_bb(s1, s2)
+                             : Stockfish::between_bb(s1, s2, pt);
+}
+
 inline int Position::count(Color c, PieceType pt) const {
   return pieceCount[make_piece(c, pt)];
 }
@@ -2793,7 +2803,7 @@ inline Square Position::gate_square(Move m) const {
 }
 
 inline bool Position::is_on_semiopen_file(Color c, Square s) const {
-  return !((pieces(c, PAWN) | pieces(c, SHOGI_PAWN, SOLDIER)) & file_bb(s));
+  return !((pieces(c, PAWN) | pieces(c, SHOGI_PAWN, SOLDIER)) & Stockfish::file_bb(file_of(s)));
 }
 
 inline bool Position::can_castle(CastlingRights cr) const {
@@ -2832,7 +2842,7 @@ inline Bitboard Position::dynamic_slider_bb(const std::map<Direction,int>& direc
     Square    nxt  = sq + step;
     if (!is_ok(nxt) || distance(nxt, nxt - step) > 2) continue; // only rook/bishop steps
 
-    Bitboard line = line_bb(sq, nxt);                 // through board edge
+    Bitboard line = Stockfish::line_bb(sq, nxt);                 // through board edge
     int dist = popcount(line & occupiedAll);          // how far to travel
 
     Square dest = sq;
@@ -3207,10 +3217,11 @@ inline bool Position::is_valid_hopper_destination(const PieceInfo::HopperProfile
         && (profile.equiRule != PieceInfo::EQUI_HOPPER || distFromLastHurdle == distToFirstHurdle);
 }
 
+template <bool Initial>
 inline Bitboard Position::special_rider_bb(const PieceInfo* pi, MoveModality modality,
                                            Square sq, Bitboard occupied,
                                            Bitboard boardMask, Bitboard ownPieces,
-                                           Color c, bool initial, bool captureMode,
+                                           Color c, bool captureMode,
                                            bool includeOwnBlockedAttacks) const
 {
   if (!pi->has_runtime_rider_augment())
@@ -3218,11 +3229,11 @@ inline Bitboard Position::special_rider_bb(const PieceInfo* pi, MoveModality mod
   Bitboard b = 0;
   const uint8_t augment = pi->riderAugmentMask;
   if (augment & PieceInfo::AUGMENT_DYNAMIC)
-      b |= Position::dynamic_slider_bb(pi->slider[0][modality], sq, occupied, occupied, c);
+      b |= Position::dynamic_slider_bb(pi->slider[Initial][modality], sq, occupied, occupied, c);
   if (augment & PieceInfo::AUGMENT_MAX)
-      b |= Position::max_slider_bb(pi->slider[0][modality], sq, occupied, boardMask, ownPieces, c, captureMode, includeOwnBlockedAttacks);
-  if (!pi->universalHopper[initial ? 1 : 0][modality].empty())
-      b |= universal_hopper_bb(pi->universalHopper[initial ? 1 : 0][modality], sq, occupied, ownPieces, c, captureMode, includeOwnBlockedAttacks);
+      b |= Position::max_slider_bb(pi->slider[Initial][modality], sq, occupied, boardMask, ownPieces, c, captureMode, includeOwnBlockedAttacks);
+  if (!pi->universalHopper[Initial][modality].empty())
+      b |= universal_hopper_bb(pi->universalHopper[Initial][modality], sq, occupied, ownPieces, c, captureMode, includeOwnBlockedAttacks);
   return b;
 }
 
@@ -3346,14 +3357,6 @@ inline Bitboard Position::universal_hopper_bb(const std::map<Direction, PieceInf
         return true;
     };
     return universal_hopper_targets_impl(profiles, sq, occupied, ownPieces, c, captureMode, includeOwnBlockedAttacks, advance, midpoint);
-}
-
-inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s) const {
-  assert(pt != NO_PIECE_TYPE);
-  Bitboard occupancy = byTypeBB[ALL_PIECES];
-  if (const SpellContext* spellCtx = current_spell_context(); spellCtx && c == sideToMove)
-      occupancy &= ~spellCtx->jumpRemoved;
-  return attacks_from(c, pt, s, occupancy);
 }
 
 inline Bitboard Position::wrapped_universal_hopper_targets(const std::map<Direction, PieceInfo::HopperProfile>& profiles,
@@ -3704,6 +3707,17 @@ inline Bitboard Position::lame_leaper_bb(const std::map<Direction, PieceInfo::La
     return b;
 }
 
+template <bool Initial>
+inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s) const {
+  assert(pt != NO_PIECE_TYPE);
+  Bitboard occupancy = byTypeBB[ALL_PIECES];
+  if (const SpellContext* spellCtx = current_spell_context(); spellCtx && c == sideToMove)
+      occupancy &= ~spellCtx->jumpRemoved;
+  return attacks_from<Initial>(c, pt, s, occupancy);
+}
+
+
+template <bool Initial>
 inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s, Bitboard occupancy) const {
   assert(pt != NO_PIECE_TYPE);
 
@@ -3733,7 +3747,12 @@ inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s, Bitboard
       b |= wrapped_hopper_targets(pi->hopper[0][MODALITY_CAPTURE], s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, false);
       b |= wrapped_universal_hopper_targets(pi->universalHopper[0][MODALITY_CAPTURE], c, s, occupancy, pieces(c), max_file(), max_rank(), wrapFile, wrapRank, true, true);
       b |= lame_leaper_bb(pi->stepsLame[0][MODALITY_CAPTURE], s, occupancy, c, false);
-      if (double_step_region(c, pt) & s)
+      const bool usesGenericPawnLikeInitialAttackHelper =
+             pt == PAWN || (pawn_like_types(c) & piece_set(pt));
+      const Bitboard initialAttackRegion = usesGenericPawnLikeInitialAttackHelper
+                                         ? double_step_region(c, pt)
+                                         : var->doubleStepRegion.get(c).explicitBoardOfPiece(piece_to_char()[pt]);
+      if ((initialAttackRegion & s) && (Initial || (not_moved_pieces(c) & s)))
       {
           b |= wrapped_universal_hopper_targets(pi->universalHopper[1][MODALITY_CAPTURE], c, s, occupancy, pieces(c), max_file(), max_rank(), wrapFile, wrapRank, true, true);
           b |= lame_leaper_bb(pi->stepsLame[1][MODALITY_CAPTURE], s, occupancy, c, false);
@@ -3802,21 +3821,21 @@ inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s, Bitboard
 
   Bitboard b = attacks_bb(c, movePt, s, occupancy);
 
-  b |= special_rider_bb(pi, MODALITY_CAPTURE, s, occupancy, board_bb(), pieces(c), c, false, true, true);
+  b |= special_rider_bb<false>(pi, MODALITY_CAPTURE, s, occupancy, board_bb(), pieces(c), c, true, true);
   b |= lame_leaper_bb(pi->stepsLame[0][MODALITY_CAPTURE], s, occupancy, c, false);
   const bool usesGenericPawnLikeInitialAttackHelper =
          pt == PAWN || (pawn_like_types(c) & piece_set(pt));
   const Bitboard initialAttackRegion = usesGenericPawnLikeInitialAttackHelper
                                      ? double_step_region(c, pt)
                                      : var->doubleStepRegion.get(c).explicitBoardOfPiece(piece_to_char()[pt]);
-  if (initialAttackRegion & s)
+  if ((initialAttackRegion & s) && (Initial || (not_moved_pieces(c) & s)))
   {
-      b |= special_rider_bb(pi, MODALITY_CAPTURE, s, occupancy, board_bb(), pieces(c), c, true, true, true);
+      b |= special_rider_bb<true>(pi, MODALITY_CAPTURE, s, occupancy, board_bb(), pieces(c), c, true, true);
       b |= lame_leaper_bb(pi->stepsLame[1][MODALITY_CAPTURE], s, occupancy, c, false);
   }
 
   // Xiangqi soldier
-  if (pt == SOLDIER && !(promoted_soldiers(c) & s))
+  if (pt == SOLDIER && !(zone_bb(c, var->soldierPromotionRank, max_rank()) & s))
       b &= file_bb(file_of(s));
   // Janggi cannon restrictions
   if (pt == JANGGI_CANNON)
@@ -3839,17 +3858,23 @@ inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s, Bitboard
   return b & board_bb(c, pt);
 }
 
+template <bool Initial>
 inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
+  assert(pt != NO_PIECE_TYPE);
+  Bitboard occupancy = byTypeBB[ALL_PIECES];
+  if (const SpellContext* spellCtx = current_spell_context(); spellCtx && c == sideToMove)
+      occupancy &= ~spellCtx->jumpRemoved;
+  return moves_from<Initial>(c, pt, s, occupancy);
+}
+
+template <bool Initial>
+inline Bitboard Position::moves_from(Color c, PieceType pt, Square s, Bitboard occupancy) const {
     assert(pt != NO_PIECE_TYPE);
 
     Bitboard extraDestinations = 0x00;
 
     if (topology_wraps())
     {
-        Bitboard occupancy = byTypeBB[ALL_PIECES];
-        if (const SpellContext* spellCtx = current_spell_context(); spellCtx && c == sideToMove)
-            occupancy &= ~spellCtx->jumpRemoved;
-
         PieceType movePt = effective_piece_type(pt);
         const PieceInfo* pi = pieceMap.get(movePt);
         const bool wrapFile = wraps_files();
@@ -3862,14 +3887,14 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
             Square to = SQ_NONE;
             if (wrapped_destination_square(s, 0, forward, max_file(), max_rank(), wrapFile, wrapRank, to) && !(occupancy & to))
             {
-                b |= to;
+                b |= square_bb(to);
                 if ((double_step_region(c, pt) & s)
-                    && (not_moved_pieces(c) & s)
+                    && (Initial || (not_moved_pieces(c) & s))
                     && wrapped_destination_square(to, 0, forward, max_file(), max_rank(), wrapFile, wrapRank, to)
                     && !(occupancy & to))
-                    b |= to;
+                    b |= square_bb(to);
             }
-            if ((triple_step_region(c, pt) & s) && (not_moved_pieces(c) & s))
+            if ((triple_step_region(c, pt) & s) && (Initial || (not_moved_pieces(c) & s)))
             {
                 Square s1 = SQ_NONE, s2 = SQ_NONE, s3 = SQ_NONE;
                 if (wrapped_destination_square(s, 0, forward, max_file(), max_rank(), wrapFile, wrapRank, s1)
@@ -3878,7 +3903,7 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
                     && !(occupancy & s2)
                     && wrapped_destination_square(s2, 0, forward, max_file(), max_rank(), wrapFile, wrapRank, s3)
                     && !(occupancy & s3))
-                    b |= s1 | s2 | s3;
+                    b |= square_bb(s1) | square_bb(s2) | square_bb(s3);
             }
             return b & board_bb(c, pt);
         }
@@ -3899,7 +3924,7 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
         if (pi->rose[0][MODALITY_QUIET])
             b |= wrapped_rose_targets(s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
 
-        if (double_step_region(c, pt) & s)
+        if ((double_step_region(c, pt) & s) && (Initial || (not_moved_pieces(c) & s)))
         {
             b |= wrapped_step_targets(pi->steps[1][MODALITY_QUIET], s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
             b |= wrapped_tuple_targets(pi->tupleSteps[1][MODALITY_QUIET], c, s, occupancy, max_file(), max_rank(), wrapFile, wrapRank, true);
@@ -3927,7 +3952,6 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
     // Due to some unknown issues, shift<Direction D>(Bitboard b) cannot be used here
     const Bitboard explicitTripleStepRegion = var->tripleStepRegion.get(c).explicitBoardOfPiece(piece_to_char()[pt]);
     const Bitboard explicitDoubleStepRegion = var->doubleStepRegion.get(c).explicitBoardOfPiece(piece_to_char()[pt]);
-    Bitboard occupied = this->pieces();  //Bitboard where the bits whose corresponding squares having a piece on it are 1
     Bitboard piecePosition = square_bb(s);  //Bitboard where only the bit which refers to the square that the piece starts the move (original square) is 1
     PieceType movePt = effective_piece_type(pt);
     const PieceInfo* pi = pieceMap.get(movePt);
@@ -3949,19 +3973,21 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
         && !pawnLikeHasCustomNonStepQuietMovement
         && !explicitTripleStepRegion
         && !explicitDoubleStepRegion;
-    if (explicitTripleStepRegion & piecePosition & this->not_moved_pieces(c))  //If the original square is in explicit tripleStepRegion and the piece is not moved
+    const Bitboard tripleStepRegion = usesGenericPawnLikeStepHelper ? this->triple_step_region(c)
+                                                                    : explicitTripleStepRegion;
+    if (tripleStepRegion & piecePosition & (Initial ? AllSquares : this->not_moved_pieces(c)))  //If the original square is in tripleStepRegion and the piece is not moved
     {
         Bitboard extraMultipleStepMoveDestinations = 0x00;  //Bitboard where extra legal multi-step destination square bits are 1
         Bitboard oneSquareAhead = (c == WHITE) ? piecePosition << NORTH : piecePosition >> NORTH;
-        if (!(oneSquareAhead & occupied))  //If the square which is 1 square ahead of original square is NOT blocked
+        if (!(oneSquareAhead & occupancy))  //If the square which is 1 square ahead of original square is NOT blocked
         {
             extraMultipleStepMoveDestinations |= oneSquareAhead;  //Add the square which is 1 square ahead of original square to destination squares for triple step
             Bitboard twoSquareAhead = (c == WHITE) ? piecePosition << NORTH << NORTH : piecePosition >> NORTH >> NORTH;
-            if (!(twoSquareAhead & occupied))  //If the square which is 2 squares ahead of original square is NOT blocked
+            if (!(twoSquareAhead & occupancy))  //If the square which is 2 squares ahead of original square is NOT blocked
             {
                 extraMultipleStepMoveDestinations |= twoSquareAhead;  //Add the square which is 2 squares ahead of original square to destination squares for triple step
                 Bitboard threeSquareAhead = (c == WHITE) ? piecePosition << NORTH << NORTH << NORTH : piecePosition >> NORTH >> NORTH >> NORTH;
-                if (!(threeSquareAhead & occupied))  //If the square which is 3 squares ahead of original square is NOT blocked
+                if (!(threeSquareAhead & occupancy))  //If the square which is 3 squares ahead of original square is NOT blocked
                 {
                     extraMultipleStepMoveDestinations |= threeSquareAhead;  //Add the square which is 3 squares ahead of original square to destination squares for triple step
                 }
@@ -3971,15 +3997,15 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
     }
     Bitboard doubleStepRegion = usesGenericPawnLikeStepHelper ? this->double_step_region(c)
                                                               : explicitDoubleStepRegion;
-    if (doubleStepRegion & piecePosition & this->not_moved_pieces(c))  //If the original square is in doubleStepRegion and the piece is not moved
+    if (doubleStepRegion & piecePosition & (Initial ? AllSquares : this->not_moved_pieces(c)))  //If the original square is in doubleStepRegion and the piece is not moved
     {
         Bitboard extraMultipleStepMoveDestinations = 0x00;  //Bitboard where extra legal multi-step destination square bits are 1
         Bitboard oneSquareAhead = (c == WHITE) ? piecePosition << NORTH : piecePosition >> NORTH;
-        if (!(oneSquareAhead & occupied))  //If the square which is 1 square ahead of original square is NOT blocked
+        if (!(oneSquareAhead & occupancy))  //If the square which is 1 square ahead of original square is NOT blocked
         {
             extraMultipleStepMoveDestinations |= oneSquareAhead;  //Add the square which is 1 square ahead of original square to destination squares for double step
             Bitboard twoSquareAhead = (c == WHITE) ? piecePosition << NORTH << NORTH : piecePosition >> NORTH >> NORTH;
-            if (!(twoSquareAhead & occupied))  //If the square which is 2 squares ahead of original square is NOT blocked
+            if (!(twoSquareAhead & occupancy))  //If the square which is 2 squares ahead of original square is NOT blocked
             {
                 extraMultipleStepMoveDestinations |= twoSquareAhead;  //Add the square which is 2 squares ahead of original square to destination squares for double step
             }
@@ -3987,25 +4013,9 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
         extraDestinations |= extraMultipleStepMoveDestinations; //Add destination squares to base board
     }
 
-  Bitboard occupancy = byTypeBB[ALL_PIECES];
-  if (const SpellContext* spellCtx = current_spell_context(); spellCtx && c == sideToMove)
-      occupancy &= ~spellCtx->jumpRemoved;
+  Bitboard b = (moves_bb<false>(c, movePt, s, occupancy) | extraDestinations);
 
-  const bool hasRuntimeSpecialMoves = pi->has_runtime_rider_augment()
-                                   || pi->has_explicit_initial_moves();
-
-  if (!hasRuntimeSpecialMoves && !pi->has_lame_leaper() && (fast_attacks() || fast_attacks2()) && (pt != KING || king_type() == KING))
-      return (moves_bb(c, pt, s, occupancy) | extraDestinations) & board_bb();
-
-  if (!pi->has_explicit_initial_moves()
-      && (fast_attacks() || fast_attacks2())
-      && !pi->has_runtime_rider_augment()
-      && !pi->has_lame_leaper())
-      return (moves_bb(c, movePt, s, occupancy) | extraDestinations) & board_bb();
-
-  Bitboard b = (moves_bb(c, movePt, s, occupancy) | extraDestinations);
-
-  b |= special_rider_bb(pi, MODALITY_QUIET, s, occupancy, board_bb(), pieces(c), c, false, false, false);
+  b |= special_rider_bb<false>(pi, MODALITY_QUIET, s, occupancy, board_bb(), pieces(c), c, false, false);
   b |= lame_leaper_bb(pi->stepsLame[0][MODALITY_QUIET], s, occupancy, c, true);
 
   const bool usesGenericPawnLikeInitialMoveHelper =
@@ -4017,27 +4027,27 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
                                    : var->doubleStepRegion.get(c).explicitBoardOfPiece(piece_to_char()[pt]);
 
   // Add initial moves
-  if ((initialMoveRegion & s) && (this->not_moved_pieces(c) & s))
+  if ((initialMoveRegion & s) && (Initial || (this->not_moved_pieces(c) & s)))
   {
       b |= moves_bb<true>(c, movePt, s, occupancy);
-      b |= special_rider_bb(pi, MODALITY_QUIET, s, occupancy, board_bb(), pieces(c), c, true, false, false);
+      b |= special_rider_bb<true>(pi, MODALITY_QUIET, s, occupancy, board_bb(), pieces(c), c, false, false);
       b |= lame_leaper_bb(pi->stepsLame[1][MODALITY_QUIET], s, occupancy, c, true);
   }
   // Xiangqi soldier
-  if (pt == SOLDIER && !(promoted_soldiers(c) & s))
+  if (pt == SOLDIER && !(zone_bb(c, var->soldierPromotionRank, max_rank()) & s))
       b &= file_bb(file_of(s));
   // Janggi cannon restrictions
   if (pt == JANGGI_CANNON)
   {
       b &= ~pieces(pt);
-      b &= attacks_bb(c, pt, s, (occupancy ^ pieces(pt)));
+      b &= moves_bb<false>(c, pt, s, (occupancy ^ pieces(pt)));
   }
   // Janggi palace moves
   if (diagonal_lines() & s)
   {
       PieceType diagType = movePt == WAZIR ? FERS : movePt == SOLDIER ? PAWN : movePt == ROOK ? BISHOP : NO_PIECE_TYPE;
       if (diagType)
-          b |= attacks_bb(c, diagType, s, occupancy) & diagonal_lines();
+          b |= moves_bb<false>(c, diagType, s, occupancy) & diagonal_lines();
       else if (movePt == JANGGI_CANNON)
           b |=  rider_attacks_bb<RIDER_CANNON_DIAG>(s, occupancy)
               & rider_attacks_bb<RIDER_CANNON_DIAG>(s, (occupancy ^ pieces(pt)))

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -71,10 +71,8 @@ std::set<string, UCI::CaseInsensitiveLess> standard_variants = {
 
 void init_variant(const Variant* v) {
     const bool useBoardSizeMagics = bool(Options["DynamicMagicsByBoardSize"]) || v->cylindrical || v->toroidal;
-    if (!v->magicGeometry)
-        const_cast<Variant*>(v)->magicGeometry = useBoardSizeMagics
-                                               ? Bitboards::init_magics(v->maxFile, v->maxRank)
-                                               : Bitboards::init_magics(FILE_MAX, RANK_MAX);
+    Bitboards::init_magics(useBoardSizeMagics ? v->maxFile : FILE_MAX,
+                           useBoardSizeMagics ? v->maxRank : RANK_MAX);
     pieceMap.init(v);
     Bitboards::init_wrapped_rays(v->maxFile, v->maxRank, v->cylindrical || v->toroidal, v->toroidal);
     Bitboards::init_pieces();

--- a/src/variant.h
+++ b/src/variant.h
@@ -314,7 +314,7 @@ struct Variant {
   int nFoldRuleImmediate = 0;
   ColorSetting<Value> nFoldValue = ColorSetting<Value>(VALUE_DRAW);
 
-  std::shared_ptr<const MagicGeometry> magicGeometry;
+
 
   bool nFoldValueAbsolute = false;
   bool perpetualCheckIllegal = false;


### PR DESCRIPTION
  PR Summary: Porting Unified Attack Engine & Magic Simplification

  This PR integrates the significant refactoring from #122 into the latest master, focusing on architectural
  unification and performance optimization for complex piece movements.

  Core Changes:
   1. Templated Attack Logic: Unified attacks_from<Initial>, attackers_to, and set_check_info.All changes have been
      committed to the pr-122-manual-merge branch. The commit includes the unified attack engine refactor, the
      simplified magic bitboard infrastructure, and several robustness fixes (such as resolving bitwise ambiguities and
      improving lame_leaper_path).

  Commit Summary: f9de29c3 - Integrate PR #122: Unified attack engine and magic bitboard simplification.

  PR Comment Draft:
  This commit integrates the core architectural refactor and magic bitboard simplification from PR #122 into the latest
  master.

  Key Enhancements:
   - Unified Attack Engine: Consolidated attacks_from, attackers_to, and set_check_info using a template <bool Initial>
     pattern, streamlining the logic for initial-step dependent pieces.
   - Simplified Magic Bitboards: Replaced MagicGeometry with global magic bitboard arrays and a simplified lookup
     pointer array (magics[]), reducing overhead.
   - Expanded Rider Support: Updated RiderType enum and added bitboard helpers for RIDER_ROSE and other non-sliding
     riders.
   - Robustness: Resolved bitwise operator ambiguities, fixed precomputed magic initialization for large boards, and
     improved lame_leaper_path safety.
