### PR TITLE
Fixes from PR 80 rebased

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -148,12 +148,13 @@ vector<string> setup_bench(const Position& current, istream& is) {
   string limitType = next_arg(idx, "depth");
   string evalType  = next_arg(idx, "mixed");
 
-  auto is_uint = [](const string& s) {
-      return !s.empty() && std::all_of(s.begin(), s.end(), [](unsigned char ch) { return std::isdigit(ch) != 0; });
+  auto is_uint = [](const string& s, bool allowZero = true) {
+      return !s.empty() && std::all_of(s.begin(), s.end(), [](unsigned char ch) { return std::isdigit(ch) != 0; })
+             && (allowZero || std::any_of(s.begin(), s.end(), [](char ch) { return ch != '0'; }));
   };
-  if (!is_uint(ttSize))
+  if (!is_uint(ttSize, false))
       ttSize = "16";
-  if (!is_uint(threads))
+  if (!is_uint(threads, false))
       threads = "1";
   if (limitType != "eval" && !is_uint(limit))
       limit = "13";

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1990,10 +1990,6 @@ Bitboard Position::compute_checkers_bb(Color side) const {
 
   if (!allow_checks())
   {
-      if (pseudo_royal_types())
-          checkers |= checked_pseudo_royals(side);
-      if (anti_royal_types())
-          checkers |= checked_anti_royals(side);
       if (var->blastPassiveTypes)
           checkers |= passive_blast_checkers(side, pieces());
   }
@@ -3409,7 +3405,8 @@ bool Position::legal(Move m) const {
       {
           if ((capture(m) || rifleShot) && blast_on_capture(m))
           {
-              moverRemovedByBlast = (blast_center() && effectiveTo == shotSq);
+              moverRemovedByBlast = zero_range_blast_on_capture(m)
+                                 || (blast_center() && effectiveTo == shotSq);
           }
           else if ((blast_on_move() && !capture(m) && !is_self_destruct(m))
                 || (blast_on_self_destruct() && is_self_destruct(m)))


### PR DESCRIPTION
This PR completes the remaining beneficial changes from the original PR #80, which was significantly behind master and has been closed.

Changes included:
- **Pseudo-royal safety check node count bug**: Removed pseudo-royal and anti-royal squares from `checkersBB`. This prevents the engine from incorrectly reporting check status based on the royal piece's own square, which previously caused issues in node counting and search heuristics for certain variants.
- **Immobility legality for blast captures**: Added missing `zero_range_blast_on_capture(m)` check to ensure the engine correctly identifies moves where the mover is removed by its own blast.
- **Tightened benchmark command parsing**: Added validation to ensure `ttSize` and `threads` are greater than zero.