### PR TITLE
NNUE: stage experimental SIMD kernels (Rebased)

### DIFF
--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -145,11 +145,12 @@ namespace Stockfish::Eval::NNUE::Layers {
         __m512i product1 = _mm512_maddubs_epi16(a1, b1);
         __m512i product2 = _mm512_maddubs_epi16(a2, b2);
         __m512i product3 = _mm512_maddubs_epi16(a3, b3);
-        product0 = _mm512_adds_epi16(product0, product1);
         product0 = _mm512_madd_epi16(product0, Ones512);
-        product2 = _mm512_adds_epi16(product2, product3);
+        product1 = _mm512_madd_epi16(product1, Ones512);
         product2 = _mm512_madd_epi16(product2, Ones512);
-        acc = _mm512_add_epi32(acc, _mm512_add_epi32(product0, product2));
+        product3 = _mm512_madd_epi16(product3, Ones512);
+        acc = _mm512_add_epi32(acc, _mm512_add_epi32(_mm512_add_epi32(product0, product1),
+                                                    _mm512_add_epi32(product2, product3)));
 #endif
       };
 
@@ -403,14 +404,28 @@ namespace Stockfish::Eval::NNUE::Layers {
         output[i] = _mm_cvtsi64_si32(sum);
 
 #elif defined(USE_NEON)
+#if defined(__aarch64__)
+        int32x4_t sum = vsetq_lane_s32(biases[i], vdupq_n_s32(0), 0);
+#else
         int32x4_t sum = {biases[i]};
+#endif
         const auto row = reinterpret_cast<const int8x8_t*>(&weights[offset]);
         for (IndexType j = 0; j < NumChunks; ++j) {
+#if defined(__ARM_FEATURE_DOTPROD)
+          const auto in = reinterpret_cast<const int8x16_t*>(&inputVector[j * 2])[0];
+          const auto rw = reinterpret_cast<const int8x16_t*>(&row[j * 2])[0];
+          sum = vdotq_s32(sum, in, rw);
+#else
           int16x8_t product = vmull_s8(inputVector[j * 2], row[j * 2]);
           product = vmlal_s8(product, inputVector[j * 2 + 1], row[j * 2 + 1]);
           sum = vpadalq_s16(sum, product);
+#endif
         }
+#if defined(__aarch64__)
+        output[i] = vaddvq_s32(sum);
+#else
         output[i] = sum[0] + sum[1] + sum[2] + sum[3];
+#endif
 
 #else
         OutputType sum = biases[i];

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -71,6 +71,26 @@ namespace Stockfish::Eval::NNUE::Layers {
           transformedFeatures, buffer + SelfBufferSize);
       const auto output = reinterpret_cast<OutputType*>(buffer);
 
+  #if defined(USE_AVX512)
+      if constexpr (InputDimensions % SimdWidth == 0) {
+        constexpr IndexType NumChunks = InputDimensions / SimdWidth;
+        const __m512i Zero = _mm512_setzero_si512();
+        const __m512i Control = _mm512_setr_epi32(
+             0,  4,  8, 12,  1,  5,  9, 13,  2,  6, 10, 14,  3,  7, 11, 15);
+        const auto in = reinterpret_cast<const __m512i*>(input);
+        const auto out = reinterpret_cast<__m512i*>(output);
+        for (IndexType i = 0; i < NumChunks; ++i) {
+          const __m512i words0 = _mm512_srai_epi16(_mm512_packs_epi32(
+              _mm512_load_si512(&in[i * 4 + 0]),
+              _mm512_load_si512(&in[i * 4 + 1])), WeightScaleBits);
+          const __m512i words1 = _mm512_srai_epi16(_mm512_packs_epi32(
+              _mm512_load_si512(&in[i * 4 + 2]),
+              _mm512_load_si512(&in[i * 4 + 3])), WeightScaleBits);
+          _mm512_store_si512(&out[i], _mm512_permutexvar_epi32(
+              Control, _mm512_max_epi8(_mm512_packs_epi16(words0, words1), Zero)));
+        }
+      } else
+  #endif
   #if defined(USE_AVX2)
       if constexpr (InputDimensions % SimdWidth == 0) {
         constexpr IndexType NumChunks = InputDimensions / SimdWidth;

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -58,7 +58,10 @@ namespace Stockfish::Eval::NNUE {
   constexpr std::size_t CacheLineSize = 64;
 
   // SIMD width (in bytes)
-  #if defined(USE_AVX2)
+  #if defined(USE_AVX512)
+  constexpr std::size_t SimdWidth = 64;
+
+  #elif defined(USE_AVX2)
   constexpr std::size_t SimdWidth = 32;
 
   #elif defined(USE_SSE2)


### PR DESCRIPTION
This PR replaces #70. It copies the beneficial experimental AVX-512 and ARM NEON SIMD optimizations onto a clean rebased branch off of master, as the original PR was failing CI tests due to being tested against an old master base.