### PR TITLE
Remove redundant wrapper Position::decode_direction

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -723,7 +723,6 @@ private:
                                 Bitboard ownPieces, Color c,
                                 bool captureMode,
                                 bool includeOwnBlockedAttacks);
-  static std::pair<int, int> decode_direction(Direction d);
   static Bitboard wrapped_step_targets(const std::map<Direction, int>& directions,
                                        Square sq, Bitboard occupied,
                                        File maxFile, Rank maxRank,
@@ -2843,10 +2842,6 @@ inline Bitboard Position::max_slider_bb(const std::map<Direction,int>& direction
       out |= square_bb(dest);
   }
   return out;
-}
-
-inline std::pair<int, int> Position::decode_direction(Direction d) {
-  return Stockfish::decode_direction(d);
 }
 
 inline Bitboard Position::wrapped_step_targets(const std::map<Direction, int>& directions,


### PR DESCRIPTION
This PR replaces #138 cleanly. The old PR had 58 commits due to an outdated base. This PR cherry-picks the single beneficial change: removing the redundant `Position::decode_direction` wrapper. Internal calls to `decode_direction` naturally resolve to `Stockfish::decode_direction` via namespace lookup.