### PR TITLE
Implement blastOnCaptureMoverCenter variant option

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1592,6 +1592,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("blastPromotion", v->blastPromotion);
     parse_attribute("blastDiagonals", v->blastDiagonals);
     parse_attribute("blastCenter", v->blastCenter);
+    parse_attribute("blastOnCaptureMoverCenter", v->blastOnCaptureMoverCenter);
     parse_attribute("blastPassiveTypes", v->blastPassiveTypes, v);
     parse_attribute("blastImmuneTypes", v->blastImmuneTypes, v);
     parse_attribute("mutuallyImmuneTypes", v->mutuallyImmuneTypes, v);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -3449,7 +3449,7 @@ bool Position::legal(Move m) const {
   {
       const bool blastOnCapture = blast_on_capture(m);
       Square kto = rifleShot ? from : to;
-      Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? shotSq : kto;
+      Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? (blast_on_capture_mover_center() ? effectiveTo : shotSq) : kto;
       Bitboard occupied = rifleShot ? pieces() : (!dropMove && !cloneMove ? pieces() ^ from : pieces());
       Bitboard blastImmune = blastOnCapture ? blast_immune_bb() : Bitboard(0);
       if (walling_rule() == DUCK)
@@ -3557,7 +3557,7 @@ bool Position::legal(Move m) const {
   {
       const bool blastOnCapture = blast_on_capture(m);
       Square kto = rifleShot ? from : to;
-      Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? shotSq : kto;
+      Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? (blast_on_capture_mover_center() ? effectiveTo : shotSq) : kto;
       Square rfrom = SQ_NONE, rto = SQ_NONE;
       Bitboard occupied = rifleShot ? pieces() : (!dropMove ? pieces() ^ from : pieces());
       Bitboard blastImmune = blastOnCapture ? blast_immune_bb() : Bitboard(0);
@@ -3735,7 +3735,7 @@ bool Position::legal(Move m) const {
           || (blast_on_move() && !capture(m) && !is_self_destruct(m))
           || (blast_on_self_destruct() && is_self_destruct(m)))
       {
-          Square blastCenter = (capture(m) || rifleShot) ? shotSq : effectiveTo;
+          Square blastCenter = (capture(m) || rifleShot) ? (blast_on_capture_mover_center() ? effectiveTo : shotSq) : effectiveTo;
           Bitboard blastRelevant = occupied & ~blast_immune_bb();
           removedByEffects |= blast_pattern(blastCenter) & blastRelevant;
           if (blast_center())
@@ -6031,7 +6031,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
            ( blast_on_move() && !captured && !is_self_destruct(m) ) ||
            ( blast_on_self_destruct() && is_self_destruct(m) ) ) {
 
-          blast_mask = (blastOnCaptureMove || blast_on_move() || blast_on_self_destruct()) ? blast_squares(captured ? st->captureSquare : to)
+          blast_mask = (blastOnCaptureMove || blast_on_move() || blast_on_self_destruct()) ? blast_squares(captured ? (blast_on_capture_mover_center() ? moverSq : st->captureSquare) : to)
               : (var->petrifyOnCaptureTypes & type_of(pc) ? square_bb(moverSq) : Bitboard(0));
           if (captured && blastOnCaptureMove && (blast_immune_types() & movedType))
               blast_mask &= ~square_bb(moverSq);
@@ -7166,7 +7166,7 @@ Value Position::blast_see(Move m) const {
   Piece mover = moved_piece(m);
   Color us = color_of(mover);
   Bitboard fromto = is_drop_move(m) ? square_bb(to) | (paired_drop(m) ? square_bb(secondary_drop_square(m)) : Bitboard(0)) : from | to;
-  Bitboard blast = blast_squares(capture(m) ? capture_square(m) : to);
+  Bitboard blast = blast_squares(capture(m) ? (blast_on_capture_mover_center() ? (rifle_capture(m) ? from : to) : capture_square(m)) : to);
 
   // If the explosion would capture an opponent royal or pseudo-royal piece,
   // treat the move as delivering immediate mate. This prevents the static

--- a/src/position.h
+++ b/src/position.h
@@ -274,6 +274,7 @@ public:
   bool blast_diagonals() const;
   bool blast_orthogonals() const;
   bool blast_center() const;
+  bool blast_on_capture_mover_center() const;
   bool zero_range_blast_on_capture(Piece mover, Piece captured) const;
   bool zero_range_blast_on_capture(Move m) const;
   PieceSet blast_immune_types() const;
@@ -1067,6 +1068,11 @@ inline bool Position::blast_orthogonals() const {
 inline bool Position::blast_center() const {
   assert(var != nullptr);
   return var->blastCenter;
+}
+
+inline bool Position::blast_on_capture_mover_center() const {
+  assert(var != nullptr);
+  return var->blastOnCaptureMoverCenter;
 }
 
 inline bool Position::zero_range_blast_on_capture(Move m) const {

--- a/src/variant.h
+++ b/src/variant.h
@@ -156,6 +156,7 @@ struct Variant {
   bool blastPromotion = false;
   bool blastDiagonals = true;
   bool blastCenter = true;
+  bool blastOnCaptureMoverCenter = false;
   PieceSet blastPassiveTypes = NO_PIECE_SET;
   PieceSet blastImmuneTypes = NO_PIECE_SET;
   PieceSet mutuallyImmuneTypes = NO_PIECE_SET;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -248,6 +248,7 @@
 # blastDiagonals: are diagonals included in blast [bool] (default: true)
 # blastOrthogonals: are orthogonals included in blast [bool] (default: true)
 # blastCenter: is the center square included in blast [bool] (default: true)
+# blastOnCaptureMoverCenter: when the mover square differs from the capture square, center blast on mover square instead of capture square [bool] (default: false)
 # blastOnSameTypeCapture: if capture target has same piece type, trigger a zero-range blast on the capture square [bool] (default: false)
 # blastPassiveTypes: pieces of these types passively blast adjacent enemy pieces after moves (rejected with royal kings) [PieceSet] (default: none)
 # blastImmuneTypes: pieces completely immune to explosions (even at ground zero) [PieceSet] (default: none)

--- a/test.py
+++ b/test.py
@@ -194,6 +194,19 @@ customPiece2 = b:W
 captureForbidden = *:*
 captureAllowed = a:b
 startFen = 8/8/8/3b4/3A4/8/8/8 w - - 0 1
+
+[blast-default-test:fairy]
+blastOnCapture = true
+rifleCapture = true
+king = -
+startFen = 8/8/8/8/8/8/8/8 w - - 0 1
+
+[blast-mover-test:fairy]
+blastOnCapture = true
+rifleCapture = true
+blastOnCaptureMoverCenter = true
+king = -
+startFen = 8/8/8/8/8/8/8/8 w - - 0 1
 """
 
 sf.load_variant_config(ini_text)
@@ -2042,6 +2055,25 @@ startFen = 4r3/8/8/8/8/8/8/8[A] w - - 0 1
                     # Should fail with character validation (FEN_INVALID_CHAR = -10), not promoted piece validation
                     self.assertEqual(result, -10,
                                    f"Expected non-shogi variant to fail with character error (-10): {fen}, got {result}")
+
+    def test_blast_on_capture_mover_center(self):
+        # White Rook e3, Black Knights: e5 (target), d6 (diag to e5), d2 (diag to e3)
+        fen = "8/8/3n4/4n3/8/4R3/3n4/8 w - - 0 1"
+        move = "e3e5"
+
+        # Default blast (centered on capture square e5)
+        # e5 diagonals: d6, f6, d4, f4. d6 should be removed.
+        # d2 is not near e5.
+        fen_default = sf.get_fen("blast-default-test", fen, [move])
+        self.assertNotIn("3n4", fen_default.split("/")[2]) # d6 gone
+        self.assertIn("3n4", fen_default.split("/")[6])    # d2 remains
+
+        # Mover center blast (centered on mover square e3)
+        # e3 diagonals: d4, f4, d2, f2. d2 should be removed.
+        # d6 is not near e3.
+        fen_mover = sf.get_fen("blast-mover-test", fen, [move])
+        self.assertIn("3n4", fen_mover.split("/")[2])    # d6 remains
+        self.assertNotIn("3n4", fen_mover.split("/")[6]) # d2 gone
 
     def test_evaluate(self):
         eval_start = sf.evaluate("chess", CHESS, [])


### PR DESCRIPTION
Added a new `.ini` option `blastOnCaptureMoverCenter` to Fairy-Stockfish. When enabled, capture-triggered explosions (blasts) are centered on the mover's square (destination square, or origin for rifle-captures) instead of the capture square. This provides more flexibility for variant designers when using stationary or displacement captures in combination with blast rules. The default remains centering on the capture square. verified with custom variants and bench.

---
*PR created automatically by Jules for task [7083344658326935742](https://jules.google.com/task/7083344658326935742) started by @RainRat*