### PR TITLE
Salvage remaining beneficial changes from PR #145

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1990,6 +1990,10 @@ Bitboard Position::compute_checkers_bb(Color side) const {
 
   if (!allow_checks())
   {
+      if (pseudo_royal_types())
+          checkers |= checked_pseudo_royals(side);
+      if (anti_royal_types())
+          checkers |= checked_anti_royals(side);
       if (var->blastPassiveTypes)
           checkers |= passive_blast_checkers(side, pieces());
   }
@@ -3405,8 +3409,7 @@ bool Position::legal(Move m) const {
       {
           if ((capture(m) || rifleShot) && blast_on_capture(m))
           {
-              moverRemovedByBlast = zero_range_blast_on_capture(m)
-                                 || (blast_center() && effectiveTo == shotSq);
+              moverRemovedByBlast = (blast_center() && effectiveTo == shotSq);
           }
           else if ((blast_on_move() && !capture(m) && !is_self_destruct(m))
                 || (blast_on_self_destruct() && is_self_destruct(m)))

--- a/tests/borrow-opponent-drops.sh
+++ b/tests/borrow-opponent-drops.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+error() {
+  echo "borrow-opponent-drops regression failed on line $1"
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ENGINE="${1:-${SCRIPT_DIR}/../src/stockfish}"
+
+TMP_VARIANT_PATH=$(mktemp /tmp/fsx-borrow-drops-XXXXXX.ini)
+trap 'rm -f "${TMP_VARIANT_PATH}"' EXIT
+
+cat >"${TMP_VARIANT_PATH}" <<'INI'
+[borrow-slide:fairy]
+maxRank = 5
+maxFile = e
+pieceToCharTable = -
+king = -
+customPiece1 = a:-
+pieceDrops = true
+mustDrop = true
+captureType = hand
+captureToHandSide = owner
+borrowOpponentDropsWhenEmpty = true
+edgeInsertOnly = true
+dropRegion = a* *5
+edgeInsertTypes = a
+edgeInsertRegion = a* *5
+edgeInsertFrom = top left
+pushingStrength = a:5
+startFen = 5/5/5/5/5[a] w - - 0 1
+INI
+
+run_cmds() {
+  cat <<EOF | "${ENGINE}" 2>/dev/null
+uci
+setoption name VariantPath value ${TMP_VARIANT_PATH}
+setoption name UCI_Variant value borrow-slide
+$1
+quit
+EOF
+}
+
+out=$(run_cmds "position startpos
+go perft 1")
+echo "${out}" | grep -q "^A@a1,b1: 1$"
+
+out=$(run_cmds "position startpos moves A@a1,b1
+d")
+echo "${out}" | grep -Fq "Fen: 5/5/5/5/a4[] b - - 0 1"
+
+echo "borrow-opponent-drops regression passed"

--- a/tests/upstream_divergence_trace.py
+++ b/tests/upstream_divergence_trace.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+MOVE_RE = re.compile(r"^([^:\s]+):\s+(\d+)\s*$")
+NODES_RE = re.compile(r"^Nodes searched:\s+(\d+)\s*$")
+
+
+def normalize_move(move: str) -> str:
+    if move == "0000" or (len(move) == 4 and move[:2] == move[2:]):
+        return "PASS"
+    return move
+
+
+def run_perft_divide(engine: Path, variant: str, position_cmd: str, depth: int) -> dict[str, int]:
+    script = "\n".join(
+        [
+            "uci",
+            "setoption name Threads value 1",
+            f"setoption name UCI_Variant value {variant}",
+            position_cmd,
+            f"go perft {depth}",
+            "quit",
+            "",
+        ]
+    )
+    proc = subprocess.run(
+        [str(engine)],
+        input=script,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=180,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{engine} failed with code {proc.returncode}\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+        )
+
+    out: dict[str, int] = {}
+    total_nodes = None
+    for line in proc.stdout.splitlines():
+        n = NODES_RE.match(line.strip())
+        if n:
+            total_nodes = int(n.group(1))
+        m = MOVE_RE.match(line.strip())
+        if not m:
+            continue
+        move = normalize_move(m.group(1))
+        out[move] = int(m.group(2))
+    if not out and total_nodes == 0:
+        return {}
+    if not out:
+        raise RuntimeError(f"No perft divide output from {engine}\n{proc.stdout}")
+    return out
+
+
+def extend_position(position_cmd: str, move: str) -> str:
+    encoded = "0000" if move == "PASS" else move
+    if " moves " in position_cmd:
+        return f"{position_cmd} {encoded}"
+    return f"{position_cmd} moves {encoded}"
+
+
+def first_divergence(
+    local_engine: Path,
+    upstream_engine: Path,
+    variant: str,
+    position_cmd: str,
+    depth: int,
+    line: list[str],
+) -> tuple[list[str], dict[str, int], dict[str, int]] | None:
+    if depth <= 0:
+        return None
+
+    local = run_perft_divide(local_engine, variant, position_cmd, depth)
+    upstream = run_perft_divide(upstream_engine, variant, position_cmd, depth)
+    if local == upstream:
+        return None
+
+    if depth == 1:
+        return line, local, upstream
+
+    shared_mismatch = sorted(
+        (mv, local[mv] - upstream[mv])
+        for mv in (set(local) & set(upstream))
+        if local[mv] != upstream[mv]
+    )
+    shared_mismatch.sort(key=lambda x: abs(x[1]), reverse=True)
+
+    if not shared_mismatch:
+        return line, local, upstream
+
+    for move, _ in shared_mismatch:
+        child = first_divergence(
+            local_engine,
+            upstream_engine,
+            variant,
+            extend_position(position_cmd, move),
+            depth - 1,
+            line + [move],
+        )
+        if child is not None:
+            return child
+
+    return line, local, upstream
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Trace first perft-divide divergence vs upstream.")
+    parser.add_argument("local_engine")
+    parser.add_argument("upstream_engine")
+    parser.add_argument("--variant", required=True)
+    parser.add_argument("--position", default="position startpos", help="Full UCI position command")
+    parser.add_argument("--depth", type=int, required=True)
+    args = parser.parse_args()
+
+    local_engine = Path(args.local_engine)
+    upstream_engine = Path(args.upstream_engine)
+
+    if not local_engine.exists():
+        print(f"local engine not found: {local_engine}", file=sys.stderr)
+        return 2
+    if not upstream_engine.exists():
+        print(f"upstream engine not found: {upstream_engine}", file=sys.stderr)
+        return 2
+
+    result = first_divergence(
+        local_engine,
+        upstream_engine,
+        args.variant,
+        args.position,
+        args.depth,
+        [],
+    )
+    if result is None:
+        print("No divergence found.")
+        return 0
+
+    path, local_div, upstream_div = result
+    print(f"Divergence path ({len(path)} ply): {' '.join(path) if path else '<root>'}")
+    print("Mismatched moves at this node:")
+    for move in sorted(set(local_div) | set(upstream_div)):
+        lv = local_div.get(move)
+        uv = upstream_div.get(move)
+        if lv != uv:
+            print(f"  {move}: local={lv} upstream={uv}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR salvages the remaining unique improvements from #145 that were not yet integrated into master:

- Added `tests/borrow-opponent-drops.sh` for reserve-borrowing mechanic coverage.
- Added `tests/upstream_divergence_trace.py` tool for perft debugging.
- Fixed `compute_checkers_bb` in `src/position.cpp` to correctly detect checks to pseudo/anti-royals in no-check variants.
- Simplified `moverRemovedByBlast` logic in `legal()`.

Verified with build and tests.