### PR TITLE
Document all parser options in variants.ini

### DIFF
--- a/src/variants.ini
+++ b/src/variants.ini
@@ -188,6 +188,11 @@
 # - past: previous square (ie. Snailtrail)
 # - static: unchanging mask (ie. Isolation)
 # [PointsRule]: who gets the points for a capture [us, them, owner, non-owner]
+# [ColorChangeTrigger]: when pieces change color [capture, non-capture, always, never]
+# [PushFirstColor]: allowed color of the first contacted pushed piece [us, them, either]
+# [PushRemoval]: whether a shove off-board ejects the last pushed piece [none, shove]
+# [TransferSide]: which side receives pieces transferred to hand or prison [us, them, owner, non-owner]
+# [EnPassantPassedSquares]: which squares of a long move are marked for en passant [all, first, last]
  
 ### Additional options relevant for usage in Winboard/XBoard
 # A few options only have the purpose of improving compatibility with Winboard/Xboard.
@@ -218,6 +223,7 @@
 #            see promotionPawnTypes, enPassantTypes, and nMoveRuleTypes for more specific overrides.
 # promotionRegionWhite: region where promotions are allowed for white; supports global Bitboard or PieceTypeBitboardGroup [PieceTypeBitboardGroup] (default: *8)
 # promotionRegionBlack: region where promotions are allowed for black; supports global Bitboard or PieceTypeBitboardGroup [PieceTypeBitboardGroup] (default: *1)
+# promotionRegion: region where promotions are allowed for both colors; supports global Bitboard or PieceTypeBitboardGroup [PieceTypeBitboardGroup]
 # mandatoryPromotionRegionWhite: mandatory sub-region of white promotionRegion; moves entering it must promote if possible and are forbidden otherwise [Bitboard] (default: -)
 # mandatoryPromotionRegionBlack: mandatory sub-region of black promotionRegion [Bitboard] (default: -)
 # mandatoryPromotionRegion: mandatory sub-region for both colors [Bitboard] (default: -)
@@ -253,12 +259,14 @@
 # blastPassiveTypes: pieces of these types passively blast adjacent enemy pieces after moves (rejected with royal kings) [PieceSet] (default: none)
 # blastImmuneTypes: pieces completely immune to explosions (even at ground zero) [PieceSet] (default: none)
 # mutuallyImmuneTypes: pieces that can't capture another piece of same types (e.g., kings (commoners) in atomar) [PieceSet] (default: none)
+# mutuallyHopIllegalTypes: pieces that may not jump over other pieces of the same types [PieceSet] (default: none)
 # deathOnCaptureTypes: capturing pieces of these types become neutral dead squares '^' [PieceSet] (default: none)
 # selfCapture: allow capturing own pieces except kings [bool] (default: false)
 # selfCaptureWhite/Black: allow own-piece capture for one side only [bool] (default: inherit selfCapture)
 # selfCaptureTypes: allow self-capture only for these mover types [PieceSet] (default: inherit selfCapture)
 # selfCaptureTypesWhite/Black: color-specific overrides for selfCaptureTypes [PieceSet] (default: inherit selfCaptureTypes)
 # pushingStrength: per-piece mover-driven line-push strength, e.g. p:1 r:8 [PieceType->int map] (default: none)
+# stepwisePushing: pushed pieces move one square at a time regardless of mover's slide distance [bool] (default: true)
 # pullingStrength: per-piece source-aware pull strength, e.g. e:6 m:5 h:4 d:3 c:2 r:1 [PieceType->int map] (default: none)
 # adjacentSwapMoveTypes: piece types that may swap with an orthogonally adjacent enemy; UCI uses from+to+s [PieceSet] (default: none)
 # adjacentSwapRequiresEmptyNeighbor: swap movers must also be orthogonally adjacent to at least one empty square [bool] (default: false)
@@ -272,10 +280,13 @@
 # edgeInsertTypes: piece types that can be inserted from configured board edges as drop+push actions [PieceSet] (default: none)
 # edgeInsertRegionWhite: entry squares for white insertion [Bitboard] (default: none)
 # edgeInsertRegionBlack: entry squares for black insertion [Bitboard] (default: none)
+# edgeInsertRegion: entry squares for both colors [Bitboard]
 # edgeInsertOnly: suppress ordinary drops for edgeInsertTypes and only allow edge-insert moves for those pieces [bool] (default: false)
 # edgeInsertFrom: shared alias for enabled insertion directions using `top`, `bottom`, `left`, `right`, `vertical`, `horizontal`, `all`
 # edgeInsertFromWhite/edgeInsertFromBlack: color-specific overrides for edgeInsertFrom using the same direction tokens
 # symmetricDropTypes: drop two identical pieces at once onto horizontally paired squares; UCI uses piece@sq1,sq2 [PieceSet] (default: none)
+# changingColorTrigger: when pieces change color [ColorChangeTrigger] (default: never)
+# changingColorPieceTypes: piece types that change color based on changingColorTrigger [PieceSet] (default: none)
 # captureMorph: capturing piece morphs into captured piece type [bool] (default: false)
 # rexExclusiveMorph: kings do not morph when captureMorph is enabled [bool] (default: false)
 # captureForbidden: forbidden capture pairs attacker:targets, e.g. q:k b:pn *:i [str] (default: )
@@ -291,17 +302,19 @@
 # surroundCaptureMaxRegion: pieces in this region can be surround-captured if and only if they are surrounded on all possible orthogonal squares (ie. 4 in the center, 3 on an edge, 2 on a corner) [Bitboard] (default: -)
 # surroundCaptureHostileRegion: squares in this region are treated as enemy pieces by both sides for surround-capture requirements [Bitboard] (default: -)
 # Pawn stepping and en passant
-# Pawn stepping and en passant
 # doubleStep: enable pawn double step [bool] (default: true)
 # doubleStepRegionWhite: region where pawn double step is allowed for white; supports global Bitboard or PieceTypeBitboardGroup [PieceTypeBitboardGroup] (default: *2)
 # doubleStepRegionBlack: region where pawn double step is allowed for black; supports global Bitboard or PieceTypeBitboardGroup [PieceTypeBitboardGroup] (default: *7)
+# doubleStepRegion: region where pawn double step is allowed for both colors; supports global Bitboard or PieceTypeBitboardGroup [PieceTypeBitboardGroup]
 # tripleStepRegionWhite: region where triple step is allowed for white; supports global Bitboard or PieceTypeBitboardGroup [PieceTypeBitboardGroup] (default: -)
 # tripleStepRegionBlack: region where triple step is allowed for black; supports global Bitboard or PieceTypeBitboardGroup [PieceTypeBitboardGroup] (default: -)
+# tripleStepRegion: region where triple step is allowed for both colors; supports global Bitboard or PieceTypeBitboardGroup [PieceTypeBitboardGroup]
 # enPassantRegionWhite: define region (target squares) where en passant is allowed for white [Bitboard] (default: AllSquares)
 # enPassantRegionBlack: define region (target squares) where en passant is allowed for black [Bitboard] (default: AllSquares)
 # enPassantRegion: same as above for both colors [Bitboard] (default: AllSquares)
 # enPassantTypes: define pieces able to capture en passant [PieceSet] (default: p). Supports enPassantTypesWhite/Black.
-# enPassantPassedSquares: for custom non-pawn long initial moves, mark all traversed squares or only the first/last one for en passant [EnPassantPassedSquares: all|first|last] (default: all)
+# enPassantPassedSquares: for custom non-pawn long initial moves, mark all traversed squares or only the first/last one for en passant [EnPassantPassedSquares] (default: all)
+# castling: enable/disable castling [bool] (default: true)
 # castlingDroppedPiece: enable castling with dropped rooks/kings [bool] (default: false)
 # castlingPromotedPiece: enable castling with rooks/kings that arrive by promotion on the castling rank [bool] (default: false)
 # castlingForbiddenPlies: disable castling while gamePly is below this threshold [int] (default: 0)
@@ -406,8 +419,10 @@
 # wallingRule: rule on where wall can be placed [WallingRule] (default: none)
 # wallingWhite: whether white uses the walling rule [bool] (default: true)
 # wallingBlack: whether black uses the walling rule [bool] (default: true)
+# walling: whether both sides use the walling rule [bool]
 # wallingRegionWhite: mask where wall squares (including duck) can be placed by white [Bitboard] (default: all squares)
 # wallingRegionBlack: mask where wall squares (including duck) can be placed by black [Bitboard] (default: all squares)
+# wallingRegion: mask where wall squares can be placed by both sides [Bitboard]
 # wallOrMove: can wall or move, but not both [bool] (default: false)
 # surroundClaimRegion: empty center squares that become owned when all four orthogonal neighbors are occupied [Bitboard] (default: none)
 # surroundClaimPiece: piece type placed on a completed surroundClaimRegion square [PieceType] (default: -)
@@ -510,6 +525,7 @@
 # connectGoalByType: connect wins are checked against per-side piece-type strings (default: false)
 # connectPieceGoalWhite: ordered piece symbols that White must connect (e.g., TOOT)
 # connectPieceGoalBlack: ordered piece symbols that Black must connect (e.g., OTTO)
+# connectPieceGoal: ordered piece symbols for both sides (e.g., TOOT)
 # connectVertical: connectN looks at Vertical rows [bool] (default: true)
 # connectHorizontal: connectN looks at Horizontal rows [bool] (default: true)
 # connectDiagonal: connectN looks at Diagonal rows [bool] (default: true)
@@ -518,11 +534,14 @@
 # connect3D: interpret either a 3x9 board as flattened 3x3x3 or an 8x8 board as flattened 4x4x4 [bool] (default: false)
 # connect4D: interpret a connectN^2 x connectN^2 board as flattened connectN^4 tic-tac-toe for connectN >= 3 [bool] (default: false)
 # connectRegion1White: connect Region 1 to Region 2/3 for win. obeys connectVertical, connectHorizontal, connectDiagonal [Bitboard] (default: -)
-# connectRegion2White: "
+# connectRegion2White: connect Region 2 to Region 1/3 for win [Bitboard] (default: -)
 # connectRegion3White: optional third region for connection wins such as Y [Bitboard] (default: -)
-# connectRegion1Black: "
-# connectRegion2Black: "
-# connectRegion3Black: "
+# connectRegion1Black: connect Region 1 to Region 2/3 for win for black [Bitboard] (default: -)
+# connectRegion2Black: connect Region 2 to Region 1/3 for win for black [Bitboard] (default: -)
+# connectRegion3Black: optional third region for connection wins for black [Bitboard] (default: -)
+# connectRegion1: connect Region 1 to Region 2/3 for win for both colors [Bitboard] (default: -)
+# connectRegion2: connect Region 2 to Region 1/3 for win for both colors [Bitboard] (default: -)
+# connectRegion3: optional third region for connection wins for both colors [Bitboard] (default: -)
 # connectNxN: connect a tight NxN square for win [int] (default: 0)
 # collinearN: arrange N pieces collinearly (other squares can be between pieces) [int] (default: 0)
 # connectGroup: arrange N pieces in any shape (-1 means all remaining pieces connected) [int] (default: 0)


### PR DESCRIPTION
Documented all options accepted by the parser in `variants.ini`. This includes adding missing option types (enums) to the summary, documenting previously omitted options in their respective rule sections, removing a duplicate header, and expanding non-descriptive ditto marks in descriptions to improve clarity and searchability. Verified correctness with engine-side parser validation and functional benchmarks.

---
*PR created automatically by Jules for task [16386059976887995096](https://jules.google.com/task/16386059976887995096) started by @RainRat*