### PR TITLE
Remove experimental and unstable features

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1592,7 +1592,6 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("blastPromotion", v->blastPromotion);
     parse_attribute("blastDiagonals", v->blastDiagonals);
     parse_attribute("blastCenter", v->blastCenter);
-    parse_attribute("blastOnCaptureMoverCenter", v->blastOnCaptureMoverCenter);
     parse_attribute("blastPassiveTypes", v->blastPassiveTypes, v);
     parse_attribute("blastImmuneTypes", v->blastImmuneTypes, v);
     parse_attribute("mutuallyImmuneTypes", v->mutuallyImmuneTypes, v);

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -131,7 +131,7 @@ namespace {
 
       // Parser sugar: m(AB) -> mAmB, c(RB) -> cRcB
       auto expand_group_sugar = [&](const std::string& in) {
-          const std::string prefixChars = "mcpgnojzxiyfbrlvsh";
+          const std::string prefixChars = "mcpgnjzxifbrlvsh";
           std::string out;
           for (std::string::size_type i = 0; i < in.size(); ++i)
           {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -3477,7 +3477,7 @@ bool Position::legal(Move m) const {
           || (blast_on_move() && !capture(m) && !is_self_destruct(m))
           || (blast_on_self_destruct() && is_self_destruct(m)))
       {
-          Square blastCenter = (capture(m) || rifleShot) ? (blast_on_capture_mover_center() && !rifleShot ? effectiveTo : shotSq) : effectiveTo;
+          Square blastCenter = (capture(m) || rifleShot) ? shotSq : effectiveTo;
           Bitboard blastRelevant = postMoveOccupied & ~blast_immune_bb();
           removedByEffects |= blast_pattern(blastCenter) & blastRelevant;
           if (blast_center())
@@ -3606,7 +3606,7 @@ bool Position::legal(Move m) const {
   {
       const bool blastOnCapture = blast_on_capture(m);
       Square kto = rifleShot ? from : to;
-      Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? (blast_on_capture_mover_center() && !rifleShot ? effectiveTo : shotSq) : kto;
+      Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? shotSq : kto;
       Bitboard occupied = rifleShot ? pieces() : (!dropMove && !cloneMove ? pieces() ^ from : pieces());
       Bitboard blastImmune = blastOnCapture ? blast_immune_bb() : Bitboard(0);
       if (walling_rule() == DUCK)
@@ -3717,7 +3717,7 @@ bool Position::legal(Move m) const {
   {
       const bool blastOnCapture = blast_on_capture(m);
       Square kto = rifleShot ? from : to;
-      Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? (blast_on_capture_mover_center() && !rifleShot ? effectiveTo : shotSq) : kto;
+      Square blastCenter = (type_of(m) == EN_PASSANT || rifleShot) ? shotSq : kto;
       Square rfrom = SQ_NONE, rto = SQ_NONE;
       Bitboard occupied = rifleShot ? pieces() : (!dropMove ? pieces() ^ from : pieces());
       Bitboard blastImmune = blastOnCapture ? blast_immune_bb() : Bitboard(0);
@@ -6149,7 +6149,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
            ( blast_on_move() && !captured && !is_self_destruct(m) ) ||
            ( blast_on_self_destruct() && is_self_destruct(m) ) ) {
 
-          blast_mask = (blastOnCaptureMove || blast_on_move() || blast_on_self_destruct()) ? blast_squares(captured ? (blast_on_capture_mover_center() && !rifleShot ? moverSq : st->captureSquare) : to)
+          blast_mask = (blastOnCaptureMove || blast_on_move() || blast_on_self_destruct()) ? blast_squares(captured ? st->captureSquare : to)
               : (var->petrifyOnCaptureTypes & type_of(pc) ? square_bb(moverSq) : Bitboard(0));
           if (captured && blastOnCaptureMove && (blast_immune_types() & movedType))
               blast_mask &= ~square_bb(moverSq);
@@ -7284,7 +7284,7 @@ Value Position::blast_see(Move m) const {
   Piece mover = moved_piece(m);
   Color us = color_of(mover);
   Bitboard fromto = is_drop_move(m) ? square_bb(to) | (paired_drop(m) ? square_bb(secondary_drop_square(m)) : Bitboard(0)) : from | to;
-  Bitboard blast = blast_squares(capture(m) ? (blast_on_capture_mover_center() && !rifle_capture(m) ? to : capture_square(m)) : to);
+  Bitboard blast = blast_squares(capture(m) ? capture_square(m) : to);
 
   // If the explosion would capture an opponent royal or pseudo-royal piece,
   // treat the move as delivering immediate mate. This prevents the static

--- a/src/variant.h
+++ b/src/variant.h
@@ -156,7 +156,6 @@ struct Variant {
   bool blastPromotion = false;
   bool blastDiagonals = true;
   bool blastCenter = true;
-  bool blastOnCaptureMoverCenter = false;
   PieceSet blastPassiveTypes = NO_PIECE_SET;
   PieceSet blastImmuneTypes = NO_PIECE_SET;
   PieceSet mutuallyImmuneTypes = NO_PIECE_SET;

--- a/test.py
+++ b/test.py
@@ -194,19 +194,6 @@ customPiece2 = b:W
 captureForbidden = *:*
 captureAllowed = a:b
 startFen = 8/8/8/3b4/3A4/8/8/8 w - - 0 1
-
-[blast-default-test:fairy]
-blastOnCapture = true
-rifleCapture = true
-king = -
-startFen = 8/8/8/8/8/8/8/8 w - - 0 1
-
-[blast-mover-test:fairy]
-blastOnCapture = true
-rifleCapture = true
-blastOnCaptureMoverCenter = true
-king = -
-startFen = 8/8/8/8/8/8/8/8 w - - 0 1
 """
 
 sf.load_variant_config(ini_text)
@@ -562,19 +549,6 @@ startFen = 7k/8/8/8/8/8/8/A5K1 w - - 0 1
         tuple07_moves = sf.legal_moves("tuple07", sf.start_fen("tuple07"), [])
         self.assertIn("a1h1", tuple07_moves)
         self.assertNotIn("a1b2", tuple07_moves)
-
-        # Jump captures should honor selfCapture when the jumped piece is friendly.
-        sf.load_variant_config(
-            """[selfjump:chess]
-customPiece1 = a:mD
-jumpCaptureTypes = a
-selfCapture = true
-startFen = 7k/8/8/8/8/8/P7/A6K w - - 0 1
-"""
-        )
-        selfjump_fen = sf.start_fen("selfjump")
-        selfjump_moves = sf.legal_moves("selfjump", selfjump_fen, [])
-        self.assertIn("a1a3", selfjump_moves)
 
         # Anti-royal pieces must remain attacked.
         sf.load_variant_config(
@@ -2055,24 +2029,6 @@ startFen = 4r3/8/8/8/8/8/8/8[A] w - - 0 1
                     # Should fail with character validation (FEN_INVALID_CHAR = -10), not promoted piece validation
                     self.assertEqual(result, -10,
                                    f"Expected non-shogi variant to fail with character error (-10): {fen}, got {result}")
-
-    def test_blast_on_capture_mover_center(self):
-        # White Rook e3, Black Knights: e5 (target), d6 (diag to e5), d2 (diag to e3)
-        fen = "8/8/3n4/4n3/8/4R3/3n4/8 w - - 0 1"
-        move = "e3e5"
-
-        # Default blast (centered on capture square e5)
-        # e5 diagonals: d6, f6, d4, f4. d6 should be removed.
-        # d2 is not near e5.
-        fen_default = sf.get_fen("blast-default-test", fen, [move])
-        self.assertEqual(fen_default, "8/8/8/8/8/4R3/3n4/8 b - - 0 1")
-
-        # Rifle captures keep the shooter on its source square, so capture blasts
-        # are centered on the captured piece even when mover-centered blast is
-        # enabled. If a variant wants the shooter to explode, it should not model
-        # the capture as rifle.
-        fen_mover = sf.get_fen("blast-mover-test", fen, [move])
-        self.assertEqual(fen_mover, "8/8/8/8/8/4R3/3n4/8 b - - 0 1")
 
     def test_evaluate(self):
         eval_start = sf.evaluate("chess", CHESS, [])

--- a/tests/unorthodox-interactions.sh
+++ b/tests/unorthodox-interactions.sh
@@ -62,11 +62,7 @@ blastDiagonals = false
 changingColorTrigger = capture
 changingColorPieceTypes = *
 
-[rifle-jump:chess]
-customPiece1 = m:c{hurdles: 1,1; pre: 1,1; post: 1,1; capture: locust_first; hurdle_types: enemy}W
-rifleCapture = true
-
-[rifle-duck:chess]
+[jump-blast:chess]
 rifleCapture = true
 wallingRule = duck
 castling = false
@@ -209,11 +205,6 @@ echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/8/8/R3K3 b"
 out=$(run_cmds "rifle-color" "${TEMP_INI}" "position fen r3k3/8/8/8/8/8/8/R3K3 w - - 0 1 moves a1a8
 d")
 echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/8/8/r3K3 b"
-
-# 5. Test rifleCapture + jumpCaptureTypes
-out=$(run_cmds "rifle-jump" "${TEMP_INI}" "position fen 4k3/8/8/8/8/8/p7/M3K3 w - - 0 1 moves a1a3
-d")
-echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/8/8/M3K3 b"
 
 # 5b. Test jumpCapture + zero-range blast-on-capture (mover survives)
 out=$(run_cmds "jump-blast" "${TEMP_INI}" "position fen 4k3/8/8/8/8/8/m7/M3K3 w - - 0 1 moves a1a3


### PR DESCRIPTION
Removes Betza modifiers 'y' and 'o', jumpCaptureTypes, and blastOnCaptureMoverCenter as they were never in a stable release.