### PR TITLE
test: Add wrapped-board custom lame profile coverage

### DIFF
--- a/tests/alfil-dabbaba-riders.sh
+++ b/tests/alfil-dabbaba-riders.sh
@@ -474,27 +474,33 @@ echo "$out" | grep -q "^a1e1: 1$"
 out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-anypath\nposition fen k7/8/8/8/8/8/8/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
   | "${ENGINE}")
 echo "$out" | grep -q "^a1h3: 1$"
+echo "$out" | grep -q "^a1g2: 1$"
 # a2 blocked
 out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-anypath\nposition fen k7/8/8/8/8/8/P7/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
   | "${ENGINE}")
 echo "$out" | grep -q "^a1h3: 1$"
+echo "$out" | grep -q "^a1g2: 1$"
 # h2 blocked
 out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-anypath\nposition fen k7/8/8/8/8/8/7P/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
   | "${ENGINE}")
 echo "$out" | grep -q "^a1h3: 1$"
+echo "$out" | grep -q "^a1g2: 1$"
 # a2 and h2 both blocked
 out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-anypath\nposition fen k7/8/8/8/8/8/P6P/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
   | "${ENGINE}")
 ! echo "$out" | grep -q "^a1h3:"
+! echo "$out" | grep -q "^a1g2:"
 
 # Wrapped-board custom lame profile: ORTH_FIRST
 # clear board
 out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-orthfirst\nposition fen k7/8/8/8/8/8/8/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
   | "${ENGINE}")
 echo "$out" | grep -q "^a1h3: 1$"
+echo "$out" | grep -q "^a1g2: 1$"
 # a2 blocked (this leg blocks the ORTH_FIRST wrapped h3 jump)
 out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-orthfirst\nposition fen k7/8/8/8/8/8/P7/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
   | "${ENGINE}")
 ! echo "$out" | grep -q "^a1h3:"
+echo "$out" | grep -q "^a1g2: 1$"
 
 echo "alfil-dabbaba-riders test OK"

--- a/tests/alfil-dabbaba-riders.sh
+++ b/tests/alfil-dabbaba-riders.sh
@@ -194,6 +194,18 @@ startFen = k7/8/8/8/8/8/8/A6K w - - 0 1
 customPiece1 = a:RnN
 pieceToCharTable = PNBRQ............A...Kpnbrq............a...k
 startFen = k7/8/8/8/8/8/8/A6K w - - 0 1
+
+[cylinder-anypath:chess]
+cylindrical = true
+customPiece1 = a:n{path:anypath}N
+pieceToCharTable = PNBRQ............A...Kpnbrq............a...k
+startFen = k7/8/8/8/8/8/8/A3K3 w - - 0 1
+
+[cylinder-orthfirst:chess]
+cylindrical = true
+customPiece1 = a:n{path:orthfirst}N
+pieceToCharTable = PNBRQ............A...Kpnbrq............a...k
+startFen = k7/8/8/8/8/8/8/A3K3 w - - 0 1
 INI
 
 piece_moves() {
@@ -456,5 +468,33 @@ out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Varia
 out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-long-leaper\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
   | "${ENGINE}")
 echo "$out" | grep -q "^a1e1: 1$"
+
+# Wrapped-board custom lame profile: ANY_PATH
+# clear board
+out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-anypath\nposition fen k7/8/8/8/8/8/8/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
+  | "${ENGINE}")
+echo "$out" | grep -q "^a1h3: 1$"
+# a2 blocked
+out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-anypath\nposition fen k7/8/8/8/8/8/P7/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
+  | "${ENGINE}")
+echo "$out" | grep -q "^a1h3: 1$"
+# h2 blocked
+out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-anypath\nposition fen k7/8/8/8/8/8/7P/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
+  | "${ENGINE}")
+echo "$out" | grep -q "^a1h3: 1$"
+# a2 and h2 both blocked
+out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-anypath\nposition fen k7/8/8/8/8/8/P6P/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
+  | "${ENGINE}")
+! echo "$out" | grep -q "^a1h3:"
+
+# Wrapped-board custom lame profile: ORTH_FIRST
+# clear board
+out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-orthfirst\nposition fen k7/8/8/8/8/8/8/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
+  | "${ENGINE}")
+echo "$out" | grep -q "^a1h3: 1$"
+# a2 blocked (this leg blocks the ORTH_FIRST wrapped h3 jump)
+out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-orthfirst\nposition fen k7/8/8/8/8/8/P7/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
+  | "${ENGINE}")
+! echo "$out" | grep -q "^a1h3:"
 
 echo "alfil-dabbaba-riders test OK"


### PR DESCRIPTION
Adds missing regression test coverage for custom lame rider profiles (`n{path:anypath}N` and `n{path:orthfirst}N`) on wrapped cylindrical boards, checking proper blockage semantics across wrapped legs.

---
*PR created automatically by Jules for task [11680503072870083738](https://jules.google.com/task/11680503072870083738) started by @RainRat*