### PR TITLE
Fix: Avoid forced-jump follow-up check for quiet hoppers

### DIFF
--- a/src/piece.h
+++ b/src/piece.h
@@ -152,6 +152,12 @@ struct PieceInfo {
           return true;
     return false;
   }
+  inline bool has_universal_capture_hopper() const {
+    for (int initial = 0; initial < 2; ++initial)
+      if (!universalHopper[initial][MODALITY_CAPTURE].empty())
+        return true;
+    return false;
+  }
   inline bool has_lame_leaper() const {
     for (int initial = 0; initial < 2; ++initial)
       for (int modality = 0; modality < MOVE_MODALITY_NB; ++modality)

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2746,7 +2746,7 @@ bool Position::compute_forced_jump_followup(Square s, int step) const {
 
   PieceType movePt = type_of(mover) == KING ? king_type() : type_of(mover);
   const PieceInfo* pi = pieceMap.get(movePt);
-  if (!(pi->has_universal_hopper()))
+  if (!(pi->has_universal_capture_hopper()))
       return false;
 
   Color c = color_of(mover);


### PR DESCRIPTION
Fixes an issue where `compute_forced_jump_followup()` used an overly broad condition `pi->has_universal_hopper()`, causing pieces with only a quiet hopper profile to needlessly trigger forced-jump probe calculations. This PR narrows the condition by adding `has_universal_capture_hopper()` to strictly limit checking to capture-capable hoppers.

---
*PR created automatically by Jules for task [14611486372731510606](https://jules.google.com/task/14611486372731510606) started by @RainRat*