### PR TITLE
Fix LLM-flagged issues across movegen, position, and tests

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -293,7 +293,7 @@ namespace {
     {
         Square to = pop_lsb(entries);
         auto emit_insert = [&](Square from, PieceType insertPt) {
-            if (!is_ok(from))
+            if (!is_ok(from) || !(square_bb(from) & pos.board_bb()))
                 return;
             Move m = make_insert(from, to, insertPt, insertPt);
             bool push = pos.push_move(m);
@@ -425,7 +425,7 @@ namespace {
                 if (pos.promotion_allowed(Us, pop_lsb(ps), to))
                     return true;
             PieceType pt = pos.promoted_piece_type(PAWN);
-            if (pt && pos.promotion_allowed(Us, pt) && !(pos.piece_promotion_on_capture() && pos.empty(to)))
+            if (pt && pos.promotion_allowed(Us, pt, to) && !(pos.piece_promotion_on_capture() && pos.empty(to)))
                 return true;
             return false;
         };
@@ -452,9 +452,6 @@ namespace {
             Bitboard attacks = pos.attacks_from(Us, PAWN, from) & capturable & target;
             Bitboard epSquares = pos.attacks_from(Us, PAWN, from) & pos.ep_squares() & ~pos.pieces() & target;
 
-            if (Type == QUIET_CHECKS)
-                quiets &= pos.check_squares(PAWN);
-
             if (mandatoryPromotionZone)
             {
                 Bitboard blocked = 0;
@@ -478,6 +475,9 @@ namespace {
                     while (capturePromotions)
                         emit_promotions(from, pop_lsb(capturePromotions));
             }
+
+            if (Type == QUIET_CHECKS)
+                quiets &= pos.check_squares(PAWN);
 
             if (Type != CAPTURES)
                 while (quiets)
@@ -529,7 +529,7 @@ namespace {
             if (pos.promotion_allowed(Us, pop_lsb(ps), to))
                 return true;
         PieceType pt = pos.promoted_piece_type(PAWN);
-        if (pt && pos.promotion_allowed(Us, pt) && !(pos.piece_promotion_on_capture() && pos.empty(to)))
+        if (pt && pos.promotion_allowed(Us, pt, to) && !(pos.piece_promotion_on_capture() && pos.empty(to)))
             return true;
         return false;
     };
@@ -1020,7 +1020,7 @@ namespace {
             target &= pos.board_bb();
 
             if (Type == EVASIONS && (pos.blast_on_capture() || pos.blast_on_self_destruct()))
-                captureTarget = ~pos.pieces(Us);
+                captureTarget = pos.board_bb() & ~pos.pieces(Us);
             else
                 captureTarget = target;
         }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -4553,7 +4553,9 @@ bool Position::pseudo_legal(const Move m) const {
           while (remaining)
               evasionTargets &= checker_targets(pop_lsb(remaining));
 
-          const bool blastEvasion = blast_on_capture() || blast_on_move() || blast_on_self_destruct();
+          const bool blastEvasion = ((capture(m) || rifle_capture(m)) && blast_on_capture(m)) ||
+                                    (!capture(m) && !rifle_capture(m) && !is_self_destruct(m) && blast_on_move()) ||
+                                    (is_self_destruct(m) && blast_on_self_destruct());
           if (!blastEvasion && !(evasionTargets & to))
               return false;
           }

--- a/test.py
+++ b/test.py
@@ -2148,6 +2148,9 @@ stepwisePushing = true
             expected2 = "5/5/3RR/5/5 b - - 0 1"
             self.assertEqual(sf.get_fen(variant, fen2, moves2), expected2)
         finally:
+            path = repo_variants_ini()
+            if path:
+                sf.set_option("VariantPath", str(path))
             os.remove(temp_name)
 
 if __name__ == '__main__':

--- a/tests/gating-check-regression.sh
+++ b/tests/gating-check-regression.sh
@@ -13,6 +13,20 @@ ENGINE=${1:-./src/stockfish}
 ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 CXX=${CXX:-g++}
 
+ENGINE_BASENAME=$(basename "${ENGINE}")
+CXX_DEFS=()
+case "${ENGINE_BASENAME}" in
+  stockfish-allvars*)
+    CXX_DEFS+=(-DLARGEBOARDS -DALLVARS -DNNUE_EMBEDDING_OFF)
+    ;;
+  stockfish-large*)
+    CXX_DEFS+=(-DLARGEBOARDS -DALLVARS -DNNUE_EMBEDDING_OFF)
+    ;;
+  stockfish-vlb*)
+    CXX_DEFS+=(-DLARGEBOARDS -DVERY_LARGE_BOARDS -DALLVARS -DNNUE_EMBEDDING_OFF)
+    ;;
+esac
+
 run_cmds() {
   local ini=$1
   local cmds=$2
@@ -21,7 +35,7 @@ run_cmds() {
 
 echo "Running gating-check-regression tests..."
 
-TMP_INI=$(mktemp)
+TMP_INI=$(mktemp "${TMPDIR:-/tmp}/gating-check-XXXXXX.ini")
 TMP_CPP=""
 TMP_BIN=""
 HARNESS_CPP=""
@@ -82,8 +96,8 @@ if [ "$NODES" -ne 9 ]; then
 fi
 
 # --- TEST 4: Encoded gate/pull squares must preserve the last board square ---
-TMP_CPP=$(mktemp /tmp/gating-check-XXXXXX.cpp)
-TMP_BIN=$(mktemp /tmp/gating-check-XXXXXX)
+TMP_CPP=$(mktemp "${TMPDIR:-/tmp}/gating-check-XXXXXX.cpp")
+TMP_BIN=$(mktemp "${TMPDIR:-/tmp}/gating-check-XXXXXX")
 cat > "${TMP_CPP}" <<'EOF'
 #include <cassert>
 #include "types.h"
@@ -99,12 +113,12 @@ int main() {
 }
 EOF
 rm -f "${TMP_BIN}"
-"${CXX}" -std=c++17 -O2 -Wall -Wextra -I"${ROOT_DIR}/src" "${TMP_CPP}" -o "${TMP_BIN}"
+"${CXX}" -std=c++17 -O2 -Wall -Wextra -I"${ROOT_DIR}/src" "${CXX_DEFS[@]}" "${TMP_CPP}" -o "${TMP_BIN}"
 "${TMP_BIN}"
 
 # --- TEST 5: Paired gating must undo cleanly and preserve the material key ---
-HARNESS_CPP=$(mktemp /tmp/gating-check-roundtrip-XXXXXX.cpp)
-HARNESS_BIN=$(mktemp /tmp/gating-check-roundtrip-XXXXXX)
+HARNESS_CPP=$(mktemp "${TMPDIR:-/tmp}/gating-check-roundtrip-XXXXXX.cpp")
+HARNESS_BIN=$(mktemp "${TMPDIR:-/tmp}/gating-check-roundtrip-XXXXXX")
 cat > "${HARNESS_CPP}" <<'EOF'
 #include <cassert>
 #include <sstream>
@@ -166,7 +180,7 @@ done < <(find "${ROOT_DIR}/src" -maxdepth 1 -name '*.o' ! -name 'main.o' -print0
 
 (
   cd "${ROOT_DIR}/src"
-  "${CXX}" -std=c++17 -O2 -Wall -Wextra -I"${ROOT_DIR}/src" "${HARNESS_CPP}" "${OBJ_FILES[@]}" -pthread -o "${HARNESS_BIN}"
+  "${CXX}" -std=c++17 -O2 -Wall -Wextra -I"${ROOT_DIR}/src" "${CXX_DEFS[@]}" "${HARNESS_CPP}" "${OBJ_FILES[@]}" -pthread -o "${HARNESS_BIN}"
   "${HARNESS_BIN}"
 )
 

--- a/tests/local-regression.sh
+++ b/tests/local-regression.sh
@@ -24,6 +24,7 @@ fi
 
 cd "${ROOT_DIR}"
 
+run_step "fast regression" timeout 2m bash tests/fast-regression.sh "${ENGINE}"
 run_step "invalid scalar regression" timeout 30s bash tests/invalid-scalar-regression.sh "${ENGINE}"
 run_step "all-vars regression" timeout 60m bash tests/allvars-regression.sh
 run_step "protocol" timeout 2m bash tests/protocol.sh "${ENGINE}"

--- a/tests/quiet-check-special-moves.sh
+++ b/tests/quiet-check-special-moves.sh
@@ -71,6 +71,21 @@ static void load_variants() {
 [pairdrop:fairy]
 pieceDrops = true
 symmetricDropTypes = r
+
+[pull-basic:fairy]
+maxFile = e
+maxRank = 5
+castling = false
+checking = false
+king = -
+pieceToCharTable = K...A...R...k...b...r...
+king = k
+customPiece1 = a:mW
+customPiece2 = b:mW
+customPiece3 = c:mW
+pullingStrength = a:3 b:1 c:3
+startFen = 5/5/5/5/5 w - - 0 1
+
 [swap-basic:fairy]
 maxFile = e
 maxRank = 5
@@ -110,6 +125,24 @@ static void init_engine() {
     load_variants();
 }
 
+static void test_pairdrop() {
+    StateInfo st{};
+    Position pos;
+    pos.set(variants.get("pairdrop"), "4k3/8/8/8/8/8/8/4K3[RR] w - - 0 1", false, &st, nullptr);
+    const Move m = make_drop_pair(SQ_A4, SQ_H4, ROOK, ROOK);
+    assert(!pos.gives_check(m));
+    assert(!MoveList<QUIET_CHECKS>(pos).contains(m));
+}
+
+static void test_pull_basic() {
+    StateInfo st{};
+    Position pos;
+    pos.set(variants.get("pull-basic"), "5/5/2b2/2A2/5 w - - 0 1", false, &st, nullptr);
+    const Move m = make_pull(SQ_C2, SQ_D2, SQ_C3);
+    assert(!pos.gives_check(m));
+    assert(!MoveList<QUIET_CHECKS>(pos).contains(m));
+}
+
 static void test_swap_basic() {
     StateInfo st{};
     Position pos;
@@ -141,6 +174,10 @@ int main(int argc, char** argv) {
     init_engine();
 
     auto run_case = [&](const char* which) {
+        if (!which || !std::strcmp(which, "pairdrop"))
+            test_pairdrop();
+        if (!which || !std::strcmp(which, "pull"))
+            test_pull_basic();
         if (!which || !std::strcmp(which, "swap"))
             test_swap_basic();
         if (!which || !std::strcmp(which, "pass"))
@@ -166,7 +203,7 @@ done < <(find "${ROOT_DIR}/src" -maxdepth 1 -name '*.o' ! -name 'main.o' -print0
 run_case() {
   local which="$1"
   local tmp_bin
-  tmp_bin=$(mktemp /tmp/quiet-check-special-moves-XXXXXX)
+  tmp_bin=$(mktemp "${TMPDIR:-/tmp}/quiet-check-special-moves-XXXXXX")
   (
     cd "${ROOT_DIR}/src"
     "${CXX}" -std=c++17 -O2 -Wall -Wextra -flto -I"${ROOT_DIR}/src" "${CXX_DEFS[@]}" "${HARNESS_CPP}" "${OBJ_FILES[@]}" -pthread -o "${tmp_bin}"
@@ -175,7 +212,10 @@ run_case() {
   rm -f "${tmp_bin}"
 }
 
+run_case pairdrop
+run_case pull
 run_case swap
+run_case pass
 run_case wrapped
 
 echo "quiet-check-special-moves ok"

--- a/tests/upstream_movecount_baseline.py
+++ b/tests/upstream_movecount_baseline.py
@@ -140,7 +140,7 @@ def generate_baseline(upstream_engine: Path) -> dict:
                 "move_count": move_count,
             }
         )
-    return {"source": upstream_engine.name, "records": records}
+    return {"source": str(upstream_engine.resolve()), "records": records}
 
 
 def verify(local_engine: Path, fixture_path: Path) -> int:


### PR DESCRIPTION
This PR addresses 12 verifiable issues flagged by an LLM analysis of the codebase.

## Code Fixes
1. **Edge insert bounds check:** In `src/movegen.cpp`, `emit_insert` now checks whether the destination square falls within `pos.board_bb()`, protecting against invalid insertions on globally valid squares that reside outside the current variant board.
2. **QUIET_CHECKS pawn filtering:** In the wrapping pawn generator, `quiets &= pos.check_squares(PAWN)` was being applied *before* promotion handling, potentially dropping quiet checking promotions. This filtering was moved down below the promotion processing to ensure all checking promotions are correctly evaluated.
3. **Promotion fallback logic:** In `src/movegen.cpp`, the fallback in `has_promotion_for()` now uses the destination-aware `pos.promotion_allowed(Us, pt, to)` overload to respect destination-specific legality rules.
4. **Blast evasion pseudo-legality:** In `src/position.cpp`, the evasion target check relaxation under `blastEvasion` was too broad. It has been made move-specific using `rifle_capture(m)`, `capture(m)`, and `is_self_destruct(m)` in conjunction with `blast_on_capture(m)`, `blast_on_move()`, and `blast_on_self_destruct()`.
5. **Blast evasion capture mask:** `captureTarget` during blast evasion is now properly masked against `pos.board_bb()`.

## Test Fixes
6-7. **Quiet-check test coverage:** Re-added missing `pair-drop` and `pull-basic` test configurations and execution targets to `tests/quiet-check-special-moves.sh`, resolving dead code issues for `test_pass_quiet_check`.
8. **Regression coverage:** Re-added the missing execution of `tests/fast-regression.sh` to `tests/local-regression.sh`.
9. **Harness compile flags:** Added missing `CXX_DEFS` (like `-DLARGEBOARDS`) to `tests/gating-check-regression.sh` to ensure link/ABI compatibility with standard src/ objects.
10. **Temp paths:** Replaced hardcoded `/tmp` with `"${TMPDIR:-/tmp}/..."` inside `gating-check-regression.sh` and `quiet-check-special-moves.sh`.
11. **VariantPath mutation leakage:** `tests/test.py` now restores the default `VariantPath` inside a `finally` block, preventing test option leakage.
12. **Baseline Provenance:** In `tests/upstream_movecount_baseline.py`, `upstream_engine.name` was replaced with `str(upstream_engine.resolve())` to uniquely identify the upstream binary used to generate the fixtures.

All tests pass successfully with these fixes.