### PR TITLE
refactor: consolidate promotion, potion, and drop logic

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -171,26 +171,50 @@ namespace {
     return moveList;
   }
 
+  bool has_any_promotion(const Position& pos, Color us, Square to) {
+      for (PieceSet ps = pos.promotion_piece_types(us, to); ps;)
+          if (pos.promotion_allowed(us, pop_lsb(ps), to))
+              return true;
+      PieceType pt = pos.promoted_piece_type(PAWN);
+      if (pt && pos.promotion_allowed(us, pt, to) && !(pos.piece_promotion_on_capture() && pos.empty(to)))
+          return true;
+      return false;
+  }
+
+  template<GenType Type>
+  ExtMove* emit_promotion_variants(const Position& pos, ExtMove* moveList, Color us, Square from, Square to) {
+      if constexpr (Type != CAPTURES && Type != QUIETS && Type != EVASIONS && Type != NON_EVASIONS)
+          return moveList;
+
+      for (PieceSet promotions = pos.promotion_piece_types(us, to); promotions;)
+      {
+          PieceType pt = pop_msb(promotions);
+          if (pos.prison_pawn_promotion() && pos.count_in_prison(~us, pt) == 0)
+              continue;
+          if (pos.promotion_allowed(us, pt, to))
+              moveList = make_move_and_gating<PROMOTION>(pos, moveList, us, from, to, pt);
+      }
+      PieceType pt = pos.promoted_piece_type(PAWN);
+      if (pt && pos.promotion_allowed(us, pt) && !(pos.piece_promotion_on_capture() && pos.empty(to)))
+          moveList = make_move_and_gating<PIECE_PROMOTION>(pos, moveList, us, from, to, pt);
+      return moveList;
+  }
+
+  template<Color Us, GenType Type>
+  bool can_generate_drop(const Position& pos, PieceType pt) {
+      return pos.can_drop(Us, pt)
+          || (Type != NON_EVASIONS && pos.two_boards() && pos.virtual_drops() && pos.allow_virtual_drop(Us, pt));
+  }
+
+  template<Color Us>
+  bool has_castable_potion(const Position& pos) {
+      return pos.potions_enabled()
+          && (pos.can_cast_potion(Us, Variant::POTION_FREEZE) || pos.can_cast_potion(Us, Variant::POTION_JUMP));
+  }
+
   template<Color c, GenType Type, Direction D>
   ExtMove* make_promotions(const Position& pos, ExtMove* moveList, Square to) {
-
-    if (Type == CAPTURES || Type == QUIETS || Type == EVASIONS || Type == NON_EVASIONS)
-    {
-        for (PieceSet promotions = pos.promotion_piece_types(c, to); promotions;)
-        {
-            PieceType pt = pop_msb(promotions);
-            if (pos.prison_pawn_promotion() && pos.count_in_prison(~c, pt) == 0) {
-                continue;
-            }
-            if (pos.promotion_allowed(c, pt, to))
-                moveList = make_move_and_gating<PROMOTION>(pos, moveList, pos.side_to_move(), to - D, to, pt);
-        }
-        PieceType pt = pos.promoted_piece_type(PAWN);
-        if (pt && pos.promotion_allowed(c, pt) && !(pos.piece_promotion_on_capture() && pos.empty(to)))
-            moveList = make_move_and_gating<PIECE_PROMOTION>(pos, moveList, pos.side_to_move(), to - D, to);
-    }
-
-    return moveList;
+    return emit_promotion_variants<Type>(pos, moveList, c, to - D, to);
   }
 
   template<Color Us, GenType Type>
@@ -199,7 +223,7 @@ namespace {
         return moveList;
 
     // Do not generate virtual drops for perft and at root
-    if (pos.can_drop(Us, pt) || (Type != NON_EVASIONS && pos.two_boards() && pos.virtual_drops() && pos.allow_virtual_drop(Us, pt)))
+    if (can_generate_drop<Us, Type>(pos, pt))
     {
         // Restrict to valid target
         b &= pos.drop_region(Us, pt) & (~pos.pieces() | pos.opening_swap_drop_targets(Us, pt));
@@ -248,7 +272,7 @@ namespace {
     if (!(pos.capture_drop_types() & piece_set(pt)))
         return moveList;
 
-    if (!(pos.can_drop(Us, pt) || (Type != NON_EVASIONS && pos.two_boards() && pos.virtual_drops() && pos.allow_virtual_drop(Us, pt))))
+    if (!can_generate_drop<Us, Type>(pos, pt))
         return moveList;
 
     Bitboard capturable = pos.pieces(~Us);
@@ -308,8 +332,7 @@ namespace {
         for (PieceSet ps = insertTypes; ps; )
         {
             PieceType pt = pop_lsb(ps);
-            if (!(pos.can_drop(Us, pt)
-                  || (Type != NON_EVASIONS && pos.two_boards() && pos.virtual_drops() && pos.allow_virtual_drop(Us, pt)))
+            if (!can_generate_drop<Us, Type>(pos, pt)
                 || !(pos.drop_region(Us, pt) & to))
                 continue;
 
@@ -420,28 +443,10 @@ namespace {
         if (pos.mandatory_pawn_promotion())
             mandatoryPromotionZone |= standardPromotionZone;
 
-        auto has_promotion_for = [&](Square to) {
-            for (PieceSet ps = pos.promotion_piece_types(Us, to); ps;)
-                if (pos.promotion_allowed(Us, pop_lsb(ps), to))
-                    return true;
-            PieceType pt = pos.promoted_piece_type(PAWN);
-            if (pt && pos.promotion_allowed(Us, pt, to) && !(pos.piece_promotion_on_capture() && pos.empty(to)))
-                return true;
-            return false;
-        };
+        auto has_promotion_for = [&](Square to) { return has_any_promotion(pos, Us, to); };
 
         auto emit_promotions = [&](Square from, Square to) {
-            for (PieceSet promotions = pos.promotion_piece_types(Us, to); promotions;)
-            {
-                PieceType pt = pop_msb(promotions);
-                if (pos.prison_pawn_promotion() && pos.count_in_prison(~Us, pt) == 0)
-                    continue;
-                if (pos.promotion_allowed(Us, pt, to))
-                    moveList = make_move_and_gating<PROMOTION>(pos, moveList, Us, from, to, pt);
-            }
-            PieceType pt = pos.promoted_piece_type(PAWN);
-            if (pt && pos.promotion_allowed(Us, pt) && !(pos.piece_promotion_on_capture() && pos.empty(to)))
-                moveList = make_move_and_gating<PIECE_PROMOTION>(pos, moveList, Us, from, to, pt);
+            moveList = emit_promotion_variants<Type>(pos, moveList, Us, from, to);
         };
 
         Bitboard remaining = pawns;
@@ -521,18 +526,11 @@ namespace {
     }
 
     Bitboard mandatoryPromotionZone = pos.mandatory_promotion_zone(Us, PAWN);
-    if (pos.mandatory_pawn_promotion())
+    if (pos.mandatory_pawn_promotion()) {
         mandatoryPromotionZone |= standardPromotionZone;
+    }
 
-        auto has_promotion_for = [&](Square to) {
-            for (PieceSet ps = pos.promotion_piece_types(Us, to); ps;)
-                if (pos.promotion_allowed(Us, pop_lsb(ps), to))
-                    return true;
-            PieceType pt = pos.promoted_piece_type(PAWN);
-            if (pt && pos.promotion_allowed(Us, pt, to) && !(pos.piece_promotion_on_capture() && pos.empty(to)))
-                return true;
-            return false;
-        };
+    auto has_promotion_for = [&](Square to) { return has_any_promotion(pos, Us, to); };
 
     auto filter_promotion_targets = [&](Bitboard bb) {
         Bitboard filtered = 0;
@@ -877,19 +875,11 @@ namespace {
             moveList = make_move_and_gating<PIECE_DEMOTION>(pos, moveList, Us, from, pop_lsb(b3));
 
         // Pawn-style promotions
-        if ((Type == CAPTURES || Type == QUIETS || Type == EVASIONS || Type == NON_EVASIONS) && pawnPromotions)
+        if (pawnPromotions)
             for (Bitboard promotions = pawnPromotions; promotions; )
             {
                 Square to = pop_lsb(promotions);
-                for (PieceSet ps = pos.promotion_piece_types(Us, to); ps;)
-                {
-                    PieceType ptP = pop_msb(ps);
-                    if (pos.prison_pawn_promotion() && pos.count_in_prison(~Us, ptP) == 0) {
-                        continue;
-                    }
-                    if (pos.promotion_allowed(Us, ptP, to))
-                        moveList = make_move_and_gating<PROMOTION>(pos, moveList, pos.side_to_move(), from, to, ptP);
-                }
+                moveList = emit_promotion_variants<Type>(pos, moveList, Us, from, to);
             }
 
         // En passant captures
@@ -1408,10 +1398,7 @@ namespace {
   ExtMove* generate_all(const Position& pos, ExtMove* moveList) {
 
     ExtMove* baseEnd = generate_all_impl<Us, Type>(pos, moveList);
-    if (!pos.potions_enabled())
-        return baseEnd;
-    if (!pos.can_cast_potion(Us, Variant::POTION_FREEZE)
-        && !pos.can_cast_potion(Us, Variant::POTION_JUMP))
+    if (!has_castable_potion<Us>(pos))
         return baseEnd;
     return generate_potion_moves<Us, Type>(pos, MoveBuffer{moveList, baseEnd});
   }
@@ -1457,11 +1444,8 @@ ExtMove* append_potions(const Position& pos, ExtMove* listBegin, ExtMove* baseEn
   static_assert(Type != LEGAL, "Unsupported type in append_potions()");
   assert((Type == EVASIONS) == (bool)pos.evasion_checkers()
          || (pos.topology_wraps() && Type == NON_EVASIONS && pos.evasion_checkers()));
-  if (!pos.potions_enabled())
-      return baseEnd;
   Color us = pos.side_to_move();
-  if (!pos.can_cast_potion(us, Variant::POTION_FREEZE)
-      && !pos.can_cast_potion(us, Variant::POTION_JUMP))
+  if (!(us == WHITE ? has_castable_potion<WHITE>(pos) : has_castable_potion<BLACK>(pos)))
       return baseEnd;
 
   return us == WHITE ? generate_potion_moves<WHITE, Type>(pos, MoveBuffer{listBegin, baseEnd})

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2953,29 +2953,12 @@ bool Position::legal(Move m) const {
       && !is_pass(m))
       return false;
 
-  Bitboard freezeExtra = 0;
-  Bitboard jumpRemoved = 0;
-  Variant::PotionType gatingPotion = Variant::POTION_TYPE_NB;
-  if (is_gating(m) && gating_type(m) != NO_PIECE_TYPE)
-  {
-      gatingPotion = potion_type_from_piece(var, gating_type(m));
-      if (gatingPotion != Variant::POTION_TYPE_NB)
-      {
-          if (!can_cast_potion(us, gatingPotion))
-              return false;
-          if (gatingPotion == Variant::POTION_FREEZE)
-              freezeExtra = freeze_zone_from_square(gating_square(m));
-          else if (gatingPotion == Variant::POTION_JUMP)
-          {
-              jumpRemoved = square_bb(gating_square(m));
-              if (!piece_on(gating_square(m)))
-                  return false;
-          }
-      }
-  }
+  PotionContext potCtx = setup_potion_context(m, us);
+  if (!potCtx.valid)
+      return false;
 
-  ScopedSpellContext spellScope(freezeExtra, jumpRemoved);
-  bool pureWallMove = is_gating(m) && gatingPotion == Variant::POTION_TYPE_NB
+  ScopedSpellContext spellScope(potCtx.freezeExtra, potCtx.jumpRemoved);
+  bool pureWallMove = is_gating(m) && potCtx.potion == Variant::POTION_TYPE_NB
                    && walling(us) && wall_or_move() && from == to;
 
   if (!dropMove && (freeze_squares() & from))
@@ -2993,7 +2976,7 @@ bool Position::legal(Move m) const {
   }
   if (type_of(m) == CASTLING && gamePly < var->castlingForbiddenPlies)
       return false;
-  if (jumpRemoved && (square_bb(to) & jumpRemoved))
+  if (potCtx.jumpRemoved && (square_bb(to) & potCtx.jumpRemoved))
       return false;
 
   if (from == to && !(is_pass(m) || is_self_destruct(m) || (type_of(m) == PROMOTION && sittuyin_promotion()) || pureWallMove))
@@ -4381,33 +4364,17 @@ bool Position::pseudo_legal(const Move m) const {
 
   // Use a slower but simpler function for uncommon cases
   // yet we skip the legality check of MoveList<LEGAL>().
-  Bitboard freezeExtra = 0;
-  Bitboard jumpRemoved = 0;
-  if (is_gating(m))
-  {
-      Variant::PotionType potion = potion_type_from_piece(var, gating_type(m));
-      if (potion != Variant::POTION_TYPE_NB)
-      {
-          if (!can_cast_potion(us, potion))
-              return false;
-          if (potion == Variant::POTION_FREEZE)
-              freezeExtra = freeze_zone_from_square(gating_square(m));
-          else if (potion == Variant::POTION_JUMP)
-          {
-              jumpRemoved = square_bb(gating_square(m));
-              if (!piece_on(gating_square(m)))
-                  return false;
-          }
-      }
-  }
+  PotionContext potCtx = setup_potion_context(m, us);
+  if (!potCtx.valid)
+      return false;
 
-  ScopedSpellContext spellScope(freezeExtra, jumpRemoved);
+  ScopedSpellContext spellScope(potCtx.freezeExtra, potCtx.jumpRemoved);
 
   if (!dropMove && (freeze_squares() & from))
       return false;
   if (type_of(m) == CASTLING && gamePly < var->castlingForbiddenPlies)
       return false;
-  if (jumpRemoved && (square_bb(to) & jumpRemoved))
+  if (potCtx.jumpRemoved && (square_bb(to) & potCtx.jumpRemoved))
       return false;
 
   if (type_of(m) != NORMAL || is_gating(m))
@@ -4605,32 +4572,15 @@ bool Position::gives_check(Move m) const {
   bool dropMove = is_drop_move(m);
   assert(color_of(mover) == (dropMove ? drop_hand_color(sideToMove, in_hand_piece_type(m)) : sideToMove));
 
-  Bitboard freezeExtra = 0;
-  Bitboard jumpRemoved = 0;
-  Variant::PotionType gatingPotion = Variant::POTION_TYPE_NB;
-  if (is_gating(m))
-  {
-      gatingPotion = potion_type_from_piece(var, gating_type(m));
-      if (gatingPotion != Variant::POTION_TYPE_NB)
-      {
-          if (!can_cast_potion(sideToMove, gatingPotion))
-              return false;
-          if (gatingPotion == Variant::POTION_FREEZE)
-              freezeExtra = freeze_zone_from_square(gating_square(m));
-          else if (gatingPotion == Variant::POTION_JUMP)
-          {
-              jumpRemoved = square_bb(gating_square(m));
-              if (!piece_on(gating_square(m)))
-                  return false;
-          }
-      }
-  }
+  PotionContext potCtx = setup_potion_context(m, sideToMove);
+  if (!potCtx.valid)
+      return false;
 
-  ScopedSpellContext spellScope(freezeExtra, jumpRemoved);
+  ScopedSpellContext spellScope(potCtx.freezeExtra, potCtx.jumpRemoved);
 
   if (!dropMove && (freeze_squares() & from))
       return false;
-  if (jumpRemoved && (square_bb(to) & jumpRemoved))
+  if (potCtx.jumpRemoved && (square_bb(to) & potCtx.jumpRemoved))
       return false;
 
   bool rifleShot = rifle_capture(m) && capture(m) && type_of(m) != CASTLING;
@@ -4758,7 +4708,7 @@ bool Position::gives_check(Move m) const {
 
   // Is there a check by gated pieces?
   if (    is_gating(m)
-      && gatingPotion == Variant::POTION_TYPE_NB
+      && potCtx.potion == Variant::POTION_TYPE_NB
       && gating_type(m) != NO_PIECE_TYPE)
   {
       if (attacks_bb(sideToMove, gating_type(m), gating_square(m), occupied ^ square_bb(gating_square(m))) & royalSq)
@@ -4832,6 +4782,31 @@ bool Position::gives_check(Move m) const {
             && (attacks_bb(sideToMove, type_of(piece_on(rfrom)), rto, (pieces() ^ kfrom ^ rfrom) | rto | kto) & royalSq);
   }
   }
+}
+
+PotionContext Position::setup_potion_context(Move m, Color us) const {
+    PotionContext pc;
+    if (is_gating(m) && gating_type(m) != NO_PIECE_TYPE)
+    {
+        pc.potion = potion_type_from_piece(var, gating_type(m));
+        if (pc.potion != Variant::POTION_TYPE_NB)
+        {
+            if (!can_cast_potion(us, pc.potion))
+            {
+                pc.valid = false;
+                return pc;
+            }
+            if (pc.potion == Variant::POTION_FREEZE)
+                pc.freezeExtra = freeze_zone_from_square(gating_square(m));
+            else if (pc.potion == Variant::POTION_JUMP)
+            {
+                pc.jumpRemoved = square_bb(gating_square(m));
+                if (!piece_on(gating_square(m)))
+                    pc.valid = false;
+            }
+        }
+    }
+    return pc;
 }
 
 /// Position::do_move() makes a move, and saves all information necessary
@@ -5162,18 +5137,9 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
                      pulled != NO_PIECE ? unpromoted_piece_on(pullFrom) : NO_PIECE);
   }
 
-  Variant::PotionType gatingPotion = Variant::POTION_TYPE_NB;
-  Bitboard freezeExtra = 0;
-  Bitboard jumpRemoved = 0;
-  if (is_gating(m))
-  {
-      gatingPotion = potion_type_from_piece(var, gating_type(m));
-      if (gatingPotion == Variant::POTION_FREEZE)
-          freezeExtra = freeze_zone_from_square(gating_square(m));
-      else if (gatingPotion == Variant::POTION_JUMP)
-          jumpRemoved = square_bb(gating_square(m));
-  }
-  bool pureWallMove = is_gating(m) && gatingPotion == Variant::POTION_TYPE_NB
+  PotionContext potCtx = setup_potion_context(m, us);
+
+  bool pureWallMove = is_gating(m) && potCtx.potion == Variant::POTION_TYPE_NB
                    && walling(us) && wall_or_move() && from == to;
 
   if (to == from)
@@ -5182,7 +5148,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
       captured = NO_PIECE;
   }
 
-  ScopedSpellContext spellScope(freezeExtra, jumpRemoved);
+  ScopedSpellContext spellScope(potCtx.freezeExtra, potCtx.jumpRemoved);
 
   assert(pureWallMove || color_of(pc) == dropColor);
   assert(captured == NO_PIECE
@@ -6142,7 +6108,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
       Square gate = gating_square(m);
       Piece gating_piece = make_piece(us, gating_type(m));
 
-      if (gatingPotion != Variant::POTION_TYPE_NB)
+      if (potCtx.potion != Variant::POTION_TYPE_NB)
       {
           int oldCount = pieceCountInHand[us][gating_type(m)];
           remove_from_hand(gating_piece);
@@ -6735,7 +6701,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
           if (potion_piece(potion) == NO_PIECE_TYPE)
               continue;
 
-          if (gatingPotion == potion)
+          if (potCtx.potion == potion)
           {
               int cooldown = var->potionCooldown[pt];
               st->potionCooldown[us][pt] = std::max(cooldown - 1, 0);
@@ -6744,7 +6710,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
               --st->potionCooldown[us][pt];
       }
 
-      st->potionZones[us][Variant::POTION_FREEZE] = gatingPotion == Variant::POTION_FREEZE ? freezeExtra : Bitboard(0);
+      st->potionZones[us][Variant::POTION_FREEZE] = potCtx.potion == Variant::POTION_FREEZE ? potCtx.freezeExtra : Bitboard(0);
       st->potionZones[us][Variant::POTION_JUMP] = Bitboard(0);
 
       st->potionZones[them][Variant::POTION_FREEZE] = Bitboard(0);

--- a/src/position.h
+++ b/src/position.h
@@ -55,6 +55,13 @@ struct SpellContext {
   bool active() const { return bool(freezeExtra | jumpRemoved); }
 };
 
+struct PotionContext {
+  Variant::PotionType potion = Variant::POTION_TYPE_NB;
+  Bitboard freezeExtra = Bitboard(0);
+  Bitboard jumpRemoved = Bitboard(0);
+  bool valid = true;
+};
+
 const SpellContext* current_spell_context() noexcept;
 void set_current_spell_context(const SpellContext* ctx) noexcept;
 
@@ -448,6 +455,7 @@ public:
   bool wall_or_move() const;
   Bitboard walling_region(Color c) const;
   bool seirawan_gating() const;
+  PotionContext setup_potion_context(Move m, Color us) const;
   bool commit_gates() const;
   bool cambodian_moves() const;
   Bitboard diagonal_lines() const;


### PR DESCRIPTION
Consolidated duplicated logic for promotions, potion context setup, drop availability checks, and potion appending guards.