### PR TITLE
Fix potion issues: rifle capture consumption, freeze scoping, and jump generation

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -1282,13 +1282,13 @@ namespace {
             continue;
 
         Bitboard candidates = pos.board_bb();
-        if (!var->potionDropOnOccupied)
+        if (potion == Variant::POTION_JUMP)
+            candidates &= pos.pieces();
+        else if (!var->potionDropOnOccupied)
             candidates &= ~pos.pieces();
 
         if (potion == Variant::POTION_FREEZE)
             candidates &= useful_freeze_gates(pos, Us);
-        else if (potion == Variant::POTION_JUMP)
-            candidates &= pos.pieces();
 
         if (potion == Variant::POTION_FREEZE)
         {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -6137,7 +6137,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
           apply_morph(moverSq, moveMorphType);
   }
   // Add gating piece
-  if (is_gating(m) && gating_type(m) != NO_PIECE_TYPE && !rifleShot)
+  if (is_gating(m) && gating_type(m) != NO_PIECE_TYPE)
   {
       Square gate = gating_square(m);
       Piece gating_piece = make_piece(us, gating_type(m));
@@ -6152,7 +6152,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
           if (Eval::useNNUE)
               append_dirty(st, gating_piece, SQ_NONE, SQ_NONE, gating_piece, pieceCountInHand[us][gating_type(m)]);
       }
-      else
+      else if (!rifleShot)
       {
           if (Eval::useNNUE)
               // Add gating piece

--- a/src/position.h
+++ b/src/position.h
@@ -1991,7 +1991,7 @@ inline Bitboard Position::freeze_squares(Color c) const {
   if (!potions_enabled())
       return Bitboard(0);
   Bitboard mask = st->potionZones[c][Variant::POTION_FREEZE];
-  if (const SpellContext* spellCtx = current_spell_context())
+  if (const SpellContext* spellCtx = current_spell_context(); spellCtx && c == ~sideToMove)
       mask |= spellCtx->freezeExtra;
   return mask;
 }


### PR DESCRIPTION
This PR fixes three issues related to potions:
1. Potion consumption during rifle captures: previously potions were not consumed from the hand if the capture was a rifle shot.
2. Scoped freeze effects: correctly added a side-to-move guard to ensure freeze effects only apply to the opponent during move generation and legality checks.
3. Jump potion generation: fixed a contradictory mask that prevented jump potion moves from being generated when dropping on occupied squares was generally disabled.