### PR TITLE
fix(pseudo-royal): prevent premature game loss with candidates

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -7828,7 +7828,7 @@ bool Position::is_immediate_game_end(Value& result, int ply) const {
   // immediately even though the family may include other off-board types.
   if (pseudo_royal_value() != VALUE_NONE)
       for (Color c : { ~sideToMove, sideToMove })
-          if (!(st->pseudoRoyals & pieces(c)))
+          if (!(st->pseudoRoyals & pieces(c)) && popcount(pieces(c) & st->pseudoRoyalCandidates) == 0)
           {
               result = c == sideToMove ? pseudo_royal_value(ply) : -pseudo_royal_value(ply);
               return true;


### PR DESCRIPTION
Fixed a bug in is_immediate_game_end where a position with multiple pseudo-royal candidates was incorrectly identified as an immediate loss when none of them were currently royal due to the count exceeding pseudo_royal_count. Verified with a reproduction position in the villagers variant.