### PR TITLE
Refactor test harness: source uci.sh, normalize assertions, and fix swap-roundtrip test

### DIFF
--- a/tests/movegen-regressions.sh
+++ b/tests/movegen-regressions.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ENGINE="${1:-$ROOT_DIR/src/stockfish-large}"
+ENGINE="${1:-$ROOT_DIR/src/stockfish}"
+source "$ROOT_DIR/tests/lib/uci.sh"
 
 TMP_INI="$(mktemp)"
 cleanup() {
@@ -35,16 +36,12 @@ checking = false
 pass = true
 pieceToCharTable = -
 customPiece1 = a:mW
-adjacentSwapMoveTypes = a
-startFen = 5/5/5/1AP2/5 w - - 0 1
+adjacentSwapMoveTypes = a p
+startFen = 5/5/5/1aP2/5 w - - 0 1
 EOF
 
 run_cmds() {
-  local variant_path="$1"
-  local variant="$2"
-  local cmds="$3"
-  printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\n%s\nquit\n' \
-    "$variant_path" "$variant" "$cmds" | "$ENGINE"
+  run_uci "$ENGINE" "$1" "$2" <<< "$3"
 }
 
 variant_available() {
@@ -52,7 +49,7 @@ variant_available() {
   local variant="$2"
   local out
   out=$(run_cmds "$variant_path" "$variant" "d" || true)
-  echo "$out" | grep -q "info string variant ${variant} "
+  assert_contains "$out" "info string variant ${variant} "
 }
 
 echo "movegen regressions started"
@@ -61,114 +58,114 @@ echo "movegen regressions started"
 out=$(run_cmds "$ROOT_DIR/src/variants.ini" chess \
   "position fen 7k/4P3/8/8/8/8/8/4K3 w - - 0 1
 go perft 1")
-echo "$out" | grep -q "e7e8q: 1"
+assert_contains "$out" "e7e8q: 1"
 
 # Built-in Berolina should not regain orthodox forward pawn pushes.
 out=$(printf 'uci\nsetoption name UCI_Variant value berolina\nposition startpos\ngo perft 1\nquit\n' | "$ENGINE")
-echo "$out" | grep -q "a2b3: 1"
-echo "$out" | grep -q "a2c4: 1"
-! echo "$out" | grep -q "^a2a3:"
-! echo "$out" | grep -q "^a2a4:"
+assert_contains "$out" "a2b3: 1"
+assert_contains "$out" "a2c4: 1"
+assert_not_contains "$out" "^a2a3:"
+assert_not_contains "$out" "^a2a4:"
 
 # Direct king capture must end the game immediately in capture-the-royal flows.
 out=$(run_cmds "$ROOT_DIR/src/variants.ini" british-chess \
   "position fen 10/10/10/10/10/10/10/10/4q5/3Q6 w - - 0 1 moves d1e2
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 
 if variant_available "$ROOT_DIR/src/variants.ini" minihexchess; then
   out=$(run_cmds "$ROOT_DIR/src/variants.ini" minihexchess \
     "position fen ***4/**5/*k5/7/6*/5**/KR2*** w - - 0 1 moves b1b5
 go perft 1")
-  grep -Fxq "Nodes searched: 0" <<<"$out"
+  assert_nodes "$out" "0"
 fi
 
 # Custom king movement must still participate in orthodox checkmate semantics.
 out=$(run_cmds "$TMP_INI" wazir-chess \
   "position startpos moves b7h7 h8h7 a7h7
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 
 # Tablut-family surround capture of the king must also end immediately.
 out=$(run_cmds "$ROOT_DIR/src/variants.ini" brandub \
   "position fen 4r2/7/3r3/2rK3/3r3/7/7 b - - 0 1 moves e7e4
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 
 # Anti extinction variants using "*" must not end when a single piece class is gone.
 out=$(run_cmds "$ROOT_DIR/src/variants.ini" antiminishogi \
   "position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 1" <<<"$out"
-echo "$out" | grep -q "^e1e4: 1$"
+assert_nodes "$out" "1"
+assert_contains "$out" "^e1e4: 1$"
 
 out=$(run_cmds "$ROOT_DIR/src/variants.ini" anti-losalamos \
   "position fen rn1knr/pppppp/6/6/PPPPPP/RNQKNR w - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 10" <<<"$out"
+assert_nodes "$out" "10"
 
 out=$(run_cmds "$ROOT_DIR/src/variants.ini" chaturanga-al-adli \
   "position fen brn1knrb/pppppppp/8/8/8/8/PPPPPPPP/BRNFKNRB w - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 14" <<<"$out"
+assert_nodes "$out" "14"
 
 # wallOrMove should not crash when the side to move has no pieces.
 out=$(run_cmds "$TMP_INI" wallpass \
   "position startpos
 go perft 1")
-grep -q "Nodes searched:" <<<"$out"
+assert_contains "$out" "Nodes searched:"
 
 # Duck wall relocation uses gating encoding without a gated piece.
 out=$(run_cmds "$ROOT_DIR/src/variants.ini" atomicduck \
   "position startpos moves a2a3,a3a2
 go depth 2")
-echo "$out" | grep -q "^bestmove "
+assert_contains "$out" "^bestmove "
 
 # Racing Kings must not grant generic pawn-style initial pushes to non-pawns.
 out=$(run_cmds "$ROOT_DIR/src/variants.ini" racingkings \
   "position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 21" <<<"$out"
-! echo "$out" | grep -q "^h2h4:"
-! echo "$out" | grep -q "^e2e3:"
-! echo "$out" | grep -q "^e2e4:"
-! echo "$out" | grep -q "^f2f3:"
-! echo "$out" | grep -q "^f2f4:"
+assert_nodes "$out" "21"
+assert_not_contains "$out" "^h2h4:"
+assert_not_contains "$out" "^e2e3:"
+assert_not_contains "$out" "^e2e4:"
+assert_not_contains "$out" "^f2f3:"
+assert_not_contains "$out" "^f2f4:"
 
 # A pawn with explicit initial W moves must use the generic move generator.
 out=$(run_cmds "$TMP_INI" pawn-explicit-initial \
   "position fen 4k3/8/8/8/8/8/4P3/4K3 w - - 0 1
 go perft 1")
-echo "$out" | grep -q "^e2d2: 1$"
-echo "$out" | grep -q "^e2f2: 1$"
-echo "$out" | grep -q "^e2e3: 1$"
-! echo "$out" | grep -q "^e2e4:"
+assert_contains "$out" "^e2d2: 1$"
+assert_contains "$out" "^e2f2: 1$"
+assert_contains "$out" "^e2e3: 1$"
+assert_not_contains "$out" "^e2e4:"
 
 # A pawn that moved away and returned to its starting square must not regain double-step rights.
 out=$(run_cmds "$TMP_INI" swap-roundtrip \
-  "position fen 5/5/5/1AP2/5 w - - 0 1 moves b2c2s 0000 c2b2s 0000 0000
+  "position fen 5/5/5/1aP2/5 w - - 0 1 moves c2b2s 0000 b2c2s 0000
 go perft 1")
-! echo "$out" | grep -q "^c2c4:"
+assert_not_contains "$out" "^c2c4:"
 
 # Kings Valley pieces use the maximum-distance rule, not ordinary queen slides.
 out=$(run_cmds "$ROOT_DIR/src/variants.ini" kings-valley \
   "position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 13" <<<"$out"
-echo "$out" | grep -q "^a1d4: 1$"
-echo "$out" | grep -q "^b1e4: 1$"
-echo "$out" | grep -q "^c1a3: 1$"
-echo "$out" | grep -q "^c1c4: 1$"
-echo "$out" | grep -q "^c1e3: 1$"
-! echo "$out" | grep -q "^a1a2:"
-! echo "$out" | grep -q "^a1b2:"
-! echo "$out" | grep -q "^c1c2:"
-! echo "$out" | grep -q "^d1d2:"
+assert_nodes "$out" "13"
+assert_contains "$out" "^a1d4: 1$"
+assert_contains "$out" "^b1e4: 1$"
+assert_contains "$out" "^c1a3: 1$"
+assert_contains "$out" "^c1c4: 1$"
+assert_contains "$out" "^c1e3: 1$"
+assert_not_contains "$out" "^a1a2:"
+assert_not_contains "$out" "^a1b2:"
+assert_not_contains "$out" "^c1c2:"
+assert_not_contains "$out" "^d1d2:"
 
 # Oshi search should not prefer handing the opponent a point by self-ejecting.
 out=$(run_cmds "$ROOT_DIR/src/variants.ini" oshi \
   "position fen ca2a4/b4ab1c/4a4/9/5A3/2AC5/9/2BAA1B2/C8 w - - 10 6 {0 0}
 go depth 8")
-! echo "$out" | grep -q "^bestmove d4a4"
+assert_not_contains "$out" "^bestmove d4a4"
 
 echo "movegen regressions passed"

--- a/tests/new-variants-smoke.sh
+++ b/tests/new-variants-smoke.sh
@@ -8,6 +8,9 @@ error() {
 }
 trap 'error ${LINENO}' ERR
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/lib/uci.sh"
+
 ENGINE=${1:-}
 if [[ -z "${ENGINE}" ]]; then
   if [[ -x "src/stockfish" ]]; then
@@ -22,20 +25,30 @@ if [[ ! -f "${VARIANT_PATH}" && -f "src/variants.ini" ]]; then
 fi
 
 run_cmds() {
-  cat <<EOF | "${ENGINE}"
-uci
-setoption name VariantPath value ${VARIANT_PATH}
-$1
-quit
-EOF
+  local cmds="$1"
+  local variant=""
+  if [[ "$cmds" =~ "setoption name UCI_Variant value "([^[:space:]]+) ]]; then
+    variant="${BASH_REMATCH[1]}"
+    cmds=$(echo "$cmds" | grep -v "setoption name UCI_Variant value ")
+  fi
+  run_uci "$ENGINE" "$VARIANT_PATH" "$variant" <<< "$cmds"
 }
+
+contains() {
+  assert_contains "$out" "$1"
+}
+
+not_contains() {
+  assert_not_contains "$out" "$1"
+}
+
 
 variant_available() {
   local v="$1"
   local out
   out=$(run_cmds "setoption name UCI_Variant value ${v}
 d")
-  if echo "${out}" | grep -q "info string variant ${v} "; then
+  if grep -q "info string variant ${v} " <<<"${out}"; then
     return 0
   fi
   return 1
@@ -62,8 +75,8 @@ go perft 1
 quit
 EOF
 )
-echo "${out}" | grep -q "^a7a8q: 1$"
-echo "${out}" | grep -q "^h7h8q: 1$"
+contains "^a7a8q: 1$"
+contains "^h7h8q: 1$"
 rm -f "${tmp_ini}"
 
 # This smoke suite contains >8x8 and template-dependent variants.
@@ -73,23 +86,23 @@ rm -f "${tmp_ini}"
 out=$(run_cmds "setoption name UCI_Variant value berolina
 position startpos
 go perft 1")
-echo "${out}" | grep -q "^a2b3: 1$"
-echo "${out}" | grep -q "^a2c4: 1$"
-! echo "${out}" | grep -q "^a2a3: 1$"
-! echo "${out}" | grep -q "^a2a4: 1$"
+contains "^a2b3: 1$"
+contains "^a2c4: 1$"
+not_contains "^a2a3: 1$"
+not_contains "^a2a4: 1$"
 
 # 1) Hasami: orthogonal sandwich should capture the middle piece.
 if variant_available "hasami"; then
 out=$(run_cmds "setoption name UCI_Variant value hasami
 position fen 9/9/9/9/9/9/9/R1rR5/9 w - - 0 1 moves a2b2
 d")
-echo "${out}" | grep -q "Fen: 9/9/9/9/9/9/9/1R1R5/9 b - - 1 1"
+contains "Fen: 9/9/9/9/9/9/9/1R1R5/9 b - - 1 1"
 
 # 2) Hasami: edge alone is not hostile; moving away must not capture.
 out=$(run_cmds "setoption name UCI_Variant value hasami
 position fen 9/9/9/9/9/9/9/Rr7/9 w - - 0 1 moves a2a1
 d")
-echo "${out}" | grep -q "Fen: 9/9/9/9/9/9/9/1r7/R8 b - - 1 1"
+contains "Fen: 9/9/9/9/9/9/9/1r7/R8 b - - 1 1"
 fi
 
 # 3) Achi: pre-connected line is immediate game end (no legal moves).
@@ -97,13 +110,13 @@ if variant_available "achi"; then
 out=$(run_cmds "setoption name UCI_Variant value achi
 position fen PPP/3/3[PPPPpppp] b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 
 # 4) Achi: non-terminal filled setup still yields legal drops.
 out=$(run_cmds "setoption name UCI_Variant value achi
 position fen PpP/pPp/3[PpppPPPP] w - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 3" <<<"$out"
+assert_nodes "$out" "3"
 fi
 
 # 5) Checkless: king capture is legal (checks are disabled by variant).
@@ -111,7 +124,7 @@ if variant_available "checkless"; then
 out=$(run_cmds "setoption name UCI_Variant value checkless
 position fen 4k3/8/8/8/8/8/4Q3/4K3 w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^e2e8: 1$"
+contains "^e2e8: 1$"
 fi
 
 # 5a) Janggi: non-king moves may not expose the king to a cannon check.
@@ -119,7 +132,7 @@ if variant_available "janggi"; then
 out=$(run_cmds "setoption name UCI_Variant value janggi
 position fen rnba1abnr/4k4/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/4C2C1/4K4/RNBA1ABNR b - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^e7f7: 1$"
+not_contains "^e7f7: 1$"
 fi
 
 # 5b) Little Trio: the opening cannon capture over the pawn screen is available.
@@ -127,7 +140,7 @@ if variant_available "little-trio"; then
 out=$(run_cmds "setoption name UCI_Variant value little-trio
 position startpos
 go perft 1")
-echo "${out}" | grep -q "^f1f6: 1$"
+contains "^f1f6: 1$"
 fi
 
 # 5ba) Former built-ins moved to variants.ini still load and preserve core behavior.
@@ -137,32 +150,32 @@ done
 out=$(run_cmds "setoption name UCI_Variant value balancedalternation2
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 20" <<<"$out"
+assert_nodes "$out" "20"
 out=$(run_cmds "setoption name UCI_Variant value raazuvaa
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"
+contains "Fen: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"
 out=$(run_cmds "setoption name UCI_Variant value paradigm
 position fen 4k3/1P6/8/8/8/8/8/4K3 w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^b7b8b: 1$"
+contains "^b7b8b: 1$"
 if variant_available "joust"; then
 out=$(run_cmds "setoption name UCI_Variant value joust
 position startpos
 go perft 1")
-echo "${out}" | grep -q "^d4b5,b5d4: 1$"
+contains "^d4b5,b5d4: 1$"
 fi
 out=$(run_cmds "setoption name UCI_Variant value fox-and-hounds
 position startpos
 go perft 1")
-echo "${out}" | grep -q "^e1d2: 1$"
+contains "^e1d2: 1$"
 
 if variant_available "lewthwaite-swap"; then
 out=$(run_cmds "setoption name UCI_Variant value lewthwaite-swap
 position startpos
 go perft 1")
-grep -q "Nodes searched:" <<<"$out"
-! echo "${out}" | grep -q "s: 1$"
+contains "Nodes searched:"
+not_contains "s: 1$"
 fi
 
 # 5bb) Additional Groups variants load and expose the expected setup-phase drops.
@@ -172,170 +185,170 @@ done
 out=$(run_cmds "setoption name UCI_Variant value groups-setup
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 8" <<<"$out"
+assert_nodes "$out" "8"
 out=$(run_cmds "setoption name UCI_Variant value groups-jump-setup
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 8" <<<"$out"
+assert_nodes "$out" "8"
 out=$(run_cmds "setoption name UCI_Variant value groups-queen-setup
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 8" <<<"$out"
+assert_nodes "$out" "8"
 out=$(run_cmds "setoption name UCI_Variant value groups-queen-jump-setup
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 8" <<<"$out"
+assert_nodes "$out" "8"
 
 # 5bb1) Mini Hexchess loads on the masked 37-cell hex board and exposes the expected opening moves.
 if variant_available "hex-7x7"; then
 out=$(run_cmds "setoption name UCI_Variant value hex-7x7
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 49" <<<"$out"
+assert_nodes "$out" "49"
 fi
 
 if variant_available "hex-10x10"; then
 out=$(run_cmds "setoption name UCI_Variant value hex-10x10
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 100" <<<"$out"
+assert_nodes "$out" "100"
 fi
 
 if variant_available "hex-16x16"; then
 out=$(run_cmds "setoption name UCI_Variant value hex-16x16
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 256" <<<"$out"
+assert_nodes "$out" "256"
 fi
 
 if variant_available "esa-hex"; then
 out=$(run_cmds "setoption name UCI_Variant value esa-hex
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 100" <<<"$out"
+assert_nodes "$out" "100"
 out=$(run_cmds "setoption name UCI_Variant value esa-hex
 position startpos moves P@a1
 go perft 1")
-echo "${out}" | grep -q "^0000: 1$"
+contains "^0000: 1$"
 fi
 
 if variant_available "misere-hex"; then
 out=$(run_cmds "setoption name UCI_Variant value misere-hex
 position fen 11/11/11/11/11/11/11/11/11/11/PPPPPPPPPPP[P] b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 fi
 
 if variant_available "minihexchess"; then
 out=$(run_cmds "setoption name UCI_Variant value minihexchess
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 11" <<<"$out"
-echo "${out}" | grep -q "^a2d3: 1$"
-echo "${out}" | grep -q "^a2b5: 1$"
-echo "${out}" | grep -q "^c1d2: 1$"
-echo "${out}" | grep -q "^a3b4: 1$"
-echo "${out}" | grep -q "^c3d4: 1$"
-echo "${out}" | grep -q "^b2d3: 1$"
-echo "${out}" | grep -q "^b2c4: 1$"
+assert_nodes "$out" "11"
+contains "^a2d3: 1$"
+contains "^a2b5: 1$"
+contains "^c1d2: 1$"
+contains "^a3b4: 1$"
+contains "^c3d4: 1$"
+contains "^b2d3: 1$"
+contains "^b2c4: 1$"
 fi
 
 if variant_available "glinski-chess"; then
 out=$(run_cmds "setoption name UCI_Variant value glinski-chess
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 48" <<<"$out"
-echo "${out}" | grep -q "^d1d2: 1$"
-echo "${out}" | grep -q "^a4b4: 1$"
-echo "${out}" | grep -q "^a1c2: 1$"
-echo "${out}" | grep -q "^a5b6: 1$"
-echo "${out}" | grep -q "^b1d2: 1$"
+assert_nodes "$out" "48"
+contains "^d1d2: 1$"
+contains "^a4b4: 1$"
+contains "^a1c2: 1$"
+contains "^a5b6: 1$"
+contains "^b1d2: 1$"
 fi
 
 if variant_available "glinski-chess-3shift"; then
 out=$(run_cmds "setoption name UCI_Variant value glinski-chess-3shift
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 44" <<<"$out"
-echo "${out}" | grep -q "^c3e4: 1$"
-echo "${out}" | grep -q "^c5d6: 1$"
+assert_nodes "$out" "44"
+contains "^c3e4: 1$"
+contains "^c5d6: 1$"
 fi
 
 if variant_available "glinski-chess-5shift"; then
 out=$(run_cmds "setoption name UCI_Variant value glinski-chess-5shift
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 46" <<<"$out"
-echo "${out}" | grep -q "^c3e4: 1$"
-echo "${out}" | grep -q "^b4c5: 1$"
+assert_nodes "$out" "46"
+contains "^c3e4: 1$"
+contains "^b4c5: 1$"
 fi
 
 if variant_available "van-gennip-hexchess"; then
 out=$(run_cmds "setoption name UCI_Variant value van-gennip-hexchess
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 36" <<<"$out"
-echo "${out}" | grep -q "^c3d4: 1$"
+assert_nodes "$out" "36"
+contains "^c3d4: 1$"
 fi
 
 if variant_available "van-gennip-small-hexchess"; then
 out=$(run_cmds "setoption name UCI_Variant value van-gennip-small-hexchess
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 29" <<<"$out"
-echo "${out}" | grep -q "^c3d4: 1$"
+assert_nodes "$out" "29"
+contains "^c3d4: 1$"
 fi
 
 if variant_available "mccooey-chess"; then
 out=$(run_cmds "setoption name UCI_Variant value mccooey-chess
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 31" <<<"$out"
-echo "${out}" | grep -q "^c3e4: 1$"
-echo "${out}" | grep -q "^c2e1: 1$"
-echo "${out}" | grep -q "^a4b5: 1$"
-echo "${out}" | grep -q "^a4c6: 1$"
+assert_nodes "$out" "31"
+contains "^c3e4: 1$"
+contains "^c2e1: 1$"
+contains "^a4b5: 1$"
+contains "^a4c6: 1$"
 fi
 
 if variant_available "grand-hexachess"; then
 out=$(run_cmds "setoption name UCI_Variant value grand-hexachess
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 125" <<<"$out"
-echo "${out}" | grep -q "^i13g12: 1$"
-echo "${out}" | grep -q "^a5a6: 1$"
-echo "${out}" | grep -q "^k5k6: 1$"
-echo "${out}" | grep -q "^c3d4: 1$"
-echo "${out}" | grep -q "^e11f10: 1$"
-echo "${out}" | grep -q "^j13k12: 1$"
+assert_nodes "$out" "125"
+contains "^i13g12: 1$"
+contains "^a5a6: 1$"
+contains "^k5k6: 1$"
+contains "^c3d4: 1$"
+contains "^e11f10: 1$"
+contains "^j13k12: 1$"
 fi
 
 # 5bc) Simplified inheritance stanzas still preserve start positions.
 out=$(run_cmds "setoption name UCI_Variant value maharajah
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rnbqkbnr/pppppppp/8/8/8/8/8/4M3 w kq - 0 1"
+contains "Fen: rnbqkbnr/pppppppp/8/8/8/8/8/4M3 w kq - 0 1"
 out=$(run_cmds "setoption name UCI_Variant value pawnsonly
 position startpos
 d")
-echo "${out}" | grep -q "Fen: 8/pppppppp/8/8/8/8/PPPPPPPP/8 w - - 0 1"
+contains "Fen: 8/pppppppp/8/8/8/8/PPPPPPPP/8 w - - 0 1"
 out=$(run_cmds "setoption name UCI_Variant value pawns
 position startpos
 d")
-echo "${out}" | grep -q "Fen: pppppppp/8/8/8/8/8/8/PPPPPPPP w - - 0 1"
+contains "Fen: pppppppp/8/8/8/8/8/8/PPPPPPPP w - - 0 1"
 out=$(run_cmds "setoption name UCI_Variant value rugby
 position startpos
 d")
-echo "${out}" | grep -q "Fen: pppppppp/8/8/8/8/8/8/PPPPPPPP w - - 0 1"
+contains "Fen: pppppppp/8/8/8/8/8/8/PPPPPPPP w - - 0 1"
 
 # 5c) Bombardment: front-rank missiles move forward quietly and can self-destruct.
 if variant_available "bombardment"; then
 out=$(run_cmds "setoption name UCI_Variant value bombardment
 position startpos
 go perft 1")
-echo "${out}" | grep -q "^a2a3: 1$"
-echo "${out}" | grep -q "^a2b3: 1$"
-echo "${out}" | grep -q "^a2a2x: 1$"
+contains "^a2a3: 1$"
+contains "^a2b3: 1$"
+contains "^a2a2x: 1$"
 fi
 
 # 5d) Ko-Oshi: opening setup loads and immediate push-back is illegal.
@@ -343,11 +356,11 @@ if variant_available "ko-oshi"; then
 out=$(run_cmds "setoption name UCI_Variant value ko-oshi
 position startpos
 d")
-echo "${out}" | grep -q "Fen: b3b/1aaa1/5/1AAA1/B3B w - - 0 1 {0 0}"
+contains "Fen: b3b/1aaa1/5/1AAA1/B3B w - - 0 1 {0 0}"
 out=$(run_cmds "setoption name UCI_Variant value ko-oshi
 position fen 5/5/5/1a3/1A3 w - - 0 1 {0 0} moves b1b2
 go perft 1")
-! echo "${out}" | grep -q "b3b2: 1"
+not_contains "b3b2: 1"
 fi
 
 # 5e) Oshi: opening setup loads, push-back is illegal, and scoring/adjudication follow rules.
@@ -355,27 +368,27 @@ if variant_available "oshi"; then
 out=$(run_cmds "setoption name UCI_Variant value oshi
 position startpos
 d")
-echo "${out}" | grep -q "Fen: c7c/2baaab2/4a4/9/9/9/4A4/2BAAAB2/C7C w - - 0 1 {0 0}"
+contains "Fen: c7c/2baaab2/4a4/9/9/9/4A4/2BAAAB2/C7C w - - 0 1 {0 0}"
 out=$(run_cmds "setoption name UCI_Variant value oshi
 position fen 9/9/9/9/9/9/9/1a3/1A3 w - - 0 1 {0 0} moves b1b2
 go perft 1")
-! echo "${out}" | grep -q "b3b2: 1"
+not_contains "b3b2: 1"
 out=$(run_cmds "setoption name UCI_Variant value oshi
 position fen 9/9/9/9/9/9/9/C8/c8 w - - 0 1 {0 0} moves a2a1
 d")
-echo "${out}" | grep -q "Fen: 9/9/9/9/9/9/9/9/C8 b - - 0 1 {3 0}"
+contains "Fen: 9/9/9/9/9/9/9/9/C8 b - - 0 1 {3 0}"
 out=$(run_cmds "setoption name UCI_Variant value oshi
 position fen 9/9/9/9/9/9/9/C8/C8 w - - 0 1 {0 0} moves a2a1
 d")
-echo "${out}" | grep -q "Fen: 9/9/9/9/9/9/9/9/C8 b - - 0 1 {0 3}"
+contains "Fen: 9/9/9/9/9/9/9/9/C8 b - - 0 1 {0 3}"
 out=$(run_cmds "setoption name UCI_Variant value oshi
 position fen C8/9/9/9/9/9/9/9/9 b - - 0 1 {7 0}
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 out=$(run_cmds "setoption name UCI_Variant value oshi
 position fen 9/9/9/9/9/9/9/9/9 b - - 0 1 {8 7}
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 fi
 
 # 5f) Aries: opening setup loads and a repetition-losing move is avoided in search.
@@ -383,11 +396,11 @@ if variant_available "aries"; then
 out=$(run_cmds "setoption name UCI_Variant value aries
 position startpos
 d")
-echo "${out}" | grep -q "Fen: 4rrrr/4rrrr/4rrrr/4rrrr/RRRR4/RRRR4/RRRR4/RRRR4 w - - 0 1"
+contains "Fen: 4rrrr/4rrrr/4rrrr/4rrrr/RRRR4/RRRR4/RRRR4/RRRR4 w - - 0 1"
 out=$(run_cmds "setoption name UCI_Variant value aries
 position fen 8/8/8/8/8/8/7r/R7 w - - 0 1 moves a1a2 h2h1 a2a1 h1h2 a1a2 h2h1 a2a1
 go depth 3")
-! echo "${out}" | grep -q "^bestmove h1h2$"
+not_contains "^bestmove h1h2$"
 fi
 
 # 5g) Ko-app-paw-na: hunter capture and rabbit-pattern goal both end the game.
@@ -395,15 +408,15 @@ if variant_available "ko-app-paw-na"; then
 out=$(run_cmds "setoption name UCI_Variant value ko-app-paw-na
 position fen 5/2R2/2h2/5/5 b - - 0 1 moves c3c5
 d")
-echo "${out}" | grep -q "Fen: 2h2/5/5/5/5 w - - 0 2 {0 1}"
+contains "Fen: 2h2/5/5/5/5 w - - 0 2 {0 1}"
 out=$(run_cmds "setoption name UCI_Variant value ko-app-paw-na
 position fen 5/2R2/2h2/5/5 w - - 0 2 {0 1}
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 out=$(run_cmds "setoption name UCI_Variant value ko-app-paw-na
 position fen RRRRR/5/R1h1R/5/5 b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 fi
 
 # 6) Tablut split: edge-escape should end immediately, corner-escape should not.
@@ -411,32 +424,32 @@ if variant_available "tablut" && variant_available "tablut-corner-escape"; then
 out=$(run_cmds "setoption name UCI_Variant value tablut
 position fen 4K4/9/9/9/4r4/9/9/9/9 b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 
 out=$(run_cmds "setoption name UCI_Variant value tablut-corner-escape
 position fen 4K4/9/9/9/4r4/9/9/9/9 b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 15" <<<"$out"
+assert_nodes "$out" "15"
 fi
 
 # 6b) Ardri: the escape king loss ends immediately.
 out=$(run_cmds "setoption name UCI_Variant value ardri
 position fen 2rrr2/3r3/r1RRR1r/rrR1Rrr/r1RRR1r/3r3/2rrr2 b - - 0 1
 go perft 1")
-echo "${out}" | grep -q "info string variant ardri "
-grep -Fxq "Nodes searched: 0" <<<"$out"
+contains "info string variant ardri "
+assert_nodes "$out" "0"
 out=$(run_cmds "setoption name UCI_Variant value ardri
 position fen 2rrr2/3r3/r1RRR1r/rrRKRrr/r1RRR1r/3r3/2rrr2 w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "info string variant ardri "
-grep -Fxq "Nodes searched: 8" <<<"$out"
+contains "info string variant ardri "
+assert_nodes "$out" "8"
 
 # 7b) Tawlbwrdd: edge escape should end immediately on 11x11, unlike corner-escape Hnefatafl.
 if variant_available "tawlbwrdd"; then
 out=$(run_cmds "setoption name UCI_Variant value tawlbwrdd
 position fen 5K5/11/11/11/11/5r5/11/11/11/11/11 b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 fi
 
 # 7) Tablut split: throne-adjacent king strength changes capture outcome.
@@ -444,12 +457,12 @@ if variant_available "tablut" && variant_available "tablut-throne-adjacent-stron
 out=$(run_cmds "setoption name UCI_Variant value tablut
 position fen 9/9/9/9/3K5/2r6/9/9/9 b - - 0 1 moves c4c5
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 
 out=$(run_cmds "setoption name UCI_Variant value tablut-throne-adjacent-strong
 position fen 9/9/9/9/3K5/2r6/9/9/9 b - - 0 1 moves c4c5
 go perft 1")
-grep -Fxq "Nodes searched: 12" <<<"$out"
+assert_nodes "$out" "12"
 fi
 
 # 7a) Crossway: alternating 2x2 checker-pattern placements are illegal.
@@ -457,23 +470,23 @@ if variant_available "crossway"; then
 out=$(run_cmds "setoption name UCI_Variant value crossway
 position fen 8/8/8/8/8/8/S7/sS6[Ss] b - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "@b2: 1"
+not_contains "@b2: 1"
 
 # Existing edge-to-edge connection should end the game immediately.
 out=$(run_cmds "setoption name UCI_Variant value crossway
 position fen 8/8/8/SSSSSSSS/8/8/8/8[Ss] b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 
 out=$(run_cmds "setoption name UCI_Variant value crossway
 position startpos moves S@d4
 go perft 1")
-echo "${out}" | grep -q "^S@d4: 1$"
+contains "^S@d4: 1$"
 
 out=$(run_cmds "setoption name UCI_Variant value crossway
 position startpos moves S@d4 S@d4
 go perft 1")
-! echo "${out}" | grep -q "^S@d4: 1$"
+not_contains "^S@d4: 1$"
 fi
 
 # 7b) Pathway: enemy-only adjacency drops are illegal, one-friendly drops are legal, and no-placement wins.
@@ -481,17 +494,17 @@ if variant_available "pathway"; then
 out=$(run_cmds "setoption name UCI_Variant value pathway
 position fen 6/6/6/6/3p2/6[Pp] w - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^P@c2: 1$"
+not_contains "^P@c2: 1$"
 
 out=$(run_cmds "setoption name UCI_Variant value pathway
 position fen 6/6/6/2P3/3p2/6[Pp] w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^P@c2: 1$"
+contains "^P@c2: 1$"
 
 out=$(run_cmds "setoption name UCI_Variant value pathway
 position fen PPPPPP/PPPPPP/PPPPPP/pppppp/pppppp/pppppp[Pp] w - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 fi
 
 # 7c) Kopano: mirrored opening swap, reciprocal weak links, crosscut blocks, and no-placement wins.
@@ -499,33 +512,33 @@ if variant_available "kopano"; then
 out=$(run_cmds "setoption name UCI_Variant value kopano
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 64" <<<"$out"
+assert_nodes "$out" "64"
 
 out=$(run_cmds "setoption name UCI_Variant value kopano
 position startpos moves P@b1
 go perft 1")
-echo "${out}" | grep -q "^P@a2: 1$"
-! echo "${out}" | grep -q "^P@b1: 1$"
+contains "^P@a2: 1$"
+not_contains "^P@b1: 1$"
 
 out=$(run_cmds "setoption name UCI_Variant value kopano
 position fen 8/8/8/8/8/8/1P6/8[Pp] w - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^P@c3: 1$"
+not_contains "^P@c3: 1$"
 
 out=$(run_cmds "setoption name UCI_Variant value kopano
 position fen 8/8/8/8/3p4/8/1P6/8[Pp] w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^P@c3: 1$"
+contains "^P@c3: 1$"
 
 out=$(run_cmds "setoption name UCI_Variant value kopano
 position fen 8/8/8/8/2pP4/3p4/8/8[Pp] w - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^P@c3: 1$"
+not_contains "^P@c3: 1$"
 
 out=$(run_cmds "setoption name UCI_Variant value kopano
 position fen 7p/6p1/5p2/4p3/3p4/2p5/1p6/p7 w - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 fi
 
 # 7d) Hex-family connection variants: Y and Hex load on the expected build sizes.
@@ -533,14 +546,14 @@ if variant_available "y"; then
 out=$(run_cmds "setoption name UCI_Variant value y
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 55" <<<"$out"
+assert_nodes "$out" "55"
 fi
 
 if variant_available "hex"; then
 out=$(run_cmds "setoption name UCI_Variant value hex
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 121" <<<"$out"
+assert_nodes "$out" "121"
 fi
 
 # 8) Neutreeko: max-distance move completes a line and ends the game.
@@ -548,7 +561,7 @@ if variant_available "neutreeko"; then
 out=$(run_cmds "setoption name UCI_Variant value neutreeko
 position fen 5/3N1/5/1N3/N4 w - - 0 1 moves d4c3
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 fi
 
 # 9) Forced en passant: when EP is legal, ordinary king moves are forbidden.
@@ -556,8 +569,8 @@ if variant_available "forced-en-passant"; then
 out=$(run_cmds "setoption name UCI_Variant value forced-en-passant
 position fen 4k3/8/8/3pP3/8/8/8/4K3 w - d6 0 1
 go perft 1")
-echo "${out}" | grep -q "^e5d6: 1$"
-grep -Fxq "Nodes searched: 1" <<<"$out"
+contains "^e5d6: 1$"
+assert_nodes "$out" "1"
 fi
 
 # 10) Eurasian: entering the optional promotion band without reserve is still legal.
@@ -565,47 +578,47 @@ if variant_available "eurasian"; then
 out=$(run_cmds "setoption name UCI_Variant value eurasian
 position fen 4k5/10/P9/10/10/10/10/10/10/5K4 w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^a8a9: 1$"
+contains "^a8a9: 1$"
 
 # 11) Eurasian: entering the last rank without a reserve promotion is forbidden.
 out=$(run_cmds "setoption name UCI_Variant value eurasian
 position fen 4k5/P9/10/10/10/10/10/10/10/5K4 w - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^a9a10"
+not_contains "^a9a10"
 
 # 12) Eurasian: a matching reserve piece enables the last-rank promotion.
 out=$(run_cmds "setoption name UCI_Variant value eurasian
 position fen 4k5/P9/10/10/10/10/10/10/10/5K4[Q] w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^a9a10q: 1$"
+contains "^a9a10q: 1$"
 fi
 
 # 12b) Battery Chess: promotion requires a captured reserve piece and consumes it.
 out=$(run_cmds "setoption name UCI_Variant value battery-chess
 position fen 4k3/P7/8/8/8/8/8/4K3 w - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^a7a8"
+not_contains "^a7a8"
 out=$(run_cmds "setoption name UCI_Variant value battery-chess
 position fen 4k3/P7/8/8/8/8/8/4K3[Q] w - - 0 1 moves a7a8q
 d")
-echo "${out}" | grep -q "Fen: Q~3k3/8/8/8/8/8/8/4K3\\[\\] b - - 0 1"
+contains "Fen: Q~3k3/8/8/8/8/8/8/4K3\\[\\] b - - 0 1"
 
 # 12c) Beast Chess: documented replacement back rank loads.
 out=$(run_cmds "setoption name UCI_Variant value beast-chess
 position startpos
 d")
-echo "${out}" | grep -q "Fen: eghqkhge/pppppppp/8/8/8/8/PPPPPPPP/EGHQKHGE w KQkq - 0 1"
+contains "Fen: eghqkhge/pppppppp/8/8/8/8/PPPPPPPP/EGHQKHGE w KQkq - 0 1"
 
 # 13) Fatal giveaway: non-pawn capturer dies, pawns survive captures.
 if variant_available "fatal-giveaway"; then
 out=$(run_cmds "setoption name UCI_Variant value fatal-giveaway
 position fen 4k3/8/8/4p3/4R3/8/8/8 w - - 0 1 moves e4e5
 d")
-echo "${out}" | grep -q "Fen: 4k3/8/8/4\\^3/8/8/8/8 b - - 0 1"
+contains "Fen: 4k3/8/8/4\\^3/8/8/8/8 b - - 0 1"
 out=$(run_cmds "setoption name UCI_Variant value fatal-giveaway
 position fen 4k3/8/8/3p4/4P3/8/8/8 w - - 0 1 moves e4d5
 d")
-echo "${out}" | grep -q "Fen: 4k3/8/8/3P4/8/8/8/8 b - - 0 1"
+contains "Fen: 4k3/8/8/3P4/8/8/8/8 b - - 0 1"
 fi
 
 # 14) Kamikaze giveaway: any capturer is removed after capture.
@@ -613,7 +626,7 @@ if variant_available "kamikaze-giveaway"; then
 out=$(run_cmds "setoption name UCI_Variant value kamikaze-giveaway
 position fen 4k3/8/8/3p4/4P3/8/8/8 w - - 0 1 moves e4d5
 d")
-echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/8/8/8 b - - 0 1"
+contains "Fen: 4k3/8/8/8/8/8/8/8 b - - 0 1"
 fi
 
 # 15) Kamikaze: plain chess family, capturer is removed.
@@ -621,13 +634,13 @@ if variant_available "kamikaze"; then
 out=$(run_cmds "setoption name UCI_Variant value kamikaze
 position fen 4k3/8/8/3p4/4P3/8/8/4K3 w - - 0 1 moves e4d5
 d")
-echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/8/8/4K3 b - - 0 1"
+contains "Fen: 4k3/8/8/8/8/8/8/4K3 b - - 0 1"
 
 # 15b) Kamikaze (nocheckatomic template): kings are explosion-immune.
 out=$(run_cmds "setoption name UCI_Variant value kamikaze
 position fen r1bqkbnr/pppp1ppp/8/4pK2/4P3/8/PPPP1PPP/RNBQ2NR w KQkq - 0 3 moves f5e5
 d")
-echo "${out}" | grep -q "Fen: r1bqkbnr/pppp1ppp/8/4K3/4P3/8/PPPP1PPP/RNBQ2NR b kq - 0 3"
+contains "Fen: r1bqkbnr/pppp1ppp/8/4K3/4P3/8/PPPP1PPP/RNBQ2NR b kq - 0 3"
 fi
 
 # 16) Fatal giveaway: dead squares can be captured as neutral blockers.
@@ -635,22 +648,22 @@ if variant_available "fatal-giveaway"; then
 out=$(run_cmds "setoption name UCI_Variant value fatal-giveaway
 position fen 4k3/8/8/4\\^3/8/8/8/4Q3 w - - 0 1 moves e1e5
 d")
-echo "${out}" | grep -q "Fen: 4k3/8/8/4Q3/8/8/8/8 b - - 0 1"
+contains "Fen: 4k3/8/8/4Q3/8/8/8/8 b - - 0 1"
 fi
 
 # 17) Progressive: after Black's first move, White must pass before Black's second move.
 out=$(run_cmds "setoption name UCI_Variant value progressive
 position startpos moves e2e4 e7e5
 go perft 1")
-echo "${out}" | grep -q "^0000: 1$"
+contains "^0000: 1$"
 
 # 18) British chess: the royal queen may not move through check.
 if variant_available "british-chess"; then
 out=$(run_cmds "setoption name UCI_Variant value british-chess
 position fen 9q/10/10/10/10/10/10/10/1r8/4Q5 w - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^e1e3: 1$"
-echo "${out}" | grep -q "^e1f1: 1$"
+not_contains "^e1e3: 1$"
+contains "^e1f1: 1$"
 fi
 
 # 18b) Hippolyta: captures are stationary, mandatory, and pieces do not move.
@@ -658,50 +671,50 @@ if variant_available "hippolyta"; then
 out=$(run_cmds "setoption name UCI_Variant value hippolyta
 position startpos
 go perft 1")
-echo "${out}" | grep -q "^a1b2: 1$"
-! echo "${out}" | grep -q "^a1a2:"
+contains "^a1b2: 1$"
+not_contains "^a1a2:"
 fi
 
 # 19) iChess: setup starts with non-king drops only.
 out=$(run_cmds "setoption name UCI_Variant value ichess
 position startpos
 go perft 1")
-! echo "${out}" | grep -q "^K@"
-echo "${out}" | grep -q "^Q@"
+not_contains "^K@"
+contains "^Q@"
 # 19b) Half Chess: 4x8 orthodox setup with no pawns.
 out=$(run_cmds "setoption name UCI_Variant value half-chess
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rnbq/kbbq/4/4/4/4/KBBQ/RNBQ w - - 0 1"
+contains "Fen: rnbq/kbbq/4/4/4/4/KBBQ/RNBQ w - - 0 1"
 
 # 19baa) Los Alamos Chess: 6x6 chess without bishops.
 out=$(run_cmds "setoption name UCI_Variant value losalamos
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rnqknr/pppppp/6/6/PPPPPP/RNQKNR w - - 0 1"
+contains "Fen: rnqknr/pppppp/6/6/PPPPPP/RNQKNR w - - 0 1"
 
 # 19bab) Promotion Chess: pawn-only setup with kings in opposite corners.
 out=$(run_cmds "setoption name UCI_Variant value promotion-chess
 position startpos
 d")
-echo "${out}" | grep -q "Fen: 7k/pppppppp/8/pppppppp/PPPPPPPP/8/PPPPPPPP/K7 w - - 0 1"
+contains "Fen: 7k/pppppppp/8/pppppppp/PPPPPPPP/8/PPPPPPPP/K7 w - - 0 1"
 out=$(run_cmds "setoption name UCI_Variant value promotion-chess
 position fen 7k/P7/8/8/8/8/8/K7 w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "a7a8q: 1"
-echo "${out}" | grep -q "a7a8r: 1"
-echo "${out}" | grep -q "a7a8b: 1"
-echo "${out}" | grep -q "a7a8n: 1"
+contains "a7a8q: 1"
+contains "a7a8r: 1"
+contains "a7a8b: 1"
+contains "a7a8n: 1"
 
 # 19bac) Reach Chess: reaching the back rank wins, and the current checkmated case is terminal.
 out=$(run_cmds "setoption name UCI_Variant value reach-chess
 position fen 4P3/8/8/8/8/8/8/4k3 b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 out=$(run_cmds "setoption name UCI_Variant value reach-chess
 position fen 7k/6Q1/5K2/8/8/8/8/8 b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 
 # 19bad) All Queens Chess: source-backed setup and line-of-four win.
 if variant_available "allqueenschess"; then
@@ -712,7 +725,7 @@ echo "${out}" | grep -Eq "Fen: qQqQq/5/Q3q/5/QqQqQ(\\[\\])? w - - 0 1"
 out=$(run_cmds "setoption name UCI_Variant value allqueenschess
 position fen 5/QQQQ1/5/5/5 b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 fi
 
 # 19bb) Compound Chess: setup and dragon-specific en passant capture.
@@ -720,53 +733,53 @@ if variant_available "compound-chess"; then
 out=$(run_cmds "setoption name UCI_Variant value compound-chess
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rdcbqkbcdr/ssssssssss/10/10/10/10/SSSSSSSSSS/RDCBQKBCDR w KQkq - 0 1"
+contains "Fen: rdcbqkbcdr/ssssssssss/10/10/10/10/SSSSSSSSSS/RDCBQKBCDR w KQkq - 0 1"
 fi
 
 # 19ba) Crown Prince Chess: crown prince cannot capture and wins by reaching the back rank.
 out=$(run_cmds "setoption name UCI_Variant value crown-prince-chess
 position fen 4k3/8/8/8/8/8/4p3/4C3 w - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^e1e2"
+not_contains "^e1e2"
 out=$(run_cmds "setoption name UCI_Variant value crown-prince-chess
 position fen 4C3/8/8/8/8/8/8/4k3 b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 
 # 19c) Dris at-Talata: setup by drops, then pieces move to any empty square.
 out=$(run_cmds "setoption name UCI_Variant value dris-at-talata
 position startpos
 go perft 1")
-echo "${out}" | grep -q "^M@a1: 1$"
+contains "^M@a1: 1$"
 out=$(run_cmds "setoption name UCI_Variant value dris-at-talata
 position startpos moves M@a1 M@a3 M@b2 M@b1 M@c1 M@c3
 go perft 1")
-echo "${out}" | grep -q "^a1a2: 1$"
-echo "${out}" | grep -q "^a1b3: 1$"
+contains "^a1a2: 1$"
+contains "^a1b3: 1$"
 
 # 19ca) Tic-Tac-Chess: setup by drops, then chess-style motion plus hop-without-capture.
 out=$(run_cmds "setoption name UCI_Variant value tictacchess
 position startpos
 go perft 1")
-echo "${out}" | grep -q "^Q@a1: 1$"
+contains "^Q@a1: 1$"
 out=$(run_cmds "setoption name UCI_Variant value tictacchess
 position startpos moves Q@a1 Q@b2 R@a2 R@c2 K@b1 K@c1
 go perft 1")
-echo "${out}" | grep -q "^b1b3: 1$"
-echo "${out}" | grep -q "^a2a3: 1$"
+contains "^b1b3: 1$"
+contains "^a2a3: 1$"
 
 # 19d) Shatranj al-Jawarhiya: source-backed 7x8 setup should load as documented.
 out=$(run_cmds "setoption name UCI_Variant value shatranj-al-jawarhiya
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rafkanr/ppppppp/7/7/7/7/PPPPPPP/RNAFKAR w - - 0 1"
+contains "Fen: rafkanr/ppppppp/7/7/7/7/PPPPPPP/RNAFKAR w - - 0 1"
 
 # 19daa) Shatranj (14x14): source-backed setup should load if the build supports it.
 if variant_available "shatranj-14x14"; then
 out=$(run_cmds "setoption name UCI_Variant value shatranj-14x14
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rndwbmksbwdnr1/pppppppppppppp/14/14/14/14/14/14/14/14/14/14/PPPPPPPPPPPPPP/RNDWBSKMBWDNR1 w - - 0 1"
+contains "Fen: rndwbmksbwdnr1/pppppppppppppp/14/14/14/14/14/14/14/14/14/14/PPPPPPPPPPPPPP/RNDWBSKMBWDNR1 w - - 0 1"
 fi
 
 # 19da) Shatranj: source-backed setup should load as documented.
@@ -774,73 +787,73 @@ if variant_available "shatranj"; then
 out=$(run_cmds "setoption name UCI_Variant value shatranj
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rnafkanr/pppppppp/8/8/8/8/PPPPPPPP/RNAFKANR w - - 0 1"
+contains "Fen: rnafkanr/pppppppp/8/8/8/8/PPPPPPPP/RNAFKANR w - - 0 1"
 fi
 
 # 19db) Chaturanga: source-backed setup should load as documented.
 out=$(run_cmds "setoption name UCI_Variant value chaturanga
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"
+contains "Fen: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"
 
 # 19dc) Chaturanga (Payagunda): source-backed setup should load as documented.
 out=$(run_cmds "setoption name UCI_Variant value chaturanga-payagunda
 position startpos
 d")
-echo "${out}" | grep -q "Fen: afrkbnfa/pppppppp/8/8/8/8/PPPPPPPP/AFRNBKFA w - - 0 1"
+contains "Fen: afrkbnfa/pppppppp/8/8/8/8/PPPPPPPP/AFRNBKFA w - - 0 1"
 
 # 19dd) Chaturanga (al-Adli): source-backed setup should load as documented.
 out=$(run_cmds "setoption name UCI_Variant value chaturanga-al-adli
 position startpos
 d")
-echo "${out}" | grep -q "Fen: brnfknrb/pppppppp/8/8/8/8/PPPPPPPP/BRNFKNRB w - - 0 1"
+contains "Fen: brnfknrb/pppppppp/8/8/8/8/PPPPPPPP/BRNFKNRB w - - 0 1"
 
 # 19de) Shatranj (Iraq): source-backed setup and current elephant immunity behavior.
 out=$(run_cmds "setoption name UCI_Variant value shatranj-iraq
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rnefkenr/pppppppp/8/8/8/8/PPPPPPPP/RNEFKENR w - - 0 1"
+contains "Fen: rnefkenr/pppppppp/8/8/8/8/PPPPPPPP/RNEFKENR w - - 0 1"
 out=$(run_cmds "setoption name UCI_Variant value shatranj-iraq
 position fen 8/8/8/3e4/4E3/8/8/4K3 w - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^e4d5: 1$"
-echo "${out}" | grep -q "^e4d3: 1$"
-echo "${out}" | grep -q "^e4f5: 1$"
-echo "${out}" | grep -q "^e4f3: 1$"
+not_contains "^e4d5: 1$"
+contains "^e4d3: 1$"
+contains "^e4f5: 1$"
+contains "^e4f3: 1$"
 
 # 19de) Shatranj (Turkey): source-backed setup currently loads without first-move Fers leaps.
 out=$(run_cmds "setoption name UCI_Variant value shatranj-turkey
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rnafkanr/pppppppp/8/8/8/8/PPPPPPPP/RNAFKANR w - - 0 1"
+contains "Fen: rnafkanr/pppppppp/8/8/8/8/PPPPPPPP/RNAFKANR w - - 0 1"
 
 # 19df) Tsatsarandi: documented title currently maps to orthodox shatranj rules.
 out=$(run_cmds "setoption name UCI_Variant value tsatsarandi
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rnbkqbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBKQBNR w - - 0 1"
+contains "Fen: rnbkqbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBKQBNR w - - 0 1"
 
 # 19e) Chess (Siberia): source-backed 9x9 setup should load as documented.
 if variant_available "chess-siberia"; then
 out=$(run_cmds "setoption name UCI_Variant value chess-siberia
 position startpos
 d")
-echo "${out}" | grep -q "Fen: rnbqk1bnr/ppppppppp/9/9/9/9/9/PPPPPPPPP/RNBQK1BNR w - - 0 1"
+contains "Fen: rnbqk1bnr/ppppppppp/9/9/9/9/9/PPPPPPPPP/RNBQK1BNR w - - 0 1"
 fi
 
 # 19dzz) Fart (5x5): two placements per turn, centre excluded, then orthogonal sliding with line-5 win.
 out=$(run_cmds "setoption name UCI_Variant value fart-5x5
 position startpos
 go perft 1")
-echo "${out}" | grep -q "^M@a1: 1$"
-echo "${out}" | grep -vq "^M@c3: 1$"
+contains "^M@a1: 1$"
+not_contains "^M@c3: 1$"
 
 # 19e0) English Draughts: documented title matches the supported checkers ruleset.
 if variant_available "english-draughts"; then
 out=$(run_cmds "setoption name UCI_Variant value english-draughts
 position startpos
 d")
-echo "${out}" | grep -q "Fen: 1m1m1m1m/m1m1m1m1/1m1m1m1m/8/8/M1M1M1M1/1M1M1M1M/M1M1M1M1 w - - 0 1"
+contains "Fen: 1m1m1m1m/m1m1m1m1/1m1m1m1m/8/8/M1M1M1M1/1M1M1M1M/M1M1M1M1 w - - 0 1"
 fi
 
 # 19e1) Checkers: orthodox start moves are diagonal only.
@@ -848,112 +861,112 @@ if variant_available "checkers"; then
 out=$(run_cmds "setoption name UCI_Variant value checkers
 position startpos
 go perft 1")
-echo "${out}" | grep -q "^a3b4: 1$"
-echo "${out}" | grep -q "^g3h4: 1$"
-! echo "${out}" | grep -q "^b2b3: 1$"
-! echo "${out}" | grep -q "^d2d3: 1$"
+contains "^a3b4: 1$"
+contains "^g3h4: 1$"
+not_contains "^b2b3: 1$"
+not_contains "^d2d3: 1$"
 fi
 
 # 19ea) HP-minichess: 5x5 orthodox setup with kings on the a-file.
 out=$(run_cmds "setoption name UCI_Variant value hp-minichess
 position startpos
 d")
-echo "${out}" | grep -q "Fen: kqbnr/ppppp/5/PPPPP/KQBNR w - - 0 1"
+contains "Fen: kqbnr/ppppp/5/PPPPP/KQBNR w - - 0 1"
 
 # 19eaa) Jeson Mor: center reach by a knight is an immediate win.
 if variant_available "jesonmor"; then
 out=$(run_cmds "setoption name UCI_Variant value jesonmor
 position startpos
 d")
-echo "${out}" | grep -q "Fen: nnnnnnnnn/9/9/9/9/9/9/9/NNNNNNNNN w - - 0 1"
+contains "Fen: nnnnnnnnn/9/9/9/9/9/9/9/NNNNNNNNN w - - 0 1"
 out=$(run_cmds "setoption name UCI_Variant value jesonmor
 position fen 9/9/9/9/4N4/9/9/9/9 b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 fi
 
 # 19eb) Dodgem: classic 3x3 rules on an internal 5x4 board with escape lanes.
 out=$(run_cmds "setoption name UCI_Variant value dodgem
 position startpos
 go perft 1")
-echo "${out}" | grep -q "^a2a1: 1$"
-echo "${out}" | grep -q "^a2b2: 1$"
-echo "${out}" | grep -q "^a3b3: 1$"
+contains "^a2a1: 1$"
+contains "^a2b2: 1$"
+contains "^a3b3: 1$"
 out=$(run_cmds "setoption name UCI_Variant value dodgem
 position fen 4k/5/2X2/4K w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^c2d2: 1$"
+contains "^c2d2: 1$"
 out=$(run_cmds "setoption name UCI_Variant value dodgem
 position fen 4k/5/3U1/3UK b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 
 # 19fzzzz) Gale 15x15: only available on VERY_LARGE_BOARDS builds.
 if variant_available "gale-15"; then
   out=$(run_cmds "setoption name UCI_Variant value gale-15
 position startpos
 go perft 1")
-  grep -Fxq "Nodes searched: 113" <<<"$out"
-  echo "${out}" | grep -q "^P@a1: 1$"
+  assert_nodes "$out" "113"
+  contains "^P@a1: 1$"
 fi
 
 # 21) Maak Yek: moving between two enemy pieces captures both of them.
 out=$(run_cmds "setoption name UCI_Variant value maak-yek
 position fen 8/8/8/8/2r1r3/8/8/3R4 w - - 0 1 moves d1d4
 d")
-echo "${out}" | grep -q "Fen: 8/8/8/8/3R4/8/8/8 b - - 1 1"
+contains "Fen: 8/8/8/8/3R4/8/8/8 b - - 1 1"
 
 # 22) Troll: drops flip enclosed enemy stones but paths connect only orthogonally.
 out=$(run_cmds "setoption name UCI_Variant value troll
 position fen 8/8/8/8/8/8/3p4/3P4[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPpppppppppppppppppppppppppppppppp] w - - 0 1 moves P@d3
 d")
-echo "${out}" | grep -q "Fen: 8/8/8/8/8/3P4/3P4/3P4 b - - 0 1"
+contains "Fen: 8/8/8/8/8/3P4/3P4/3P4 b - - 0 1"
 
 # 23) Tic-Tac-Toe misere: completing your own line loses immediately.
 out=$(run_cmds "setoption name UCI_Variant value tictactoe-misere
 position fen PPP/3/3[pppp] b - - 0 1
 go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+assert_nodes "$out" "0"
 
 out=$(run_cmds "setoption name UCI_Variant value progressive
 position startpos moves e2e4 e7e5 e1e1
 go perft 1")
-grep -Fxq "Nodes searched: 29" <<<"$out"
+assert_nodes "$out" "29"
 
 # 17b) Progressive: forced pass plies must not increment halfmove clock.
 out=$(run_cmds "setoption name UCI_Variant value progressive
 position startpos moves e2e4 e7e5 0000
 d")
-echo "${out}" | grep -q "Fen: rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 2"
+contains "Fen: rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 2"
 
 # 18) Hindustani baseline: no pawn double-step.
 if variant_available "hindustani"; then
 out=$(run_cmds "setoption name UCI_Variant value hindustani
 position startpos
 go perft 1")
-! echo "${out}" | grep -q "^e2e4:"
-echo "${out}" | grep -q "^e1d3: 1$"
-echo "${out}" | grep -q "^e1f3: 1$"
+not_contains "^e2e4:"
+contains "^e1d3: 1$"
+contains "^e1f3: 1$"
 
 # 19) Hindustani baseline: if all promotion targets are at cap, promotion is forbidden.
 out=$(run_cmds "setoption name UCI_Variant value hindustani
 position fen 4k3/3P4/8/8/8/8/RNBQKBNR/R6R w - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^d7d8"
+not_contains "^d7d8"
 
 # 20) Hindustani baseline: if queen is below cap, central-file promotion to queen is legal.
 out=$(run_cmds "setoption name UCI_Variant value hindustani
 position fen 4k3/3P4/8/8/8/8/RNB1KBNR/R6R w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^d7d8q: 1$"
-! echo "${out}" | grep -q "^d7d8r:"
+contains "^d7d8q: 1$"
+not_contains "^d7d8r:"
 fi
 
 # 21) Gala: opening drop phase starts from pockets on own half (white has 10 choices).
 out=$(run_cmds "setoption name UCI_Variant value gala
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 10" <<<"$out"
+assert_nodes "$out" "10"
 
 # 22) Gala: custodial capture by orthogonal sandwich.
 out=$(run_cmds "setoption name UCI_Variant value gala
@@ -965,93 +978,93 @@ echo "${out}" | grep -Eq "Fen: 5/5/2D1D/5/5(\\[\\])? b - - 1 1"
 out=$(run_cmds "setoption name UCI_Variant value ichess
 position startpos
 go perft 1")
-! echo "${out}" | grep -q "@a8"
-echo "${out}" | grep -q "^Q@a1: 1$"
+not_contains "@a8"
+contains "^Q@a1: 1$"
 
 # 24) iChess baseline: pawn is shogi-like (one-step forward only, no initial double-step).
 out=$(run_cmds "setoption name UCI_Variant value ichess
 position fen 4k3/8/8/8/8/8/4P3/4K3 w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^e2e3: 1$"
-! echo "${out}" | grep -q "^e2e4:"
+contains "^e2e3: 1$"
+not_contains "^e2e4:"
 
 # 25) iChess baseline: promotion rank is constrained (no unpromoted advance to rank 8).
 out=$(run_cmds "setoption name UCI_Variant value ichess
 position fen k7/4P3/8/8/8/8/8/4K3 w - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^e7e8"
+not_contains "^e7e8"
 
 # 26) Fianchetto chess: bishops and rooks are swapped in initial setup, castling disabled.
 out=$(run_cmds "setoption name UCI_Variant value fianchetto
 position startpos
 d")
-echo "${out}" | grep -q "Fen: bnrqkrnb/pppppppp/8/8/8/8/PPPPPPPP/BNRQKRNB w - - 0 1"
-! echo "${out}" | grep -q " KQkq "
+contains "Fen: bnrqkrnb/pppppppp/8/8/8/8/PPPPPPPP/BNRQKRNB w - - 0 1"
+not_contains " KQkq "
 
 # 27) Asymmetrical chess baseline: custom start position, no castling, no pawn double-step.
 out=$(run_cmds "setoption name UCI_Variant value asymmetrical
 position startpos
 d")
-echo "${out}" | grep -q "Fen: 3prnbk/4ppqn/5ppb/P5pr/RP5p/BPP5/NQPP4/KBNRP3 w - - 0 1"
-! echo "${out}" | grep -q " KQkq "
+contains "Fen: 3prnbk/4ppqn/5ppb/P5pr/RP5p/BPP5/NQPP4/KBNRP3 w - - 0 1"
+not_contains " KQkq "
 out=$(run_cmds "setoption name UCI_Variant value asymmetrical
 position startpos
 go perft 1")
-! echo "${out}" | grep -q "d1d3"
+not_contains "d1d3"
 
 # 28) Brotherhood baseline: same-type captures are forbidden.
 out=$(run_cmds "setoption name UCI_Variant value brotherhood
 position fen 4k3/8/8/3p4/4P3/8/8/4K3 w - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^e4d5:"
-echo "${out}" | grep -q "^e4e5: 1$"
+not_contains "^e4d5:"
+contains "^e4e5: 1$"
 
 # 29) Marseillais baseline: each side gets two moves per turn (with pass separator).
 out=$(run_cmds "setoption name UCI_Variant value marseillais
 position startpos moves e2e4
 go perft 1")
-echo "${out}" | grep -q "^0000: 1$"
-! echo "${out}" | grep -q "^e7e5:"
+contains "^0000: 1$"
+not_contains "^e7e5:"
 out=$(run_cmds "setoption name UCI_Variant value marseillais
 position startpos moves e2e4 0000
 go perft 1")
-echo "${out}" | grep -q "^e4e5: 1$"
-! echo "${out}" | grep -q "^e7e5:"
+contains "^e4e5: 1$"
+not_contains "^e7e5:"
 
 # 30) Antimatter baseline: same-type captures annihilate the capturer.
 out=$(run_cmds "setoption name UCI_Variant value antimatter
 position fen 4k3/8/8/3p4/4P3/8/8/4K3 w - - 0 1 moves e4d5
 d")
-echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/8/8/4K3 b - - 0 1"
+contains "Fen: 4k3/8/8/8/8/8/8/4K3 b - - 0 1"
 out=$(run_cmds "setoption name UCI_Variant value antimatter
 position fen 4k3/8/8/3n4/4P3/8/8/4K3 w - - 0 1 moves e4d5
 d")
-echo "${out}" | grep -q "Fen: 4k3/8/8/3P4/8/8/8/4K3 b - - 0 1"
+contains "Fen: 4k3/8/8/3P4/8/8/8/4K3 b - - 0 1"
 out=$(run_cmds "setoption name UCI_Variant value antimatter
 position startpos moves g2g3
 go movetime 50")
-echo "${out}" | grep -q "^bestmove "
+contains "^bestmove "
 out=$(run_cmds "setoption name UCI_Variant value antimatter
 position fen 4k3/8/8/3p4/4P3/8/8/3K4 b - - 0 1
 go depth 1")
-echo "${out}" | grep -q "^bestmove "
+contains "^bestmove "
 
 # 30b) Benedict (capture morph): capturer adopts captured piece type.
 out=$(run_cmds "setoption name UCI_Variant value benedictmorph
 position fen 4k3/8/8/3n4/4B3/8/8/4K3 w - - 0 1 moves e4d5
 d")
-echo "${out}" | grep -q "Fen: 4k3/8/8/3N4/8/8/8/4K3 b - - 0 1"
+contains "Fen: 4k3/8/8/3N4/8/8/8/4K3 b - - 0 1"
 
 # 31) Pawns baseline: pawn-only start and promotion race objective.
 if variant_available "pawns"; then
 out=$(run_cmds "setoption name UCI_Variant value pawns
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 8" <<<"$out"
+assert_nodes "$out" "8"
 out=$(run_cmds "setoption name UCI_Variant value pawns
 position fen 8/P7/8/8/8/8/8/8 w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^a7a8p: 1$"
+contains "^a7a8p: 1$"
 fi
 
 # 32) Rugby baseline: king-like pawn movement without orthogonal captures.
@@ -1059,12 +1072,12 @@ if variant_available "rugby"; then
 out=$(run_cmds "setoption name UCI_Variant value rugby
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 22" <<<"$out"
+assert_nodes "$out" "22"
 out=$(run_cmds "setoption name UCI_Variant value rugby
 position fen 8/8/8/8/8/4P3/4p3/8 w - - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^e3e2:"
-echo "${out}" | grep -q "^e3d2: 1$"
+not_contains "^e3e2:"
+contains "^e3d2: 1$"
 fi
 
 # 33) Capped pawns: extra two-step window from rank 6/3 into promotion.
@@ -1072,11 +1085,11 @@ if variant_available "capped-pawns"; then
 out=$(run_cmds "setoption name UCI_Variant value capped-pawns
 position fen k7/8/4P3/8/8/8/8/4K3 w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^e6e8q: 1$"
+contains "^e6e8q: 1$"
 out=$(run_cmds "setoption name UCI_Variant value capped-pawns
 position fen k7/8/8/8/8/4p3/8/7K b - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^e3e1q: 1$"
+contains "^e3e1q: 1$"
 fi
 
 # 34) No-castle-10: castling blocked before ply 20, allowed afterwards.
@@ -1084,13 +1097,13 @@ if variant_available "no-castle-10"; then
 out=$(run_cmds "setoption name UCI_Variant value no-castle-10
 position fen r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^e1g1:"
-! echo "${out}" | grep -q "^e1c1:"
+not_contains "^e1g1:"
+not_contains "^e1c1:"
 out=$(run_cmds "setoption name UCI_Variant value no-castle-10
 position fen r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 11
 go perft 1")
-echo "${out}" | grep -q "^e1g1: 1$"
-echo "${out}" | grep -q "^e1c1: 1$"
+contains "^e1g1: 1$"
+contains "^e1c1: 1$"
 fi
 
 # 35) Dueling archbishops baseline: bishops gain knight movement.
@@ -1098,14 +1111,14 @@ if variant_available "dueling-archbishops"; then
 out=$(run_cmds "setoption name UCI_Variant value dueling-archbishops
 position startpos
 go perft 1")
-echo "${out}" | grep -q "^c1b3: 1$"
-echo "${out}" | grep -q "^f1g3: 1$"
+contains "^c1b3: 1$"
+contains "^f1g3: 1$"
 
 # 36) Dueling archbishops baseline: hand pieces can be dropped.
 out=$(run_cmds "setoption name UCI_Variant value dueling-archbishops
 position fen 4k3/8/8/8/8/8/8/4K3[P] w - - 0 1
 go perft 1")
-echo "${out}" | grep -q "^P@a2: 1$"
+contains "^P@a2: 1$"
 fi
 
 # 37) Royal race baseline: variant loads and produces a best move with custom movers.
@@ -1113,60 +1126,60 @@ if variant_available "royal-race"; then
 out=$(run_cmds "setoption name UCI_Variant value royal-race
 position startpos
 go movetime 10")
-echo "${out}" | grep -q "^bestmove "
+contains "^bestmove "
 
 # 38) Royal race baseline: king on goal rank is an immediate game end.
 out=$(run_cmds "setoption name UCI_Variant value royal-race
 position fen 3K3/7/7/7/7/7/7/7/3k3 b - - 0 1
 go movetime 10")
-echo "${out}" | grep -q "bestmove (none)"
+contains "bestmove \(none\)"
 fi
 
 # 39) Spell chess: frozen castling rook blocks castling.
 out=$(run_cmds "setoption name UCI_Variant value spell-chess
 position fen 4k3/8/8/8/8/8/8/4K2R[f] b K - 0 1 moves f@h1 e8e7
 go perft 1")
-! echo "${out}" | grep -q "^e1g1:"
+not_contains "^e1g1:"
 
 # 40) Spell chess: castling through attack is illegal, but legal if attacker is frozen first.
 out=$(run_cmds "setoption name UCI_Variant value spell-chess
 position fen 4kr2/8/8/8/8/8/8/4K2R[F] w K - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^e1g1:"
-echo "${out}" | grep -q "^f@f8,e1g1: 1$"
+not_contains "^e1g1:"
+contains "^f@f8,e1g1: 1$"
 
 # 41) Spell chess: castling out of check is illegal, but legal if attacker is frozen first.
 out=$(run_cmds "setoption name UCI_Variant value spell-chess
 position fen 4r1k1/8/8/8/8/8/8/4K2R[F] w K - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^e1g1:"
-echo "${out}" | grep -q "^f@e8,e1g1: 1$"
+not_contains "^e1g1:"
+contains "^f@e8,e1g1: 1$"
 
 # 42) Spell chess: jump potion does not let castling pass through occupied blockers.
 out=$(run_cmds "setoption name UCI_Variant value spell-chess
 position fen 6k1/8/8/8/8/8/8/R2nK3[J] w Q - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^e1c1:"
-! echo "${out}" | grep -q "^j@d1,e1c1:"
+not_contains "^e1c1:"
+not_contains "^j@d1,e1c1:"
 
 out=$(run_cmds "setoption name UCI_Variant value spell-chess
 position fen 6k1/8/8/8/8/8/8/Rn2K3[J] w Q - 0 1
 go perft 1")
-! echo "${out}" | grep -q "^e1c1:"
-! echo "${out}" | grep -q "^j@b1,e1c1:"
+not_contains "^e1c1:"
+not_contains "^j@b1,e1c1:"
 
 # 43) Spell chess: frozen pawn cannot capture en passant.
 out=$(run_cmds "setoption name UCI_Variant value spell-chess
 position fen 4k3/3p4/8/4P3/8/8/8/4K3[f] b - - 0 1 moves f@e5 d7d5
 go perft 1")
-! echo "${out}" | grep -q "^e5d6:"
+not_contains "^e5d6:"
 
 # 44) Monad baseline (large-board): custom 10x10 setup is loaded.
 if variant_available "monad"; then
   out=$(run_cmds "setoption name UCI_Variant value monad
 position startpos
 go perft 1")
-  grep -Fxq "Nodes searched: 37" <<<"$out"
+  assert_nodes "$out" "37"
 fi
 
 # 43) Camel-rhino baseline (large-board): setup loads and generates legal moves.
@@ -1174,7 +1187,7 @@ if variant_available "camel-rhino"; then
   out=$(run_cmds "setoption name UCI_Variant value camel-rhino
 position startpos
 go perft 1")
-  grep -Fxq "Nodes searched: 68" <<<"$out"
+  assert_nodes "$out" "68"
 fi
 
 # 44) Rifle chess baseline: start position behaves like orthodox chess before captures appear.
@@ -1182,7 +1195,7 @@ if variant_available "rifle-chess"; then
 out=$(run_cmds "setoption name UCI_Variant value rifle-chess
 position startpos
 go perft 1")
-grep -Fxq "Nodes searched: 20" <<<"$out"
+assert_nodes "$out" "20"
 fi
 
 echo "new variants smoke testing OK"

--- a/tests/parser-regressions.sh
+++ b/tests/parser-regressions.sh
@@ -12,6 +12,8 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 ROOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
 ENGINE=${1:-${SCRIPT_DIR}/../src/stockfish}
 
+source "${SCRIPT_DIR}/lib/uci.sh"
+
 cd "${ROOT_DIR}"
 
 tmp_ini=$(mktemp)
@@ -182,7 +184,8 @@ weakCrosscutDropIllegal = true
 startFen = ****1/***2/**3/*4/5[SSSSSSSSSSSSSSSsssssssssssssss] b - - 0 1
 INI
 
-printf '%s\n' '[trailing-rank-space:chess]' 'maxRank = 8 ' >> "${tmp_ini}"
+printf '%s
+' '[trailing-rank-space:chess]' 'maxRank = 8 ' >> "${tmp_ini}"
 
 echo "parser regression tests started"
 
@@ -240,101 +243,34 @@ startFen = 8/3p4/8/8/3Q2n1/8/8/8 w - - 0 1
 INI
 
 check_output=$("${ENGINE}" check "${bad_betza_ini}" 2>&1 || true)
-if ! echo "${check_output}" | grep -Fq "customPiece1 - Missing Betza move notation"; then
-  echo "${check_output}"
-  exit 1
-fi
+assert_contains "${check_output}" "customPiece1 - Missing Betza move notation"
 
 check_output=$("${ENGINE}" check "${bad_hopper_brace_ini}" 2>&1 || true)
-if ! echo "${check_output}" | grep -Fq "customPiece1 - Invalid Betza hopper parameters in 'R{hurdles: 1,1': missing closing '}'."; then
-  echo "${check_output}"
-  exit 1
-fi
+assert_contains "${check_output}" "customPiece1 - Invalid Betza hopper parameters in 'R{hurdles: 1,1': missing closing '}'."
 
 check_output=$("${ENGINE}" check "${bad_rider_range_ini}" 2>&1 || true)
-if ! echo "${check_output}" | grep -Fq "customPiece1 - Invalid Betza rider range in 'R[3-': missing closing ']'."; then
-  echo "${check_output}"
-  exit 1
-fi
+assert_contains "${check_output}" "customPiece1 - Invalid Betza rider range in 'R\[3-': missing closing '\]'."
 
 check_output=$("${ENGINE}" check "${bad_rank_wildcard_ini}" 2>&1 || true)
-if ! echo "${check_output}" | grep -q "Illegal rank character: \*"; then
-  echo "${check_output}"
-  exit 1
-fi
+assert_contains "${check_output}" "Illegal rank character: \*"
 
 check_output=$("${ENGINE}" check "${twochar_hint_ini}" 2>&1 || true)
-if ! echo "${check_output}" | grep -q "falcon looks like a custom piece definition. Use customPieceN = P':W for new custom pieces."; then
-  echo "${check_output}"
-  exit 1
-fi
+assert_contains "${check_output}" "falcon looks like a custom piece definition. Use customPieceN = P':W for new custom pieces."
 
-set +e
-bad_hopper_type_output=$(cat <<CMDS | "${ENGINE}" 2>&1
-uci
-setoption name VariantPath value ${bad_hopper_type_ini}
-setoption name UCI_Variant value bad-hopper-type
-quit
-CMDS
-)
-bad_hopper_type_rc=$?
-set -e
+bad_hopper_type_output=$(run_uci "$ENGINE" "$bad_hopper_type_ini" "bad-hopper-type" </dev/null 2>&1 || true)
+assert_contains "${bad_hopper_type_output}" "unknown variant 'bad-hopper-type'; keeping 'chess'"
 
-if [ "${bad_hopper_type_rc}" -ne 0 ]; then
-  echo "${bad_hopper_type_output}"
-  exit 1
-fi
+bad_hopper_numeric_output=$(run_uci "$ENGINE" "$bad_hopper_numeric_ini" "bad-hopper-numeric" </dev/null 2>&1 || true)
+assert_contains "${bad_hopper_numeric_output}" "Invalid numeric value in Betza hopper parameters: 'abc,1'"
+assert_contains "${bad_hopper_numeric_output}" "unknown variant 'bad-hopper-numeric'; keeping 'chess'"
 
-if ! echo "${bad_hopper_type_output}" | grep -q "unknown variant 'bad-hopper-type'; keeping 'chess'"; then
-  echo "${bad_hopper_type_output}"
-  exit 1
-fi
-
-set +e
-bad_hopper_numeric_output=$(cat <<CMDS | "${ENGINE}" 2>&1
-uci
-setoption name VariantPath value ${bad_hopper_numeric_ini}
-setoption name UCI_Variant value bad-hopper-numeric
-quit
-CMDS
-)
-bad_hopper_numeric_rc=$?
-set -e
-
-if [ "${bad_hopper_numeric_rc}" -ne 0 ]; then
-  echo "${bad_hopper_numeric_output}"
-  exit 1
-fi
-
-if ! echo "${bad_hopper_numeric_output}" | grep -Fq "Invalid numeric value in Betza hopper parameters: 'abc,1'"; then
-  echo "${bad_hopper_numeric_output}"
-  exit 1
-fi
-
-if ! echo "${bad_hopper_numeric_output}" | grep -Fq "unknown variant 'bad-hopper-numeric'; keeping 'chess'"; then
-  echo "${bad_hopper_numeric_output}"
-  exit 1
-fi
-
-capture_allowed_only_output=$(cat <<CMDS | "${ENGINE}" 2>&1
-uci
-setoption name VariantPath value ${capture_allowed_only_ini}
-setoption name UCI_Variant value capture-allowed-only
+capture_allowed_only_output=$(run_uci "$ENGINE" "$capture_allowed_only_ini" "capture-allowed-only" <<EOF
 position fen 8/3p4/8/8/3Q2n1/8/8/8 w - - 0 1
 go perft 1
-quit
-CMDS
+EOF
 )
-
-if ! echo "${capture_allowed_only_output}" | grep -q "d4d7:"; then
-  echo "${capture_allowed_only_output}"
-  exit 1
-fi
-
-if echo "${capture_allowed_only_output}" | grep -q "d4g4:"; then
-  echo "${capture_allowed_only_output}"
-  exit 1
-fi
+assert_contains "${capture_allowed_only_output}" "d4d7:"
+assert_not_contains "${capture_allowed_only_output}" "d4g4:"
 
 two_boards_output=$(python3 - <<'PY' 2>&1
 import sys
@@ -344,11 +280,7 @@ pyffish.load_variant_config("[x:chess]\ntwoBoards = true" + "   \n")
 print("two_boards_trailing_space_bool", pyffish.two_boards("x"))
 PY
 )
-
-if ! printf '%s\n' "${two_boards_output}" | grep -qF "two_boards_trailing_space_bool True"; then
-  echo "${two_boards_output}"
-  exit 1
-fi
+assert_contains "${two_boards_output}" "two_boards_trailing_space_bool True"
 
 capture_type_output=$(python3 - <<'PY' 2>&1
 import pyffish
@@ -357,11 +289,7 @@ pyffish.load_variant_config("[x:chess]\ncaptureType = hand" + "   \n")
 print("capture_type_trailing_space_enum", pyffish.captures_to_hand("x"))
 PY
 )
-
-if ! printf '%s\n' "${capture_type_output}" | grep -qF "capture_type_trailing_space_enum True"; then
-  echo "${capture_type_output}"
-  exit 1
-fi
+assert_contains "${capture_type_output}" "capture_type_trailing_space_enum True"
 
 nonking_ini=$(mktemp)
 trap 'rm -f "${tmp_ini}" "${nonking_ini}"' EXIT
@@ -370,79 +298,38 @@ cat > "${nonking_ini}" <<'INI'
 rook = r:R3
 INI
 
-tuple_output=$(cat <<CMDS | "${ENGINE}" 2>&1
-uci
-setoption name VariantPath value ${tmp_ini}
-setoption name UCI_Variant value tuple-nonsquare
+tuple_output=$(run_uci "$ENGINE" "$tmp_ini" "tuple-nonsquare" <<EOF
 position startpos
 go perft 1
-quit
-CMDS
+EOF
 )
+assert_not_contains "${tuple_output}" "No piece char found for custom piece"
 
-if echo "${tuple_output}" | grep -q "No piece char found for custom piece"; then
-  echo "${tuple_output}"
-  exit 1
-fi
-
-promotion_file_output=$(cat <<CMDS | "${ENGINE}" 2>&1
-uci
-setoption name VariantPath value ${tmp_ini}
-setoption name UCI_Variant value promotion-by-file-inherit
+promotion_file_output=$(run_uci "$ENGINE" "$tmp_ini" "promotion-by-file-inherit" <<EOF
 position startpos
 go perft 1
-quit
-CMDS
+EOF
 )
+assert_contains "${promotion_file_output}" "b7b8r:"
+assert_not_contains "${promotion_file_output}" "b7b8q:"
+assert_not_contains "${promotion_file_output}" "b7b8n:"
 
-if ! echo "${promotion_file_output}" | grep -q "b7b8r:"; then
-  echo "${promotion_file_output}"
-  exit 1
-fi
-
-if echo "${promotion_file_output}" | grep -q "b7b8q:"; then
-  echo "${promotion_file_output}"
-  exit 1
-fi
-
-if echo "${promotion_file_output}" | grep -q "b7b8n:"; then
-  echo "${promotion_file_output}"
-  exit 1
-fi
-
-promotion_spaces_output=$(cat <<CMDS | "${ENGINE}" 2>&1
-uci
-setoption name VariantPath value ${tmp_ini}
-setoption name UCI_Variant value promotion-by-file-spaces
+promotion_spaces_output=$(run_uci "$ENGINE" "$tmp_ini" "promotion-by-file-spaces" <<EOF
 position startpos
 go perft 1
-quit
-CMDS
+EOF
 )
+assert_contains "${promotion_spaces_output}" "b7b8r:"
 
-if ! echo "${promotion_spaces_output}" | grep -q "b7b8r:"; then
-  echo "${promotion_spaces_output}"
-  exit 1
-fi
-
-terminal_output=$(cat <<'CMDS' | "${ENGINE}" 2>&1
-uci
+terminal_output=$(run_uci "$ENGINE" "" "" <<EOF
 position fen 7k/5Q2/7K/8/8/8/8/8 b - - 0 1
 go depth 1
-quit
-CMDS
+EOF
 )
-
-if ! echo "${terminal_output}" | grep -q "bestmove (none)"; then
-  echo "${terminal_output}"
-  exit 1
-fi
+assert_contains "${terminal_output}" "bestmove \(none\)"
 
 bench_output=$("${ENGINE}" bench 16 1 1 default nonsense 2>&1 || true)
-if ! echo "${bench_output}" | grep -q "Nodes searched  : "; then
-  echo "${bench_output}"
-  exit 1
-fi
+assert_contains "${bench_output}" "Nodes searched  : "
 
 castling_diag_output=$(python3 - <<'PY' 2>&1
 import pyffish
@@ -482,34 +369,11 @@ for fen, variant in [
 PY
 )
 
-if ! echo "${castling_diag_output}" | grep -q "validate_fen castdiag-empty -5"; then
-  echo "${castling_diag_output}"
-  exit 1
-fi
-
-if ! echo "${castling_diag_output}" | grep -q "validate_fen castdiag-wrongpiece -5"; then
-  echo "${castling_diag_output}"
-  exit 1
-fi
-
-if ! echo "${castling_diag_output}" | grep -q "validate_fen castdiag-single-rook -5"; then
-  echo "${castling_diag_output}"
-  exit 1
-fi
-
-if ! echo "${castling_diag_output}" | grep -q "No castling rook on file J for flag J."; then
-  echo "${castling_diag_output}"
-  exit 1
-fi
-
-if ! echo "${castling_diag_output}" | grep -q "Flag J refers to file J, but that square does not contain a WHITE castling rook."; then
-  echo "${castling_diag_output}"
-  exit 1
-fi
-
-if ! echo "${castling_diag_output}" | grep -q "No castling rook for flag K on castling rank 1."; then
-  echo "${castling_diag_output}"
-  exit 1
-fi
+assert_contains "${castling_diag_output}" "validate_fen castdiag-empty -5"
+assert_contains "${castling_diag_output}" "validate_fen castdiag-wrongpiece -5"
+assert_contains "${castling_diag_output}" "validate_fen castdiag-single-rook -5"
+assert_contains "${castling_diag_output}" "No castling rook on file J for flag J."
+assert_contains "${castling_diag_output}" "Flag J refers to file J, but that square does not contain a WHITE castling rook."
+assert_contains "${castling_diag_output}" "No castling rook for flag K on castling rank 1."
 
 echo "parser regression tests passed"

--- a/tests/universal-hopper.sh
+++ b/tests/universal-hopper.sh
@@ -336,7 +336,7 @@ go perft 2
 d
 EOF
 )
-nodes=($(echo "$output" | grep "Nodes searched:" | awk '{print $3}'))
+nodes=($(grep "Nodes searched:" <<<"$output" | awk '{print $3}'))
 if [[ "${#nodes[@]}" -lt 2 || "${nodes[0]}" != "${nodes[1]}" ]]; then
     echo "  [FAIL] locust_all perft(2) instability suggests do/undo corruption"
     echo "Output was:"


### PR DESCRIPTION
This PR performs a coherent test-harness cleanup pass across the highest-duplication shell regressions in the codebase: tests/new-variants-smoke.sh, tests/movegen-regressions.sh, tests/parser-regressions.sh, and tests/universal-hopper.sh.