### PR TITLE
test-harness: migrate regression tests to shared UCI helper and normalize path resolution

### DIFF
--- a/tests/kings-or-lemmings.sh
+++ b/tests/kings-or-lemmings.sh
@@ -2,11 +2,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
-ENGINE="${1:-${ROOT_DIR}/src/stockfish}"
-VARIANTS="${2:-${ROOT_DIR}/src/variants.ini}"
-
 source "${SCRIPT_DIR}/lib/uci.sh"
+
+ENGINE=$(default_engine "${1:-}")
+VARIANTS=$(default_variants "${2:-}")
 
 echo "kings or lemmings regression started"
 
@@ -45,6 +44,6 @@ position fen 7k/8/8/8/8/8/rq6/K6K w - - 0 1
 go depth 1
 UCI
 )
-assert_contains "$out" "^bestmove \\(none\\)$"
+assert_contains_literal "$out" "bestmove (none)"
 
 echo "kings or lemmings regression passed"

--- a/tests/lib/uci.sh
+++ b/tests/lib/uci.sh
@@ -1,5 +1,55 @@
 #!/bin/bash
 
+# Detect project root directory relative to this script
+UCI_LIB_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(cd "${UCI_LIB_DIR}/../.." && pwd)
+
+default_engine() {
+  local custom_engine="${1:-}"
+  if [[ -n "$custom_engine" ]]; then
+    echo "$custom_engine"
+  elif [[ -x "${ROOT_DIR}/src/stockfish" ]]; then
+    echo "${ROOT_DIR}/src/stockfish"
+  else
+    echo "${ROOT_DIR}/stockfish"
+  fi
+}
+
+default_variants() {
+  local custom_variants="${1:-}"
+  if [[ -n "$custom_variants" ]]; then
+    echo "$custom_variants"
+  else
+    echo "${ROOT_DIR}/src/variants.ini"
+  fi
+}
+
+assert_contains_literal() {
+  local haystack="$1"
+  local needle="$2"
+  local context="${3:-contains}"
+
+  if ! grep -Fq "$needle" <<<"$haystack"; then
+    echo "expected output to ${context}: $needle" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "$haystack" >&2
+    return 1
+  fi
+}
+
+assert_not_contains_literal() {
+  local haystack="$1"
+  local needle="$2"
+  local context="${3:-not contain}"
+
+  if grep -Fq "$needle" <<<"$haystack"; then
+    echo "expected output to ${context}: $needle" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "$haystack" >&2
+    return 1
+  fi
+}
+
 uci_timeout() {
   timeout "${UCI_TIMEOUT:-60s}" "$@"
 }

--- a/tests/movegen-regressions.sh
+++ b/tests/movegen-regressions.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ENGINE="${1:-$ROOT_DIR/src/stockfish}"
-source "$ROOT_DIR/tests/lib/uci.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/uci.sh"
+
+ENGINE=$(default_engine "${1:-}")
+VARIANTS=$(default_variants "${2:-}")
 
 TMP_INI="$(mktemp)"
 cleanup() {
@@ -44,7 +46,7 @@ variant_available() {
 echo "movegen regressions started"
 
 # Quiet pawn promotions must be generated in quiet move generation.
-out=$(run_cmds "$ROOT_DIR/src/variants.ini" chess \
+out=$(run_cmds "$VARIANTS" chess \
   "position fen 7k/4P3/8/8/8/8/8/4K3 w - - 0 1
 go perft 1")
 assert_contains "$out" "e7e8q: 1"
@@ -57,13 +59,13 @@ assert_not_contains "$out" "^a2a3:"
 assert_not_contains "$out" "^a2a4:"
 
 # Direct king capture must end the game immediately in capture-the-royal flows.
-out=$(run_cmds "$ROOT_DIR/src/variants.ini" british-chess \
+out=$(run_cmds "$VARIANTS" british-chess \
   "position fen 10/10/10/10/10/10/10/10/4q5/3Q6 w - - 0 1 moves d1e2
 go perft 1")
 assert_nodes "$out" "0"
 
-if variant_available "$ROOT_DIR/src/variants.ini" minihexchess; then
-  out=$(run_cmds "$ROOT_DIR/src/variants.ini" minihexchess \
+if variant_available "$VARIANTS" minihexchess; then
+  out=$(run_cmds "$VARIANTS" minihexchess \
     "position fen ***4/**5/*k5/7/6*/5**/KR2*** w - - 0 1 moves b1b5
 go perft 1")
   assert_nodes "$out" "0"
@@ -76,24 +78,24 @@ go perft 1")
 assert_nodes "$out" "0"
 
 # Tablut-family surround capture of the king must also end immediately.
-out=$(run_cmds "$ROOT_DIR/src/variants.ini" brandub \
+out=$(run_cmds "$VARIANTS" brandub \
   "position fen 4r2/7/3r3/2rK3/3r3/7/7 b - - 0 1 moves e7e4
 go perft 1")
 assert_nodes "$out" "0"
 
 # Anti extinction variants using "*" must not end when a single piece class is gone.
-out=$(run_cmds "$ROOT_DIR/src/variants.ini" antiminishogi \
+out=$(run_cmds "$VARIANTS" antiminishogi \
   "position startpos
 go perft 1")
 assert_nodes "$out" "1"
 assert_contains "$out" "^e1e4: 1$"
 
-out=$(run_cmds "$ROOT_DIR/src/variants.ini" anti-losalamos \
+out=$(run_cmds "$VARIANTS" anti-losalamos \
   "position fen rn1knr/pppppp/6/6/PPPPPP/RNQKNR w - - 0 1
 go perft 1")
 assert_nodes "$out" "10"
 
-out=$(run_cmds "$ROOT_DIR/src/variants.ini" chaturanga-al-adli \
+out=$(run_cmds "$VARIANTS" chaturanga-al-adli \
   "position fen brn1knrb/pppppppp/8/8/8/8/PPPPPPPP/BRNFKNRB w - - 0 1
 go perft 1")
 assert_nodes "$out" "14"
@@ -105,13 +107,13 @@ go perft 1")
 assert_contains "$out" "Nodes searched:"
 
 # Duck wall relocation uses gating encoding without a gated piece.
-out=$(run_cmds "$ROOT_DIR/src/variants.ini" atomicduck \
+out=$(run_cmds "$VARIANTS" atomicduck \
   "position startpos moves a2a3,a3a2
 go depth 2")
 assert_contains "$out" "^bestmove "
 
 # Racing Kings must not grant generic pawn-style initial pushes to non-pawns.
-out=$(run_cmds "$ROOT_DIR/src/variants.ini" racingkings \
+out=$(run_cmds "$VARIANTS" racingkings \
   "position startpos
 go perft 1")
 assert_nodes "$out" "21"
@@ -131,7 +133,7 @@ assert_contains "$out" "^e2e3: 1$"
 assert_not_contains "$out" "^e2e4:"
 
 # Kings Valley pieces use the maximum-distance rule, not ordinary queen slides.
-out=$(run_cmds "$ROOT_DIR/src/variants.ini" kings-valley \
+out=$(run_cmds "$VARIANTS" kings-valley \
   "position startpos
 go perft 1")
 assert_nodes "$out" "13"
@@ -146,7 +148,7 @@ assert_not_contains "$out" "^c1c2:"
 assert_not_contains "$out" "^d1d2:"
 
 # Oshi search should not prefer handing the opponent a point by self-ejecting.
-out=$(run_cmds "$ROOT_DIR/src/variants.ini" oshi \
+out=$(run_cmds "$VARIANTS" oshi \
   "position fen ca2a4/b4ab1c/4a4/9/5A3/2AC5/9/2BAA1B2/C8 w - - 10 6 {0 0}
 go depth 8")
 assert_not_contains "$out" "^bestmove d4a4"

--- a/tests/must-capture-by-color.sh
+++ b/tests/must-capture-by-color.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/uci.sh"
+
+ENGINE=$(default_engine "${1:-}")
 
 tmp_ini="$(mktemp)"
 trap 'rm -f "$tmp_ini"' EXIT
@@ -15,7 +16,7 @@ mustCaptureBlack = false
 startFen = 4k3/8/8/3p4/4P3/8/8/4K3 w - - 0 1
 INI
 
-out_white=$(run_uci "${1:-"${ROOT_DIR}/src/stockfish"}" "$tmp_ini" asymmustcapture <<'UCI'
+out_white=$(run_uci "$ENGINE" "$tmp_ini" asymmustcapture <<'UCI'
 position startpos
 go perft 1
 UCI
@@ -26,7 +27,7 @@ assert_not_contains "$out_white" "e4e5:"
 assert_nodes "$out_white" 1
 
 black_fen='4k3/8/8/4p3/3P4/8/8/4K3 b - - 0 1'
-out_black=$(run_uci "${1:-"${ROOT_DIR}/src/stockfish"}" "$tmp_ini" asymmustcapture <<UCI
+out_black=$(run_uci "$ENGINE" "$tmp_ini" asymmustcapture <<UCI
 position fen ${black_fen}
 go perft 1
 UCI

--- a/tests/new-variants-smoke.sh
+++ b/tests/new-variants-smoke.sh
@@ -9,21 +9,10 @@ error() {
 trap 'error ${LINENO}' ERR
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-ROOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
 source "${SCRIPT_DIR}/lib/uci.sh"
 
-ENGINE=${1:-}
-if [[ -z "${ENGINE}" ]]; then
-  if [[ -x "${ROOT_DIR}/src/stockfish" ]]; then
-    ENGINE="${ROOT_DIR}/src/stockfish"
-  else
-    ENGINE="${ROOT_DIR}/stockfish"
-  fi
-fi
-VARIANT_PATH=${2:-"${ROOT_DIR}/src/variants.ini"}
-if [[ ! -f "${VARIANT_PATH}" && -f "${ROOT_DIR}/src/variants.ini" ]]; then
-  VARIANT_PATH="${ROOT_DIR}/src/variants.ini"
-fi
+ENGINE=$(default_engine "${1:-}")
+VARIANT_PATH=$(default_variants "${2:-}")
 
 run_cmds() {
   local cmds="$1"
@@ -1133,7 +1122,7 @@ contains "^bestmove "
 out=$(run_cmds "setoption name UCI_Variant value royal-race
 position fen 3K3/7/7/7/7/7/7/7/3k3 b - - 0 1
 go movetime 10")
-contains "bestmove \(none\)"
+assert_contains_literal "$out" "bestmove (none)"
 fi
 
 # 39) Spell chess: frozen castling rook blocks castling.

--- a/tests/parser-regressions.sh
+++ b/tests/parser-regressions.sh
@@ -8,11 +8,10 @@ error() {
 }
 trap 'error ${LINENO}' ERR
 
-SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-ROOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
-ENGINE=${1:-${SCRIPT_DIR}/../src/stockfish}
-
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "${SCRIPT_DIR}/lib/uci.sh"
+
+ENGINE=$(default_engine "${1:-}")
 
 cd "${ROOT_DIR}"
 
@@ -326,7 +325,7 @@ position fen 7k/5Q2/7K/8/8/8/8/8 b - - 0 1
 go depth 1
 EOF
 )
-assert_contains "${terminal_output}" "bestmove \(none\)"
+assert_contains_literal "${terminal_output}" "bestmove (none)"
 
 bench_output=$("${ENGINE}" bench 16 1 1 default nonsense 2>&1 || true)
 assert_contains "${bench_output}" "Nodes searched  : "

--- a/tests/universal-hopper.sh
+++ b/tests/universal-hopper.sh
@@ -5,20 +5,10 @@ set -euo pipefail
 # Test Universal Hopper features
 
 # 1. Setup temporary variant file
-SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-ROOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
-ENGINE=${1:-"${ROOT_DIR}/src/stockfish"}
-if [[ ! -x "${ENGINE}" ]]; then
-    if [[ -x "${ROOT_DIR}/stockfish" ]]; then
-        ENGINE="${ROOT_DIR}/stockfish"
-    fi
-fi
-if [[ ! -x "${ENGINE}" ]]; then
-    echo "engine executable not found: pass path as first argument" >&2
-    exit 2
-fi
-
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "${SCRIPT_DIR}/lib/uci.sh"
+
+ENGINE=$(default_engine "${1:-}")
 
 INI_FILE=$(mktemp -t universal_hopper_test.XXXXXX.ini)
 trap 'rm -f "${INI_FILE}"' EXIT


### PR DESCRIPTION
This PR migrates several regression test scripts to leverage the shared UCI helper, simplifies path resolution, and normalizes bestmove (none) assertions. Fast regressions pass successfully.