### PR TITLE
Cleanup target regression test harness & fix lame_ferz_blocked bug

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -3515,7 +3515,7 @@ inline bool Position::is_lame_blocked(Square from, Square to, const PieceInfo::L
         Square orthRank = SQ_NONE;
         if (!advance(from, stepF, 0, orthFile) || !advance(from, 0, stepR, orthRank))
             return true;
-        return bool(occupied & square_bb(orthFile) & square_bb(orthRank));
+        return bool((occupied & square_bb(orthFile)) && (occupied & square_bb(orthRank)));
     };
 
     auto path_blocked = [&](const PathBuffer& path, bool midpointOnly) -> bool {

--- a/tests/alfil-dabbaba-riders.sh
+++ b/tests/alfil-dabbaba-riders.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-ENGINE=${1:-"${ROOT_DIR}/src/stockfish"}
-if [[ "${ENGINE}" != /* ]]; then
-  ENGINE="${PWD}/${ENGINE}"
-fi
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/lib/uci.sh"
 
-cd "${ROOT_DIR}/src"
+ENGINE=$(default_engine "${1:-}")
 
 tmp_ini=$(mktemp)
 tmp_key_ini=""
@@ -215,10 +211,10 @@ INI
 
 piece_moves() {
   local variant=$1
-  printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" "$variant" \
-    | "${ENGINE}" \
-    | awk -F: '/^d4/{print $1}' \
-    | sort
+  run_uci "$ENGINE" "$tmp_ini" "$variant" <<'UCI' | awk -F: '/^d4/{print $1}' | sort
+position startpos
+go perft 1
+UCI
 }
 
 expected_alfil=$(mktemp)
@@ -256,183 +252,284 @@ cmp "$actual_alfil_tuple" "$expected_alfil"
 cmp "$actual_dabbaba" "$expected_dabbaba"
 cmp "$actual_dabbaba_tuple" "$expected_dabbaba"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value tuple-range-pin\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^d3c3: 1$"
-echo "$out" | grep -q "^d3e3: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" tuple-range-pin <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_contains "$out" "^d3c3: 1$"
+assert_contains "$out" "^d3e3: 1$"
 
 # Lame dabbaba/alfil and their rider forms must be blocked by the midpoint square.
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-rider-blockers\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^d7d5:"
-! echo "$out" | grep -q "^d7f7:"
-! echo "$out" | grep -q "^e7c7:"
-! echo "$out" | grep -q "^c6e8:"
-! echo "$out" | grep -q "^d6f8:"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-rider-blockers <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^d7d5:"
+assert_not_contains "$out" "^d7f7:"
+assert_not_contains "$out" "^e7c7:"
+assert_not_contains "$out" "^c6e8:"
+assert_not_contains "$out" "^d6f8:"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-rider-repeat\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^d7b5: 1$"
-echo "$out" | grep -q "^d7f5: 1$"
-echo "$out" | grep -q "^d7h3: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-rider-repeat <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_contains "$out" "^d7b5: 1$"
+assert_contains "$out" "^d7f5: 1$"
+assert_contains "$out" "^d7h3: 1$"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-rider-repeat\nposition fen 8/3a4/8/8/4p3/8/8/K6k b - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^d7b5: 1$"
-echo "$out" | grep -q "^d7f5: 1$"
-echo "$out" | grep -q "^d7h3: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-rider-repeat <<'UCI'
+position fen 8/3a4/8/8/4p3/8/8/K6k b - - 0 1
+go perft 1
+UCI
+)
+assert_contains "$out" "^d7b5: 1$"
+assert_contains "$out" "^d7f5: 1$"
+assert_contains "$out" "^d7h3: 1$"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-rider-repeat\nposition fen 8/3a4/8/5p2/8/8/8/K6k b - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^d7b5: 1$"
-! echo "$out" | grep -q "^d7f5:"
-! echo "$out" | grep -q "^d7h3:"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-rider-repeat <<'UCI'
+position fen 8/3a4/8/5p2/8/8/8/K6k b - - 0 1
+go perft 1
+UCI
+)
+assert_contains "$out" "^d7b5: 1$"
+assert_not_contains "$out" "^d7f5:"
+assert_not_contains "$out" "^d7h3:"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-rider-repeat\nposition fen 8/3a4/8/5P2/8/8/8/K6k b - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^d7b5: 1$"
-echo "$out" | grep -q "^d7f5: 1$"
-! echo "$out" | grep -q "^d7h3:"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-rider-repeat <<'UCI'
+position fen 8/3a4/8/5P2/8/8/8/K6k b - - 0 1
+go perft 1
+UCI
+)
+assert_contains "$out" "^d7b5: 1$"
+assert_contains "$out" "^d7f5: 1$"
+assert_not_contains "$out" "^d7h3:"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-rider-repeat\nposition fen 8/3a4/8/8/6p1/8/8/K6k b - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^d7b5: 1$"
-echo "$out" | grep -q "^d7f5: 1$"
-! echo "$out" | grep -q "^d7h3:"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-rider-repeat <<'UCI'
+position fen 8/3a4/8/8/6p1/8/8/K6k b - - 0 1
+go perft 1
+UCI
+)
+assert_contains "$out" "^d7b5: 1$"
+assert_contains "$out" "^d7f5: 1$"
+assert_not_contains "$out" "^d7h3:"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-rider-repeat\nposition fen 8/3a4/4p3/8/8/8/8/K6k b - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^d7b5: 1$"
-! echo "$out" | grep -q "^d7f5:"
-! echo "$out" | grep -q "^d7h3:"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-rider-repeat <<'UCI'
+position fen 8/3a4/4p3/8/8/8/8/K6k b - - 0 1
+go perft 1
+UCI
+)
+assert_contains "$out" "^d7b5: 1$"
+assert_not_contains "$out" "^d7f5:"
+assert_not_contains "$out" "^d7h3:"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-rider-bounded\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^b2d4: 1$"
-echo "$out" | grep -q "^b2f6: 1$"
-! echo "$out" | grep -q "^b2h8:"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-rider-bounded <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_contains "$out" "^b2d4: 1$"
+assert_contains "$out" "^b2f6: 1$"
+assert_not_contains "$out" "^b2h8:"
 
 # Plain DD/AA riders are not lame: midpoint blockers must NOT stop them.
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value plain-rider-midpoint\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^d7d5:"
-echo "$out" | grep -q "^e7c5:"
+out=$(run_uci "$ENGINE" "$tmp_ini" plain-rider-midpoint <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_contains "$out" "^d7d5:"
+assert_contains "$out" "^e7c5:"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-path-orthfirst\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^a1b4: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-path-orthfirst <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_contains "$out" "^a1b4: 1$"
 
 # Midpoint compatibility should still be available for historical definitions.
 # For even-length paths, the midpoint region is the whole central segment.
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-path-mid\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1d2:"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-path-mid <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1d2:"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-path-mid-clear\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^a1d2: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-path-mid-clear <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_contains "$out" "^a1d2: 1$"
 
 # A lame Ferz is blocked only when both orthogonally adjacent squares are occupied.
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-ferz-blockers\nposition fen 8/8/8/3p4/3A4/8/8/K6k w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^d4e5: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-ferz-blockers <<'UCI'
+position fen 8/8/8/3p4/3A4/8/8/K6k w - - 0 1
+go perft 1
+UCI
+)
+assert_contains "$out" "^d4e5: 1$"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-ferz-blockers\nposition fen 8/8/8/3p4/3Ap3/8/8/K6k w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^d4e5:"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-ferz-blockers <<'UCI'
+position fen 8/8/8/3p4/3Ap3/8/8/K6k w - - 0 1
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^d4e5:"
 
 # Any-path lame knight: if one valid route is clear, the move should be available.
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value moo-anypath\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^a1c2: 1$"
-! echo "$out" | grep -q "^a1e3:"
-! echo "$out" | grep -q "^a1g4:"
+out=$(run_uci "$ENGINE" "$tmp_ini" moo-anypath <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_contains "$out" "^a1c2: 1$"
+assert_not_contains "$out" "^a1e3:"
+assert_not_contains "$out" "^a1g4:"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value moo-anypath\nposition fen k7/8/8/8/8/8/p7/A6K w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^a1b3: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" moo-anypath <<'UCI'
+position fen k7/8/8/8/8/8/p7/A6K w - - 0 1
+go perft 1
+UCI
+)
+assert_contains "$out" "^a1b3: 1$"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value moa-move-blocked\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1c2:"
+out=$(run_uci "$ENGINE" "$tmp_ini" moa-move-blocked <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1c2:"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value mao-leg-blocked\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1c2:"
+out=$(run_uci "$ENGINE" "$tmp_ini" mao-leg-blocked <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1c2:"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value mao-leg-clear\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^a1c2: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" mao-leg-clear <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_contains "$out" "^a1c2: 1$"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value moa-check\nposition startpos moves a1c2\nd\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "Checkers: c2"
+out=$(run_uci "$ENGINE" "$tmp_ini" moa-check <<'UCI'
+position startpos moves a1c2
+d
+UCI
+)
+assert_contains "$out" "Checkers: c2"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value moa-check\nposition fen 8/8/8/8/3k4/3p4/8/A6K w - - 0 1 moves a1c2\nd\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "Checkers: c2"
+out=$(run_uci "$ENGINE" "$tmp_ini" moa-check <<'UCI'
+position fen 8/8/8/8/3k4/3p4/8/A6K w - - 0 1 moves a1c2
+d
+UCI
+)
+assert_not_contains "$out" "Checkers: c2"
 
-reject_out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-filter-key-reject\nquit\n' "$tmp_ini" \
-  | "${ENGINE}" 2>&1)
-grep -q "Unknown Betza parameter key 'filter' in lame block" <<<"$reject_out"
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-filter-key-reject\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1"
+reject_out=$(run_uci "$ENGINE" "$tmp_ini" lame-filter-key-reject <<'UCI' 2>&1
+UCI
+)
+assert_contains "$reject_out" "Unknown Betza parameter key 'filter' in lame block"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-filter-key-reject <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1"
 
-reject_out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-filter-value-reject\nquit\n' "$tmp_ini" \
-  | "${ENGINE}" 2>&1)
-grep -q "Unknown Betza parameter key 'filter' in lame block" <<<"$reject_out"
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-filter-value-reject\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1"
+reject_out=$(run_uci "$ENGINE" "$tmp_ini" lame-filter-value-reject <<'UCI' 2>&1
+UCI
+)
+assert_contains "$reject_out" "Unknown Betza parameter key 'filter' in lame block"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-filter-value-reject <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-invalid-clears-piece\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-invalid-clears-piece <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-invalid-stops-piece\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-invalid-stops-piece <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-invalid-multi-block\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-invalid-multi-block <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1"
 
 for variant in lame-invalid-dangling-path lame-invalid-dangling-filter lame-invalid-only-block; do
-  out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" "$variant" \
-    | "${ENGINE}")
-  ! echo "$out" | grep -q "^a1"
+  out=$(run_uci "$ENGINE" "$tmp_ini" "$variant" <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+  assert_not_contains "$out" "^a1"
 done
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-valid-after-block\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^a1a2: 1$"
-echo "$out" | grep -q "^a1b1: 1$"
-echo "$out" | grep -q "^a1c3: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-valid-after-block <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_contains "$out" "^a1a2: 1$"
+assert_contains "$out" "^a1b1: 1$"
+assert_contains "$out" "^a1c3: 1$"
 
-reject_out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-tuple-reject\nquit\n' "$tmp_ini" \
-  | "${ENGINE}" 2>&1)
-grep -q "Unsupported Betza tuple modifier combination" <<<"$reject_out"
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-tuple-reject\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1"
+reject_out=$(run_uci "$ENGINE" "$tmp_ini" lame-tuple-reject <<'UCI' 2>&1
+UCI
+)
+assert_contains "$reject_out" "Unsupported Betza tuple modifier combination"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-tuple-reject <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1"
 
-reject_out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-range-reject\nquit\n' "$tmp_ini" \
-  | "${ENGINE}" 2>&1)
-grep -q "Unsupported Betza rider range" <<<"$reject_out"
+reject_out=$(run_uci "$ENGINE" "$tmp_ini" lame-range-reject <<'UCI' 2>&1
+UCI
+)
+assert_contains "$reject_out" "Unsupported Betza rider range"
 
 for variant in lame-bare-hopper-reject lame-bare-dynamic-reject lame-bare-ski-reject lame-bare-max-reject; do
-  reject_out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nquit\n' "$tmp_ini" "$variant" \
-    | "${ENGINE}" 2>&1)
-  grep -q "Unsupported Betza lame modifier combination" <<<"$reject_out"
-  out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" "$variant" \
-    | "${ENGINE}")
-  ! echo "$out" | grep -q "^a1"
+  reject_out=$(run_uci "$ENGINE" "$tmp_ini" "$variant" <<'UCI' 2>&1
+UCI
+)
+  assert_contains "$reject_out" "Unsupported Betza lame modifier combination"
+  out=$(run_uci "$ENGINE" "$tmp_ini" "$variant" <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+  assert_not_contains "$out" "^a1"
 done
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-hybrid-rook-check\nposition startpos moves a1a7\nd\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "Checkers: a7"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-hybrid-rook-check <<'UCI'
+position startpos moves a1a7
+d
+UCI
+)
+assert_contains "$out" "Checkers: a7"
 
 tmp_key_ini=$(mktemp)
 cat > "$tmp_key_ini" <<'INI'
@@ -453,68 +550,102 @@ customPiece1 = a:{equi:bogus}W
 pieceToCharTable = PNBRQ............A...Kpnbrq............a...k
 INI
 
-reject_out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-key-routing\nquit\n' "$tmp_key_ini" \
-  | "${ENGINE}" 2>&1)
-grep -q "Unknown Betza parameter key 'capture' in lame block" <<<"$reject_out"
+reject_out=$(run_uci "$ENGINE" "$tmp_key_ini" lame-key-routing <<'UCI' 2>&1
+UCI
+)
+assert_contains "$reject_out" "Unknown Betza parameter key 'capture' in lame block"
 
-reject_out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value hopper-key-routing\nquit\n' "$tmp_key_ini" \
-  | "${ENGINE}" 2>&1)
-grep -q "Unknown Betza parameter key 'path' in hopper block" <<<"$reject_out"
+reject_out=$(run_uci "$ENGINE" "$tmp_key_ini" hopper-key-routing <<'UCI' 2>&1
+UCI
+)
+assert_contains "$reject_out" "Unknown Betza parameter key 'path' in hopper block"
 
-reject_out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value hopper-capture-value-reject\nquit\n' "$tmp_key_ini" \
-  | "${ENGINE}" 2>&1)
-grep -q "Unknown Betza hopper capture mode 'bogus'" <<<"$reject_out"
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value hopper-capture-value-reject\nposition startpos\ngo perft 1\nquit\n' "$tmp_key_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1"
+reject_out=$(run_uci "$ENGINE" "$tmp_key_ini" hopper-capture-value-reject <<'UCI' 2>&1
+UCI
+)
+assert_contains "$reject_out" "Unknown Betza hopper capture mode 'bogus'"
+out=$(run_uci "$ENGINE" "$tmp_key_ini" hopper-capture-value-reject <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1"
 
-reject_out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value hopper-equi-value-reject\nquit\n' "$tmp_key_ini" \
-  | "${ENGINE}" 2>&1)
-grep -q "Unknown Betza hopper equi mode 'bogus'" <<<"$reject_out"
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value hopper-equi-value-reject\nposition startpos\ngo perft 1\nquit\n' "$tmp_key_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1"
+reject_out=$(run_uci "$ENGINE" "$tmp_key_ini" hopper-equi-value-reject <<'UCI' 2>&1
+UCI
+)
+assert_contains "$reject_out" "Unknown Betza hopper equi mode 'bogus'"
+out=$(run_uci "$ENGINE" "$tmp_key_ini" hopper-equi-value-reject <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-path-mid-single\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1a3:"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-path-mid-single <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1a3:"
 
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value lame-long-leaper\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^a1e1: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" lame-long-leaper <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_contains "$out" "^a1e1: 1$"
 
 # Wrapped-board custom lame profile: ANY_PATH
 # clear board
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-anypath\nposition fen k7/8/8/8/8/8/8/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^a1h3: 1$"
-echo "$out" | grep -q "^a1g2: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" cylinder-anypath <<'UCI'
+position fen k7/8/8/8/8/8/8/A3K3 w - - 0 1
+go perft 1
+UCI
+)
+assert_contains "$out" "^a1h3: 1$"
+assert_contains "$out" "^a1g2: 1$"
 # a2 blocked
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-anypath\nposition fen k7/8/8/8/8/8/P7/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^a1h3: 1$"
-echo "$out" | grep -q "^a1g2: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" cylinder-anypath <<'UCI'
+position fen k7/8/8/8/8/8/P7/A3K3 w - - 0 1
+go perft 1
+UCI
+)
+assert_contains "$out" "^a1h3: 1$"
+assert_contains "$out" "^a1g2: 1$"
 # h2 blocked
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-anypath\nposition fen k7/8/8/8/8/8/7P/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^a1h3: 1$"
-echo "$out" | grep -q "^a1g2: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" cylinder-anypath <<'UCI'
+position fen k7/8/8/8/8/8/7P/A3K3 w - - 0 1
+go perft 1
+UCI
+)
+assert_contains "$out" "^a1h3: 1$"
+assert_contains "$out" "^a1g2: 1$"
 # a2 and h2 both blocked
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-anypath\nposition fen k7/8/8/8/8/8/P6P/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1h3:"
-! echo "$out" | grep -q "^a1g2:"
+out=$(run_uci "$ENGINE" "$tmp_ini" cylinder-anypath <<'UCI'
+position fen k7/8/8/8/8/8/P6P/A3K3 w - - 0 1
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1h3:"
+assert_not_contains "$out" "^a1g2:"
 
 # Wrapped-board custom lame profile: ORTH_FIRST
 # clear board
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-orthfirst\nposition fen k7/8/8/8/8/8/8/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-echo "$out" | grep -q "^a1h3: 1$"
-echo "$out" | grep -q "^a1g2: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" cylinder-orthfirst <<'UCI'
+position fen k7/8/8/8/8/8/8/A3K3 w - - 0 1
+go perft 1
+UCI
+)
+assert_contains "$out" "^a1h3: 1$"
+assert_contains "$out" "^a1g2: 1$"
 # a2 blocked (this leg blocks the ORTH_FIRST wrapped h3 jump)
-out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value cylinder-orthfirst\nposition fen k7/8/8/8/8/8/P7/A3K3 w - - 0 1\ngo perft 1\nquit\n' "$tmp_ini" \
-  | "${ENGINE}")
-! echo "$out" | grep -q "^a1h3:"
-echo "$out" | grep -q "^a1g2: 1$"
+out=$(run_uci "$ENGINE" "$tmp_ini" cylinder-orthfirst <<'UCI'
+position fen k7/8/8/8/8/8/P7/A3K3 w - - 0 1
+go perft 1
+UCI
+)
+assert_not_contains "$out" "^a1h3:"
+assert_contains "$out" "^a1g2: 1$"
 
 echo "alfil-dabbaba-riders test OK"

--- a/tests/asym-rider-checkers.sh
+++ b/tests/asym-rider-checkers.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-ENGINE=${1:-"${ROOT_DIR}/src/stockfish"}
-if [[ "${ENGINE}" != /* ]]; then
-  ENGINE="${PWD}/${ENGINE}"
-fi
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/lib/uci.sh"
 
-cd "${ROOT_DIR}/src"
+ENGINE=$(default_engine "${1:-}")
 
 tmp_ini=$(mktemp)
 trap 'rm -f "$tmp_ini"' EXIT
@@ -30,36 +26,38 @@ INI
 diag() {
   local variant=$1
   local fen=$2
-  printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nposition fen %s\nd\nquit\n' "$tmp_ini" "$variant" "$fen" \
-    | "${ENGINE}"
+  run_uci "$ENGINE" "$tmp_ini" "$variant" <<UCI
+position fen $fen
+d
+UCI
 }
 
 # Horse-family blocked leg: no check.
 hb=$(diag asymcheck-horse '4k3/3R4/3A4/8/8/8/8/4K3 b - - 0 1')
-grep -q '^Checkers:[[:space:]]*$' <<<"$hb"
+assert_contains "$hb" "^Checkers:[[:space:]]*$"
 
 # Horse-family open leg: checker on d6.
 hu=$(diag asymcheck-horse '4k3/8/3A4/8/8/8/8/4K3 b - - 0 1')
-grep -q '^Checkers: d6 ' <<<"$hu"
+assert_contains "$hu" "^Checkers: d6 "
 
 # Griffon blocked pivot: no check.
 gb=$(diag asymcheck-griffon '8/6Pk/5A2/8/8/8/8/4K3 b - - 0 1')
-grep -q '^Checkers:[[:space:]]*$' <<<"$gb"
+assert_contains "$gb" "^Checkers:[[:space:]]*$"
 
 # Griffon open pivot/ray: checker on f6.
 gu=$(diag asymcheck-griffon '8/7k/5A2/8/8/8/8/4K3 b - - 0 1')
-grep -q '^Checkers: f6 ' <<<"$gu"
+assert_contains "$gu" "^Checkers: f6 "
 
 # Non-pivot orthogonal blocker must not suppress the same griffon check.
 gx=$(diag asymcheck-griffon '8/5P1k/5A2/8/8/8/8/4K3 b - - 0 1')
-grep -q '^Checkers: f6 ' <<<"$gx"
+assert_contains "$gx" "^Checkers: f6 "
 
 # Manticore blocked pivot: no check.
 mb=$(diag asymcheck-manticore '6k1/5N2/5A2/8/8/8/8/4K3 b - - 0 1')
-grep -q '^Checkers:[[:space:]]*$' <<<"$mb"
+assert_contains "$mb" "^Checkers:[[:space:]]*$"
 
 # Manticore open pivot/ray: checker on f6.
 mu=$(diag asymcheck-manticore '6k1/8/5A2/8/8/8/8/4K3 b - - 0 1')
-grep -q '^Checkers: f6 ' <<<"$mu"
+assert_contains "$mu" "^Checkers: f6 "
 
 echo "asym-rider-checkers test OK"

--- a/tests/atlantis.sh
+++ b/tests/atlantis.sh
@@ -1,38 +1,35 @@
 #!/bin/bash
-
 set -euo pipefail
 
-error() {
-  echo "atlantis regression failed on line $1"
-  exit 1
-}
-trap 'error ${LINENO}' ERR
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/lib/uci.sh"
 
-ENGINE=${1:-./stockfish}
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
-VARIANTS=${2:-${REPO_ROOT}/src/variants.ini}
+ENGINE=$(default_engine "${1:-}")
+VARIANTS=$(default_variants "${2:-}")
 
-run_cmds() {
-  cat <<EOF | "${ENGINE}"
-uci
-setoption name VariantPath value ${VARIANTS}
-setoption name UCI_Variant value atlantis
-$1
-quit
+echo "atlantis tests started"
+
+out=$(run_uci "$ENGINE" "$VARIANTS" atlantis <<'EOF'
+position startpos
+go perft 1
 EOF
-}
+)
+assert_contains "$out" "^a2a3: 1$"
+assert_not_contains "$out" "^a2a3,a1: 1$"
+assert_contains "$out" "^0000,a3: 1$"
 
-out=$(run_cmds "position startpos
-go perft 1")
-echo "${out}" | grep -q "^a2a3: 1$"
-! echo "${out}" | grep -q "^a2a3,a1: 1$"
-echo "${out}" | grep -q "^0000,a3: 1$"
+out=$(run_uci "$ENGINE" "$VARIANTS" atlantis <<'EOF'
+position startpos moves a2a3
+d
+EOF
+)
+assert_contains_literal "$out" "Fen: rnbqkbnr/pppppppp/8/8/8/P7/1PPPPPPP/RNBQKBNR b KQkq - 0 1"
 
-out=$(run_cmds "position startpos moves a2a3
-d")
-echo "${out}" | grep -q "Fen: rnbqkbnr/pppppppp/8/8/8/P7/1PPPPPPP/RNBQKBNR b KQkq - 0 1"
+out=$(run_uci "$ENGINE" "$VARIANTS" atlantis <<'EOF'
+position startpos moves 0000,a3
+d
+EOF
+)
+assert_contains_literal "$out" "Fen: rnbqkbnr/pppppppp/8/8/8/*7/PPPPPPPP/RNBQKBNR b KQkq - 1 1"
 
-out=$(run_cmds "position startpos moves 0000,a3
-d")
-echo "${out}" | grep -q "Fen: rnbqkbnr/pppppppp/8/8/8/\\*7/PPPPPPPP/RNBQKBNR b KQkq - 1 1"
+echo "atlantis tests passed"

--- a/tests/bent-rider-evasion.sh
+++ b/tests/bent-rider-evasion.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-ENGINE=${1:-"${ROOT_DIR}/src/stockfish"}
-if [[ "${ENGINE}" != /* ]]; then
-  ENGINE="${PWD}/${ENGINE}"
-fi
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/lib/uci.sh"
 
-cd "${ROOT_DIR}/src"
+ENGINE=$(default_engine "${1:-}")
 
 tmp_ini=$(mktemp)
 trap 'rm -f "$tmp_ini"' EXIT
@@ -26,21 +22,23 @@ INI
 perft_out() {
   local variant="$1"
   local fen="$2"
-  printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nposition fen %s\ngo perft 1\nquit\n' "$tmp_ini" "$variant" "$fen" \
-    | "${ENGINE}"
+  run_uci "$ENGINE" "$tmp_ini" "$variant" <<UCI
+position fen $fen
+go perft 1
+UCI
 }
 
 # Griffon check line: f6 -> h7 (pivot g7, then outward horizontal).
 # g8g7 must be legal (interposition), while g8g6 must remain illegal.
 # h7h6 is also legal under the current pivot-square griffon semantics.
 g=$(perft_out griffon-evasion '6r1/7k/5A2/8/8/8/8/K7 b - - 0 1')
-grep -q "g8g7:" <<<"$g"
-! grep -q "g8g6:" <<<"$g"
+assert_contains "$g" "g8g7:"
+assert_not_contains "$g" "g8g6:"
 
 # Manticore check line: f6 -> g8 (pivot f7, then outward diagonal).
 # h7f7 must be legal (interposition), while h7h6 must remain illegal.
 m=$(perft_out manticore-evasion '6k1/7r/5A2/8/8/8/8/K7 b - - 0 1')
-grep -q "h7f7:" <<<"$m"
-! grep -q "h7h6:" <<<"$m"
+assert_contains "$m" "h7f7:"
+assert_not_contains "$m" "h7h6:"
 
 echo "bent-rider-evasion test OK"

--- a/tests/bent-riders.sh
+++ b/tests/bent-riders.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-ENGINE=${1:-"${ROOT_DIR}/src/stockfish"}
-if [[ "${ENGINE}" != /* ]]; then
-  ENGINE="${PWD}/${ENGINE}"
-fi
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/lib/uci.sh"
 
-cd "${ROOT_DIR}/src"
+ENGINE=$(default_engine "${1:-}")
 
 tmp_ini=$(mktemp)
 trap 'rm -f "$tmp_ini"' EXIT
@@ -27,24 +23,26 @@ INI
 
 perft_out() {
   local variant="$1"
-  printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" "$variant" \
-    | "${ENGINE}"
+  run_uci "$ENGINE" "$tmp_ini" "$variant" <<'UCI'
+position startpos
+go perft 1
+UCI
 }
 
 g=$(perft_out griffon-test)
-grep -q "d4h5:" <<<"$g"
-grep -q "d4a5:" <<<"$g"
-grep -q "d4e8:" <<<"$g"
-grep -q "d4c1:" <<<"$g"
-! grep -q "d4d5:" <<<"$g"
-! grep -q "d4e4:" <<<"$g"
+assert_contains "$g" "d4h5:"
+assert_contains "$g" "d4a5:"
+assert_contains "$g" "d4e8:"
+assert_contains "$g" "d4c1:"
+assert_not_contains "$g" "d4d5:"
+assert_not_contains "$g" "d4e4:"
 
 m=$(perft_out manticore-test)
-grep -q "d4g8:" <<<"$m"
-grep -q "d4a6:" <<<"$m"
-grep -q "d4h1:" <<<"$m"
-grep -q "d4b1:" <<<"$m"
-! grep -q "d4h5:" <<<"$m"
-! grep -q "d4e8:" <<<"$m"
+assert_contains "$m" "d4g8:"
+assert_contains "$m" "d4a6:"
+assert_contains "$m" "d4h1:"
+assert_contains "$m" "d4b1:"
+assert_not_contains "$m" "d4h5:"
+assert_not_contains "$m" "d4e8:"
 
 echo "bent-riders test OK"

--- a/tests/betza-modifiers.sh
+++ b/tests/betza-modifiers.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-ENGINE=${1:-"${ROOT_DIR}/src/stockfish"}
-if [[ "${ENGINE}" != /* ]]; then
-  ENGINE="${PWD}/${ENGINE}"
-fi
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/lib/uci.sh"
 
-cd "${ROOT_DIR}/src"
+ENGINE=$(default_engine "${1:-}")
 
 tmp_ini=$(mktemp)
 trap 'rm -f "$tmp_ini"' EXIT
@@ -52,22 +48,33 @@ INI
 
 perft_moves() {
   local variant=$1
-  printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" "$variant" \
-    | "${ENGINE}" \
-    | grep ':'
+  run_uci "$ENGINE" "$tmp_ini" "$variant" <<'UCI' | grep ':'
+position startpos
+go perft 1
+UCI
 }
 
 cmp <(perft_moves modsugar_ski_group) <(perft_moves modsugar_ski_explicit)
 cmp <(perft_moves modsugar_max_group) <(perft_moves modsugar_max_explicit)
 
-dist_out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value dist10\nposition startpos\ngo perft 1\nquit\n' "$tmp_ini" | "${ENGINE}")
-grep -q 'e5e8:' <<<"$dist_out"
-grep -q 'e5h5:' <<<"$dist_out"
+dist_out=$(run_uci "$ENGINE" "$tmp_ini" dist10 <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_contains "$dist_out" "e5e8:"
+assert_contains "$dist_out" "e5h5:"
 
-check_out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value tuplewarn\nquit\n' "$tmp_ini" | "${ENGINE}" 2>&1)
-grep -q "Unsupported Betza tuple modifier combination" <<<"$check_out"
+check_out=$(run_uci "$ENGINE" "$tmp_ini" tuplewarn <<'UCI' 2>&1
+UCI
+)
+assert_contains "$check_out" "Unsupported Betza tuple modifier combination"
 
-ski_out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value ski_autocheck\nposition startpos moves e7e5\nd\nquit\n' "$tmp_ini" | "${ENGINE}")
-grep -q 'Checkers: e5 ' <<<"$ski_out"
+ski_out=$(run_uci "$ENGINE" "$tmp_ini" ski_autocheck <<'UCI'
+position startpos moves e7e5
+d
+UCI
+)
+assert_contains "$ski_out" 'Checkers: e5 '
 
 echo "betza-modifiers test OK"

--- a/tests/betza-range-modifiers.sh
+++ b/tests/betza-range-modifiers.sh
@@ -1,17 +1,14 @@
 #!/bin/bash
-
 set -euo pipefail
 
-error() {
-  echo "betza range modifiers test failed on line $1"
-  [[ -n "${TMP_VARIANT_PATH:-}" ]] && rm -f "${TMP_VARIANT_PATH}"
-  exit 1
-}
-trap 'error ${LINENO}' ERR
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/lib/uci.sh"
 
-ENGINE=${1:-./stockfish}
+ENGINE=$(default_engine "${1:-}")
 
 TMP_VARIANT_PATH=$(mktemp "${TMPDIR:-/tmp}/fsx-betza-range-XXXXXX.ini")
+trap 'rm -f "${TMP_VARIANT_PATH}"' EXIT
+
 cat >"${TMP_VARIANT_PATH}" <<'INI'
 [range35:chess]
 king = -
@@ -35,51 +32,39 @@ pieceToCharTable = A:a
 startFen = 8/8/8/8/4A3/8/8/8 w - - 0 1
 INI
 
-run_perft() {
-  local variant="$1"
-  cat <<CMDS | "${ENGINE}"
-uci
-setoption name VariantPath value ${TMP_VARIANT_PATH}
-setoption name UCI_Variant value ${variant}
-position startpos
-go perft 1
-quit
-CMDS
-}
-
 echo "betza range modifiers tests started"
 
-out=$(run_perft "range35")
-echo "${out}" | grep -q "^e4e7: 1$"
-echo "${out}" | grep -q "^e4e8: 1$"
-echo "${out}" | grep -q "^e4b4: 1$"
-echo "${out}" | grep -q "^e4h4: 1$"
-! echo "${out}" | grep -q "^e4e5: 1$"
-! echo "${out}" | grep -q "^e4e6: 1$"
-! echo "${out}" | grep -q "^e4d4: 1$"
-! echo "${out}" | grep -q "^e4c4: 1$"
-
-out=$(run_perft "range3plus")
-echo "${out}" | grep -q "^e4e7: 1$"
-echo "${out}" | grep -q "^e4e8: 1$"
-echo "${out}" | grep -q "^e4b4: 1$"
-echo "${out}" | grep -q "^e4h4: 1$"
-! echo "${out}" | grep -q "^e4e5: 1$"
-! echo "${out}" | grep -q "^e4e6: 1$"
-! echo "${out}" | grep -q "^e4d4: 1$"
-! echo "${out}" | grep -q "^e4c4: 1$"
-
-invalid_out=$(cat <<CMDS | "${ENGINE}" 2>&1
-uci
-setoption name VariantPath value ${TMP_VARIANT_PATH}
-setoption name UCI_Variant value rangeinvalid
-quit
-CMDS
+out=$(run_uci "$ENGINE" "$TMP_VARIANT_PATH" range35 <<'UCI'
+position startpos
+go perft 1
+UCI
 )
+assert_contains "$out" "^e4e7: 1$"
+assert_contains "$out" "^e4e8: 1$"
+assert_contains "$out" "^e4b4: 1$"
+assert_contains "$out" "^e4h4: 1$"
+assert_not_contains "$out" "^e4e5: 1$"
+assert_not_contains "$out" "^e4e6: 1$"
+assert_not_contains "$out" "^e4d4: 1$"
+assert_not_contains "$out" "^e4c4: 1$"
 
-echo "${invalid_out}" | grep -q "Invalid Betza rider range"
+out=$(run_uci "$ENGINE" "$TMP_VARIANT_PATH" range3plus <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_contains "$out" "^e4e7: 1$"
+assert_contains "$out" "^e4e8: 1$"
+assert_contains "$out" "^e4b4: 1$"
+assert_contains "$out" "^e4h4: 1$"
+assert_not_contains "$out" "^e4e5: 1$"
+assert_not_contains "$out" "^e4e6: 1$"
+assert_not_contains "$out" "^e4d4: 1$"
+assert_not_contains "$out" "^e4c4: 1$"
 
-rm -f "${TMP_VARIANT_PATH}"
-unset TMP_VARIANT_PATH
+invalid_out=$(run_uci "$ENGINE" "$TMP_VARIANT_PATH" rangeinvalid <<'UCI' 2>&1
+UCI
+)
+assert_contains "$invalid_out" "Invalid Betza rider range"
 
 echo "betza range modifiers tests passed"

--- a/tests/betza-rifle-notation.sh
+++ b/tests/betza-rifle-notation.sh
@@ -1,7 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
-ENGINE="${1:-src/stockfish}"
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/lib/uci.sh"
+
+ENGINE=$(default_engine "${1:-}")
 
 tmp_ini="$(mktemp)"
 trap 'rm -f "$tmp_ini"' EXIT
@@ -17,29 +20,23 @@ EOF
 run_d() {
   local variant="$1"
   local moves="$2"
-  "$ENGINE" <<EOF
-setoption name VariantPath value $tmp_ini
-setoption name UCI_Variant value $variant
+  run_uci "$ENGINE" "$tmp_ini" "$variant" <<UCI
 position fen p3k3/8/8/8/8/8/8/A3K3 w - - 0 1${moves}
 d
-quit
-EOF
+UCI
 }
 
-rifle_moves="$("$ENGINE" <<EOF
-setoption name VariantPath value $tmp_ini
-setoption name UCI_Variant value betzarifle
+rifle_moves=$(run_uci "$ENGINE" "$tmp_ini" betzarifle <<'UCI'
 position fen p3k3/8/8/8/8/8/8/A3K3 w - - 0 1
 go perft 1
-quit
-EOF
-)"
-echo "${rifle_moves}" | grep -q "^a1a8: 1$"
+UCI
+)
+assert_contains "$rifle_moves" "^a1a8: 1$"
 
 plain_after="$(run_d "betzaplain" " moves a1a8")"
-echo "${plain_after}" | grep -q "Fen: A3k3/8/8/8/8/8/8/4K3 b - - 0 1"
+assert_contains_literal "$plain_after" "Fen: A3k3/8/8/8/8/8/8/4K3 b - - 0 1"
 
 rifle_after="$(run_d "betzarifle" " moves a1a8")"
-echo "${rifle_after}" | grep -q "Fen: 4k3/8/8/8/8/8/8/A3K3 b - - 0 1"
+assert_contains_literal "$rifle_after" "Fen: 4k3/8/8/8/8/8/8/A3K3 b - - 0 1"
 
 echo "betza rifle notation passed"

--- a/tests/hex-piece-movement.sh
+++ b/tests/hex-piece-movement.sh
@@ -1,14 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
-error() {
-  echo "hex piece movement regression failed on line $1"
-  exit 1
-}
-trap 'error ${LINENO}' ERR
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/lib/uci.sh"
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ENGINE="${1:-${SCRIPT_DIR}/../src/stockfish}"
+ENGINE=$(default_engine "${1:-}")
 
 TMP_VARIANT_PATH=$(mktemp "${TMPDIR:-/tmp}/fsx-hex-pieces-XXXXXX.ini")
 trap 'rm -f "${TMP_VARIANT_PATH}"' EXIT
@@ -55,95 +51,106 @@ king = k:WrfFlbFflFrbFrf(2,1)lb(2,1)fr(2,1)bl(2,1)
 startFen = 6k/7/7/3K3/7/7/7 w - - 0 1
 INI
 
-run_cmds() {
-  cat <<EOF | "${ENGINE}"
-uci
-setoption name VariantPath value ${TMP_VARIANT_PATH}
-setoption name UCI_Variant value $1
-$2
-quit
-EOF
-}
+out=$(run_uci "$ENGINE" "$TMP_VARIANT_PATH" hex-rook-test <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_nodes "$out" 12
+assert_contains "$out" "^c3a1: 1$"
+assert_contains "$out" "^c3c1: 1$"
+assert_contains "$out" "^c3b2: 1$"
+assert_contains "$out" "^c3c2: 1$"
+assert_contains "$out" "^c3a3: 1$"
+assert_contains "$out" "^c3b3: 1$"
+assert_contains "$out" "^c3d3: 1$"
+assert_contains "$out" "^c3e3: 1$"
+assert_contains "$out" "^c3c4: 1$"
+assert_contains "$out" "^c3d4: 1$"
+assert_contains "$out" "^c3c5: 1$"
+assert_contains "$out" "^c3e5: 1$"
 
-out=$(run_cmds "hex-rook-test" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 12" <<<"$out"
-echo "${out}" | grep -q "^c3a1: 1$"
-echo "${out}" | grep -q "^c3c1: 1$"
-echo "${out}" | grep -q "^c3b2: 1$"
-echo "${out}" | grep -q "^c3c2: 1$"
-echo "${out}" | grep -q "^c3a3: 1$"
-echo "${out}" | grep -q "^c3b3: 1$"
-echo "${out}" | grep -q "^c3d3: 1$"
-echo "${out}" | grep -q "^c3e3: 1$"
-echo "${out}" | grep -q "^c3c4: 1$"
-echo "${out}" | grep -q "^c3d4: 1$"
-echo "${out}" | grep -q "^c3c5: 1$"
-echo "${out}" | grep -q "^c3e5: 1$"
+out=$(run_uci "$ENGINE" "$TMP_VARIANT_PATH" hex-king-test <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_nodes "$out" 6
+assert_contains "$out" "^c3b2: 1$"
+assert_contains "$out" "^c3c2: 1$"
+assert_contains "$out" "^c3b3: 1$"
+assert_contains "$out" "^c3d3: 1$"
+assert_contains "$out" "^c3c4: 1$"
+assert_contains "$out" "^c3d4: 1$"
 
-out=$(run_cmds "hex-king-test" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 6" <<<"$out"
-echo "${out}" | grep -q "^c3b2: 1$"
-echo "${out}" | grep -q "^c3c2: 1$"
-echo "${out}" | grep -q "^c3b3: 1$"
-echo "${out}" | grep -q "^c3d3: 1$"
-echo "${out}" | grep -q "^c3c4: 1$"
-echo "${out}" | grep -q "^c3d4: 1$"
+out=$(run_uci "$ENGINE" "$TMP_VARIANT_PATH" hex-bishop-test <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_nodes "$out" 8
+assert_contains "$out" "^c3b1: 1$"
+assert_contains "$out" "^c3e1: 1$"
+assert_contains "$out" "^c3a2: 1$"
+assert_contains "$out" "^c3d2: 1$"
+assert_contains "$out" "^c3b4: 1$"
+assert_contains "$out" "^c3e4: 1$"
+assert_contains "$out" "^c3a5: 1$"
+assert_contains "$out" "^c3d5: 1$"
 
-out=$(run_cmds "hex-bishop-test" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 8" <<<"$out"
-echo "${out}" | grep -q "^c3b1: 1$"
-echo "${out}" | grep -q "^c3e1: 1$"
-echo "${out}" | grep -q "^c3a2: 1$"
-echo "${out}" | grep -q "^c3d2: 1$"
-echo "${out}" | grep -q "^c3b4: 1$"
-echo "${out}" | grep -q "^c3e4: 1$"
-echo "${out}" | grep -q "^c3a5: 1$"
-echo "${out}" | grep -q "^c3d5: 1$"
+out=$(run_uci "$ENGINE" "$TMP_VARIANT_PATH" hex-queen-test <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_nodes "$out" 20
+assert_contains "$out" "^c3a1: 1$"
+assert_contains "$out" "^c3e5: 1$"
+assert_contains "$out" "^c3b1: 1$"
+assert_contains "$out" "^c3e1: 1$"
+assert_contains "$out" "^c3a2: 1$"
+assert_contains "$out" "^c3d5: 1$"
 
-out=$(run_cmds "hex-queen-test" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 20" <<<"$out"
-echo "${out}" | grep -q "^c3a1: 1$"
-echo "${out}" | grep -q "^c3e5: 1$"
-echo "${out}" | grep -q "^c3b1: 1$"
-echo "${out}" | grep -q "^c3e1: 1$"
-echo "${out}" | grep -q "^c3a2: 1$"
-echo "${out}" | grep -q "^c3d5: 1$"
+out=$(run_uci "$ENGINE" "$TMP_VARIANT_PATH" hex-knight-test <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_nodes "$out" 8
+assert_contains "$out" "^d4c2: 1$"
+assert_contains "$out" "^d4e2: 1$"
+assert_contains "$out" "^d4b3: 1$"
+assert_contains "$out" "^d4f3: 1$"
+assert_contains "$out" "^d4b5: 1$"
+assert_contains "$out" "^d4f5: 1$"
+assert_contains "$out" "^d4c6: 1$"
+assert_contains "$out" "^d4e6: 1$"
 
-out=$(run_cmds "hex-knight-test" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 8" <<<"$out"
-echo "${out}" | grep -q "^d4c2: 1$"
-echo "${out}" | grep -q "^d4e2: 1$"
-echo "${out}" | grep -q "^d4b3: 1$"
-echo "${out}" | grep -q "^d4f3: 1$"
-echo "${out}" | grep -q "^d4b5: 1$"
-echo "${out}" | grep -q "^d4f5: 1$"
-echo "${out}" | grep -q "^d4c6: 1$"
-echo "${out}" | grep -q "^d4e6: 1$"
+out=$(run_uci "$ENGINE" "$TMP_VARIANT_PATH" hex-pawn-test <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_nodes "$out" 3
+assert_contains "$out" "^d4c3: 1$"
+assert_contains "$out" "^d4d5: 1$"
+assert_contains "$out" "^d4e3: 1$"
 
-out=$(run_cmds "hex-pawn-test" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 3" <<<"$out"
-echo "${out}" | grep -q "^d4c3: 1$"
-echo "${out}" | grep -q "^d4d5: 1$"
-echo "${out}" | grep -q "^d4e3: 1$"
-
-out=$(run_cmds "hex-royal-king-test" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 10" <<<"$out"
-echo "${out}" | grep -q "^d4c2: 1$"
-echo "${out}" | grep -q "^d4b3: 1$"
-echo "${out}" | grep -q "^d4c3: 1$"
-echo "${out}" | grep -q "^d4d3: 1$"
-echo "${out}" | grep -q "^d4e3: 1$"
-echo "${out}" | grep -q "^d4c4: 1$"
-echo "${out}" | grep -q "^d4e4: 1$"
-echo "${out}" | grep -q "^d4c5: 1$"
-echo "${out}" | grep -q "^d4d5: 1$"
-echo "${out}" | grep -q "^d4e5: 1$"
+out=$(run_uci "$ENGINE" "$TMP_VARIANT_PATH" hex-royal-king-test <<'UCI'
+position startpos
+go perft 1
+UCI
+)
+assert_nodes "$out" 10
+assert_contains "$out" "^d4c2: 1$"
+assert_contains "$out" "^d4b3: 1$"
+assert_contains "$out" "^d4c3: 1$"
+assert_contains "$out" "^d4d3: 1$"
+assert_contains "$out" "^d4e3: 1$"
+assert_contains "$out" "^d4c4: 1$"
+assert_contains "$out" "^d4e4: 1$"
+assert_contains "$out" "^d4c5: 1$"
+assert_contains "$out" "^d4d5: 1$"
+assert_contains "$out" "^d4e5: 1$"
 
 echo "hex piece movement regression passed"

--- a/tests/vlb-lame-riders.sh
+++ b/tests/vlb-lame-riders.sh
@@ -1,8 +1,17 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ENGINE="${1:-$ROOT_DIR/src/stockfish-vlb}"
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/lib/uci.sh"
+
+ENGINE="${1:-}"
+if [[ -z "$ENGINE" ]]; then
+  if [[ -x "${ROOT_DIR}/src/stockfish-vlb" ]]; then
+    ENGINE="${ROOT_DIR}/src/stockfish-vlb"
+  else
+    ENGINE="${ROOT_DIR}/stockfish-vlb"
+  fi
+fi
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
@@ -26,8 +35,10 @@ VAR
 
 run_variant() {
   local variant="$1"
-  printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nposition startpos\ngo perft 1\nquit\n' \
-    "$VARIANT_FILE" "$variant" | "$ENGINE" 2>&1
+  run_uci "$ENGINE" "$VARIANT_FILE" "$variant" <<'UCI' 2>&1
+position startpos
+go perft 1
+UCI
 }
 
 out=$(run_variant vlb-lame-clear)
@@ -40,17 +51,17 @@ if grep -q "No such variant" <<<"$out"; then
   exit 0
 fi
 
-grep -q "info string variant vlb-lame-clear files 16 ranks 16" <<<"$out"
-grep -q "^m16m14: 1$" <<<"$out"
-grep -q "^m16k16: 1$" <<<"$out"
-grep -q "^m16o16: 1$" <<<"$out"
-grep -Fxq "Nodes searched: 6" <<<"$out"
+assert_contains "$out" "info string variant vlb-lame-clear files 16 ranks 16"
+assert_contains "$out" "^m16m14: 1$"
+assert_contains "$out" "^m16k16: 1$"
+assert_contains "$out" "^m16o16: 1$"
+assert_nodes "$out" 6
 
 out=$(run_variant vlb-lame-blocked)
-grep -q "info string variant vlb-lame-blocked files 16 ranks 16" <<<"$out"
-! grep -q "^m16m14:" <<<"$out"
-grep -q "^m16k16: 1$" <<<"$out"
-grep -q "^m16o16: 1$" <<<"$out"
-grep -Fxq "Nodes searched: 5" <<<"$out"
+assert_contains "$out" "info string variant vlb-lame-blocked files 16 ranks 16"
+assert_not_contains "$out" "^m16m14:"
+assert_contains "$out" "^m16k16: 1$"
+assert_contains "$out" "^m16o16: 1$"
+assert_nodes "$out" 5
 
 echo "VLB lame rider regression passed"


### PR DESCRIPTION
This PR cleans up 10 target regression tests by migrating them to the shared `tests/lib/uci.sh` helper and unified assertions. It also fixes a bitwise bug in lame Ferz block detection where distinct square bitboard intersections evaluated to zero.