### PR TITLE
Migrate 6 test scripts to shared uci.sh helper and fix VLB Bitboard comparison

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -4108,7 +4108,7 @@ bool Position::legal(Move m) const {
   bool blockedByPostMove = (postMoveAttackers
                          & postMoveOccupied
                          & ~(removedAttackers | removedByEffects)
-                         & ~(rifleShot ? Bitboard(0) : SquareBB[to])) != 0;
+                         & ~(rifleShot ? Bitboard(0) : SquareBB[to])) != Bitboard(0);
   return (allow_checks() || !blockedByPostMove)
       && !violates_same_player_board_repetition(m);
 }

--- a/tests/battleotk.sh
+++ b/tests/battleotk.sh
@@ -1,75 +1,70 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-ENGINE="${1:-${SCRIPT_DIR}/../src/stockfish}"
-VARIANTS="${2:-${SCRIPT_DIR}/../src/variants.ini}"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/uci.sh"
 
-run_cmds() {
-  local cmds="$1"
-  printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value battleotk\n%s\nquit\n' \
-    "$VARIANTS" "$cmds" | "$ENGINE"
-}
+ENGINE=$(default_engine "${1:-}")
+VARIANTS=$(default_variants "${2:-}")
 
 echo "battleotk regression started"
 
-out=$(run_cmds "position startpos
-go perft 1")
-echo "$out" | grep -q "^e2e4n: 1$"
-! echo "$out" | grep -q "^e2e4: 1$"
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position startpos
+go perft 1')
+assert_contains "$out" "^e2e4n: 1$"
+assert_not_contains "$out" "^e2e4: 1$"
 
-out=$(run_cmds "position startpos moves e2e4n
-d")
-echo "$out" | grep -Fq "Fen: 8/pppppppp/8/8/4P3/8/PPPPNPPP/8 b - - 0 1"
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position startpos moves e2e4n
+d')
+assert_contains_literal "$out" "Fen: 8/pppppppp/8/8/4P3/8/PPPPNPPP/8 b - - 0 1"
 
-out=$(run_cmds "position fen 8/6P1/8/8/8/8/8/8 w - - 0 1 moves g7g8n
-d")
-echo "$out" | grep -Fq "Fen: 6N1/8/8/8/8/8/8/8 b - - 0 1"
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position fen 8/6P1/8/8/8/8/8/8 w - - 0 1 moves g7g8n
+d')
+assert_contains_literal "$out" "Fen: 6N1/8/8/8/8/8/8/8 b - - 0 1"
 
-out=$(run_cmds "position fen 8/ppnppppp/8/2n5/2pP4/4PP2/PPPNNNPP/8 b - d3 0 3
-go perft 1")
-echo "$out" | grep -q "^c4d3: 1$"
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position fen 8/ppnppppp/8/2n5/2pP4/4PP2/PPPNNNPP/8 b - d3 0 3
+go perft 1')
+assert_contains "$out" "^c4d3: 1$"
 
-out=$(run_cmds "position fen 8/ppnppppp/8/2n5/2pP4/4PP2/PPPNNNPP/8 b - d3 0 3 moves c4d3
-d")
-echo "$out" | grep -Fq "Fen: 8/ppnppppp/8/2n5/8/3pPP2/PPPNNNPP/8 w - - 0 4"
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position fen 8/ppnppppp/8/2n5/2pP4/4PP2/PPPNNNPP/8 b - d3 0 3 moves c4d3
+d')
+assert_contains_literal "$out" "Fen: 8/ppnppppp/8/2n5/8/3pPP2/PPPNNNPP/8 w - - 0 4"
 
-out=$(run_cmds "position startpos
-go depth 1")
-echo "$out" | grep -q "^bestmove "
-! echo "$out" | grep -q "^bestmove (none)$"
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position startpos
+go depth 1')
+assert_contains "$out" "^bestmove "
+assert_not_contains_literal "$out" "bestmove (none)"
 
-out=$(run_cmds "position fen 8/8/8/8/8/8/1k6/K7 w - - 0 1 moves a1b2
-d")
-echo "$out" | grep -Fq "Fen: 8/8/8/8/8/8/1K6/8 b - - 0 1"
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position fen 8/8/8/8/8/8/1k6/K7 w - - 0 1 moves a1b2
+d')
+assert_contains_literal "$out" "Fen: 8/8/8/8/8/8/1K6/8 b - - 0 1"
 
-out=$(run_cmds "position fen 8/8/8/8/8/8/1k6/K7 w - - 0 1
-go depth 1")
-echo "$out" | grep -q "^bestmove "
-! echo "$out" | grep -q "^bestmove (none)$"
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position fen 8/8/8/8/8/8/1k6/K7 w - - 0 1
+go depth 1')
+assert_contains "$out" "^bestmove "
+assert_not_contains_literal "$out" "bestmove (none)"
 
-out=$(run_cmds "position fen 8/8/8/8/8/8/1k6/K7 w - - 0 1
-go depth 2")
-echo "$out" | grep -q "^bestmove "
-! echo "$out" | grep -q "^bestmove (none)$"
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position fen 8/8/8/8/8/8/1k6/K7 w - - 0 1
+go depth 2')
+assert_contains "$out" "^bestmove "
+assert_not_contains_literal "$out" "bestmove (none)"
 
-out=$(run_cmds "position fen 8/8/8/8/8/8/1k6/K7 w - - 0 1
-go depth 2 searchmoves a1b1 a1a2 a1b2")
-echo "$out" | grep -q "^bestmove a1b2$"
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position fen 8/8/8/8/8/8/1k6/K7 w - - 0 1
+go depth 2 searchmoves a1b1 a1a2 a1b2')
+assert_contains_literal "$out" "bestmove a1b2"
 
-out=$(run_cmds "position fen 8/8/8/8/8/8/1kk5/K7 w - - 0 1 moves a1b2
-d")
-echo "$out" | grep -Fq "Fen: 8/8/8/8/8/8/1kk5/K7 w - - 0 1"
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position fen 8/8/8/8/8/8/1kk5/K7 w - - 0 1 moves a1b2
+d')
+assert_contains_literal "$out" "Fen: 8/8/8/8/8/8/1kk5/K7 w - - 0 1"
 
-out=$(run_cmds "position fen 8/8/8/8/8/8/1kk5/K7 w - - 0 1
-go depth 1")
-echo "$out" | grep -q "^bestmove (none)$"
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position fen 8/8/8/8/8/8/1kk5/K7 w - - 0 1
+go depth 1')
+assert_contains_literal "$out" "bestmove (none)"
 
-out=$(run_cmds "position fen K7/R6q/7r/8/8/8/6Q1/8 b - - 0 1 moves h7h8k
+out=$(run_uci "$ENGINE" "$VARIANTS" "battleotk" <<<'position fen K7/R6q/7r/8/8/8/6Q1/8 b - - 0 1 moves h7h8k
 d
-go perft 1")
-echo "$out" | grep -Fq "Fen: K7/R6q/7r/8/8/8/6Q1/8 b - - 0 1"
-! echo "$out" | grep -q "^h7h8k:"
-echo "$out" | grep -q "^h7g7k: 1$"
+go perft 1')
+assert_contains_literal "$out" "Fen: K7/R6q/7r/8/8/8/6Q1/8 b - - 0 1"
+assert_not_contains "$out" "^h7h8k:"
+assert_contains "$out" "^h7g7k: 1$"
 
 echo "battleotk regression passed"

--- a/tests/dots-and-boxes.sh
+++ b/tests/dots-and-boxes.sh
@@ -1,45 +1,48 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ENGINE="${1:-$ROOT_DIR/src/stockfish}"
-VARIANTS_MAIN="${2:-$ROOT_DIR/src/variants.ini}"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/uci.sh"
+
+ENGINE=$(default_engine "${1:-}")
+VARIANTS_MAIN=$(default_variants "${2:-}")
 VARIANTS_INCOMPLETE="${3:-$ROOT_DIR/src/variants-incomplete.ini}"
 ENGINE_LARGE="${4:-$ROOT_DIR/src/stockfish-large}"
 ENGINE_VLB="${5:-$ROOT_DIR/src/stockfish-vlb}"
 
-run_cmds() {
-  local variants="$1"
-  local variant="$2"
-  local cmds="$3"
-  printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\n%s\nquit\n' \
-    "$variants" "$variant" "$cmds" | "$ENGINE"
-}
-
 echo "dots and boxes regression started"
 
-out=$(run_cmds "$VARIANTS_INCOMPLETE" dots-boxes-2x2 \
-  "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 12" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANTS_INCOMPLETE" dots-boxes-2x2 <<'EOF'
+position startpos
+go perft 1
+EOF
+)
+assert_nodes "$out" 12
 
-out=$(run_cmds "$VARIANTS_MAIN" dots-boxes-7x7 \
-  "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 24" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANTS_MAIN" dots-boxes-7x7 <<'EOF'
+position startpos
+go perft 1
+EOF
+)
+assert_nodes "$out" 24
 
 if [[ -x "${ENGINE_LARGE}" ]]; then
-  out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nposition startpos\ngo perft 1\nquit\n' \
-    "$VARIANTS_MAIN" "dots-boxes-9x9" | "$ENGINE_LARGE")
-  echo "$out" | grep -q "info string variant dots-boxes-9x9 "
-  grep -Fxq "Nodes searched: 40" <<<"$out"
+  out=$(run_uci "$ENGINE_LARGE" "$VARIANTS_MAIN" dots-boxes-9x9 <<'EOF'
+position startpos
+go perft 1
+EOF
+)
+  assert_contains_literal "$out" "info string variant dots-boxes-9x9 "
+  assert_nodes "$out" 40
 fi
 
 if [[ -x "${ENGINE_VLB}" ]]; then
-  out=$(printf 'uci\nsetoption name VariantPath value %s\nsetoption name UCI_Variant value %s\nposition startpos\ngo perft 1\nquit\n' \
-    "$VARIANTS_MAIN" "dots-boxes-15x15" | "$ENGINE_VLB")
-  echo "$out" | grep -q "info string variant dots-boxes-15x15 "
-  grep -Fxq "Nodes searched: 112" <<<"$out"
+  out=$(run_uci "$ENGINE_VLB" "$VARIANTS_MAIN" dots-boxes-15x15 <<'EOF'
+position startpos
+go perft 1
+EOF
+)
+  assert_contains_literal "$out" "info string variant dots-boxes-15x15 "
+  assert_nodes "$out" 112
 fi
 
 ROOT_DIR="$ROOT_DIR" python3 - <<'PY'

--- a/tests/gating-regressions.sh
+++ b/tests/gating-regressions.sh
@@ -8,18 +8,9 @@ error() {
 }
 trap 'error ${LINENO}' ERR
 
-ENGINE=${1:-./stockfish}
+source "$(dirname "${BASH_SOURCE[0]}")/lib/uci.sh"
 
-run_cmds() {
-  local ini=$1
-  local cmds=$2
-  cat <<EOF | "${ENGINE}"
-uci
-setoption name VariantPath value ${ini}
-${cmds}
-quit
-EOF
-}
+ENGINE=$(default_engine "${1:-}")
 
 TMP_INI=$(mktemp)
 trap 'rm -f "${TMP_INI}"' EXIT
@@ -36,23 +27,20 @@ symmetricDropTypes = r
 EOF
 
 # Legal gating move: the gated knight on e1 should block the rook line to h1.
-out=$(run_cmds "${TMP_INI}" "setoption name UCI_Variant value gatingblock
-position fen 8/8/8/8/8/8/8/R3K2k[N] w KQBCDEFGH - 0 1 moves e1e2n
-d")
-echo "${out}" | grep -q "Fen: 8/8/8/8/8/8/4K3/R3N2k\\[\\] b - - 1 1"
-echo "${out}" | grep -q "^Checkers: *$"
+out=$(run_uci "$ENGINE" "${TMP_INI}" "gatingblock" <<<'position fen 8/8/8/8/8/8/8/R3K2k[N] w KQBCDEFGH - 0 1 moves e1e2n
+d')
+assert_contains "$out" "Fen: 8/8/8/8/8/8/4K3/R3N2k\\[\\] b - - 1 1"
+assert_contains "$out" "^Checkers: *$"
 
 # Symmetric gating must not generate a move that drops onto the mover's destination.
-out=$(run_cmds "${TMP_INI}" "setoption name UCI_Variant value symgating
-position fen 4k3/8/8/8/8/8/8/4K3[RR] w ABCDEFGH - 0 1
-go perft 1")
-echo "${out}" | grep -q "^e1d1: 1$"
-! echo "${out}" | grep -q "^e1d1r,d1: 1$"
-echo "${out}" | grep -q "^e1e2r,d1: 1$"
-grep -Fxq "Nodes searched: 9" <<<"$out"
+out=$(run_uci "$ENGINE" "${TMP_INI}" "symgating" <<<'position fen 4k3/8/8/8/8/8/8/4K3[RR] w ABCDEFGH - 0 1
+go perft 1')
+assert_contains "$out" "^e1d1: 1$"
+assert_not_contains "$out" "^e1d1r,d1: 1$"
+assert_contains "$out" "^e1e2r,d1: 1$"
+assert_nodes "$out" 9
 
 # A legal symmetric gating move keeps the king and adds both gated rooks.
-out=$(run_cmds "${TMP_INI}" "setoption name UCI_Variant value symgating
-position fen 4k3/8/8/8/8/8/8/4K3[RR] w ABCDEFGH - 0 1 moves e1e2r,d1
-d")
-echo "${out}" | grep -q "Fen: 4k3/8/8/8/8/8/4K3/3RR3\\[\\] b - - 1 1"
+out=$(run_uci "$ENGINE" "${TMP_INI}" "symgating" <<<'position fen 4k3/8/8/8/8/8/8/4K3[RR] w ABCDEFGH - 0 1 moves e1e2r,d1
+d')
+assert_contains "$out" "Fen: 4k3/8/8/8/8/8/4K3/3RR3\\[\\] b - - 1 1"

--- a/tests/hex-chess-variants.sh
+++ b/tests/hex-chess-variants.sh
@@ -8,24 +8,23 @@ error() {
 }
 trap 'error ${LINENO}' ERR
 
-ENGINE=${1:-src/stockfish-vlb}
-VARIANT_PATH=${2:-src/variants.ini}
+source "$(dirname "${BASH_SOURCE[0]}")/lib/uci.sh"
 
-run_cmds() {
-  cat <<EOF | "${ENGINE}"
-uci
-setoption name VariantPath value ${VARIANT_PATH}
-$1
-quit
-EOF
-}
+ENGINE="${1:-}"
+if [[ -z "${ENGINE}" ]]; then
+  if [[ -x "${ROOT_DIR}/src/stockfish-vlb" ]]; then
+    ENGINE="${ROOT_DIR}/src/stockfish-vlb"
+  else
+    ENGINE=$(default_engine)
+  fi
+fi
+VARIANT_PATH=$(default_variants "${2:-}")
 
 variant_available() {
   local v="$1"
   local out
-  out=$(run_cmds "setoption name UCI_Variant value ${v}
-d")
-  echo "${out}" | grep -q "info string variant ${v} "
+  out=$(run_uci "$ENGINE" "$VARIANT_PATH" "$v" <<<'d')
+  grep -Fq "info string variant ${v} " <<<"${out}"
 }
 
 if ! variant_available "minihexchess" \
@@ -40,89 +39,80 @@ if ! variant_available "minihexchess" \
   exit 0
 fi
 
-out=$(run_cmds "setoption name UCI_Variant value minihexchess
-position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 11" <<<"$out"
-dump_out=$(run_cmds "setoption name UCI_Variant value minihexchess
-d")
-echo "${dump_out}" | grep -q "startpos \\*\\*\\*1prb/\\*\\*2pkn/\\*3ppp/7/PPP3\\*/NKP2\\*\\*/BRP1\\*\\*\\* w - - 0 1"
-echo "${out}" | grep -q "^a2d3: 1$"
-echo "${out}" | grep -q "^a2b5: 1$"
-echo "${out}" | grep -q "^c1d2: 1$"
-echo "${out}" | grep -q "^a3b4: 1$"
-echo "${out}" | grep -q "^c3d4: 1$"
-echo "${out}" | grep -q "^b2d3: 1$"
-echo "${out}" | grep -q "^b2c4: 1$"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "minihexchess" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 11
+dump_out=$(run_uci "$ENGINE" "$VARIANT_PATH" "minihexchess" <<<'d')
+assert_contains_literal "$dump_out" "startpos ***1prb/**2pkn/*3ppp/7/PPP3*/NKP2**/BRP1*** w - - 0 1"
+assert_contains "$out" "^a2d3: 1$"
+assert_contains "$out" "^a2b5: 1$"
+assert_contains "$out" "^c1d2: 1$"
+assert_contains "$out" "^a3b4: 1$"
+assert_contains "$out" "^c3d4: 1$"
+assert_contains "$out" "^b2d3: 1$"
+assert_contains "$out" "^b2c4: 1$"
 
-out=$(run_cmds "setoption name UCI_Variant value glinski-chess
-position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 48" <<<"$out"
-echo "${out}" | grep -q "^d1d2: 1$"
-echo "${out}" | grep -q "^a4b4: 1$"
-echo "${out}" | grep -q "^a1c2: 1$"
-echo "${out}" | grep -q "^a5b6: 1$"
-echo "${out}" | grep -q "^b1d2: 1$"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "glinski-chess" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 40
+assert_contains "$out" "^d1d2: 1$"
+assert_contains "$out" "^a4b4: 1$"
+assert_contains "$out" "^a1c2: 1$"
+assert_contains "$out" "^a5b6: 1$"
+assert_contains "$out" "^b1d2: 1$"
 
-out=$(run_cmds "setoption name UCI_Variant value glinski-chess-3shift
-position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 44" <<<"$out"
-echo "${out}" | grep -q "^a2b3: 1$"
-echo "${out}" | grep -q "^a2b4: 1$"
-echo "${out}" | grep -q "^b1c2: 1$"
-echo "${out}" | grep -q "^b1d2: 1$"
-echo "${out}" | grep -q "^c5d6: 1$"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "glinski-chess-3shift" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 35
+assert_contains "$out" "^a2b3: 1$"
+assert_contains "$out" "^a2b4: 1$"
+assert_contains "$out" "^b1c2: 1$"
+assert_contains "$out" "^b1d2: 1$"
+assert_contains "$out" "^c5d6: 1$"
 
-out=$(run_cmds "setoption name UCI_Variant value glinski-chess-5shift
-position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 46" <<<"$out"
-echo "${out}" | grep -q "^a2b3: 1$"
-echo "${out}" | grep -q "^b1c2: 1$"
-echo "${out}" | grep -q "^a5b6: 1$"
-echo "${out}" | grep -q "^b4c5: 1$"
-echo "${out}" | grep -q "^d2e3: 1$"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "glinski-chess-5shift" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 37
+assert_contains "$out" "^a2b3: 1$"
+assert_contains "$out" "^b1c2: 1$"
+assert_contains "$out" "^a5b6: 1$"
+assert_contains "$out" "^b4c5: 1$"
+assert_contains "$out" "^d2e3: 1$"
 
-out=$(run_cmds "setoption name UCI_Variant value van-gennip-hexchess
-position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 36" <<<"$out"
-echo "${out}" | grep -q "^a2b3: 1$"
-echo "${out}" | grep -q "^c2a4: 1$"
-echo "${out}" | grep -q "^c3d4: 1$"
-echo "${out}" | grep -q "^d3e4: 1$"
-echo "${out}" | grep -q "^c2b3: 1$"
-echo "${out}" | grep -q "^e2g3: 1$"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "van-gennip-hexchess" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 29
+assert_contains "$out" "^a2b3: 1$"
+assert_contains "$out" "^c2a4: 1$"
+assert_contains "$out" "^c3d4: 1$"
+assert_contains "$out" "^d3e4: 1$"
+assert_contains "$out" "^c2b3: 1$"
+assert_contains "$out" "^e2g3: 1$"
 
-out=$(run_cmds "setoption name UCI_Variant value van-gennip-small-hexchess
-position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 29" <<<"$out"
-echo "${out}" | grep -q "^c2b3: 1$"
-echo "${out}" | grep -q "^a2b3: 1$"
-echo "${out}" | grep -q "^g2h3: 1$"
-echo "${out}" | grep -q "^c3d4: 1$"
-echo "${out}" | grep -q "^f3g4: 1$"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "van-gennip-small-hexchess" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 29
+assert_contains "$out" "^c2b3: 1$"
+assert_contains "$out" "^a2b3: 1$"
+assert_contains "$out" "^g2h3: 1$"
+assert_contains "$out" "^c3d4: 1$"
+assert_contains "$out" "^f3g4: 1$"
 
-out=$(run_cmds "setoption name UCI_Variant value mccooey-chess
-position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 31" <<<"$out"
-echo "${out}" | grep -q "^c3e4: 1$"
-echo "${out}" | grep -q "^c2e1: 1$"
-echo "${out}" | grep -q "^a4b5: 1$"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "mccooey-chess" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 25
+assert_contains "$out" "^c3e4: 1$"
+assert_contains "$out" "^c2e1: 1$"
+assert_contains "$out" "^a4b5: 1$"
 
-out=$(run_cmds "setoption name UCI_Variant value grand-hexachess
-position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 125" <<<"$out"
-echo "${out}" | grep -q "^i13g12: 1$"
-echo "${out}" | grep -q "^a5a6: 1$"
-echo "${out}" | grep -q "^k5k6: 1$"
-echo "${out}" | grep -q "^c3d4: 1$"
-echo "${out}" | grep -q "^e11f10: 1$"
-echo "${out}" | grep -q "^j13k12: 1$"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "grand-hexachess" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 125
+assert_contains "$out" "^i13g12: 1$"
+assert_contains "$out" "^a5a6: 1$"
+assert_contains "$out" "^k5k6: 1$"
+assert_contains "$out" "^c3d4: 1$"
+assert_contains "$out" "^e11f10: 1$"
+assert_contains "$out" "^j13k12: 1$"
 
 echo "hex chess variants regression passed"

--- a/tests/hex-connection-variants.sh
+++ b/tests/hex-connection-variants.sh
@@ -7,34 +7,23 @@ error() {
 }
 trap 'error ${LINENO}' ERR
 
+source "$(dirname "${BASH_SOURCE[0]}")/lib/uci.sh"
+
 ENGINE="${1:-}"
 if [[ -z "${ENGINE}" ]]; then
-  if [[ -x "src/stockfish-vlb" ]]; then
-    ENGINE="src/stockfish-vlb"
-  elif [[ -x "./src/stockfish-vlb" ]]; then
-    ENGINE="./src/stockfish-vlb"
+  if [[ -x "${ROOT_DIR}/src/stockfish-vlb" ]]; then
+    ENGINE="${ROOT_DIR}/src/stockfish-vlb"
   else
-    ENGINE="./src/stockfish"
+    ENGINE=$(default_engine)
   fi
 fi
-SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-VARIANT_PATH="${2:-${SCRIPT_DIR}/../src/variants.ini}"
-
-run_cmds() {
-  cat <<EOF | "${ENGINE}"
-uci
-setoption name VariantPath value ${VARIANT_PATH}
-setoption name UCI_Variant value $1
-$2
-quit
-EOF
-}
+VARIANT_PATH=$(default_variants "${2:-}")
 
 variant_available() {
   local v="$1"
   local out
-  out=$(run_cmds "${v}" "d")
-  echo "${out}" | grep -q "info string variant ${v} "
+  out=$(run_uci "$ENGINE" "$VARIANT_PATH" "$v" <<<'d')
+  grep -Fq "info string variant ${v} " <<<"${out}"
 }
 
 if ! variant_available "hex"; then
@@ -42,45 +31,45 @@ if ! variant_available "hex"; then
   exit 1
 fi
 
-out=$(run_cmds "hex" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 121" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "hex" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 121
 
-out=$(run_cmds "hex-7x7" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 49" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "hex-7x7" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 49
 
-out=$(run_cmds "hex-10x10" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 100" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "hex-10x10" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 100
 
-out=$(run_cmds "hex-16x16" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 256" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "hex-16x16" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 256
 
-out=$(run_cmds "esa-hex" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 100" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "esa-hex" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 100
 
-out=$(run_cmds "esa-hex" "position startpos moves P@a1
-go perft 1")
-echo "${out}" | grep -q "^0000: 1$"
-grep -Fxq "Nodes searched: 1" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "esa-hex" <<<'position startpos moves P@a1
+go perft 1')
+assert_contains "$out" "^0000: 1$"
+assert_nodes "$out" 1
 
-out=$(run_cmds "esa-hex" "position startpos moves P@a1 0000 p@b1 0000
-go perft 1")
-grep -Fxq "Nodes searched: 99" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "esa-hex" <<<'position startpos moves P@a1 0000 p@b1 0000
+go perft 1')
+assert_nodes "$out" 99
 
-out=$(run_cmds "hex" "position fen 11/11/11/11/11/11/11/11/11/11/PPPPPPPPPPP b - - 0 1
-go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "hex" <<<'position fen 11/11/11/11/11/11/11/11/11/11/PPPPPPPPPPP b - - 0 1
+go perft 1')
+assert_nodes "$out" 0
 
-out=$(run_cmds "misere-hex" "position fen 11/11/11/11/11/11/11/11/11/11/PPPPPPPPPPP[P] b - - 0 1
-go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "misere-hex" <<<'position fen 11/11/11/11/11/11/11/11/11/11/PPPPPPPPPPP[P] b - - 0 1
+go perft 1')
+assert_nodes "$out" 0
 
-out=$(run_cmds "y" "position startpos
-go perft 1")
-grep -Fxq "Nodes searched: 55" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANT_PATH" "y" <<<'position startpos
+go perft 1')
+assert_nodes "$out" 55
 
 echo "hex connection variants regression passed"

--- a/tests/qubic.sh
+++ b/tests/qubic.sh
@@ -1,18 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENGINE=${1:-./stockfish}
-VARIANTS=${2:-src/variants.ini}
+source "$(dirname "${BASH_SOURCE[0]}")/lib/uci.sh"
 
-run_cmds() {
-  printf 'uci\nsetoption name VariantPath value %s\n%s\nquit\n' "$VARIANTS" "$1" | "$ENGINE"
-}
+ENGINE=$(default_engine "${1:-}")
+VARIANTS=$(default_variants "${2:-}")
 
 variant_available() {
   local out
-  out=$(run_cmds "setoption name UCI_Variant value qubic
-d")
-  echo "$out" | grep -q "info string variant qubic "
+  out=$(run_uci "$ENGINE" "$VARIANTS" qubic <<<'d')
+  grep -Fq "info string variant qubic " <<<"$out"
 }
 
 echo "qubic regression tests started"
@@ -22,24 +19,20 @@ if ! variant_available; then
   exit 0
 fi
 
-out=$(run_cmds "setoption name UCI_Variant value qubic
-position fen 8/8/8/8/8/8/8/8[pppppppppppppppppppppppppppppppp] b - - 0 1
-go perft 1")
-grep -Fxq "Nodes searched: 64" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANTS" qubic <<<'position fen 8/8/8/8/8/8/8/8[pppppppppppppppppppppppppppppppp] b - - 0 1
+go perft 1')
+assert_nodes "$out" 64
 
-out=$(run_cmds "setoption name UCI_Variant value qubic
-position fen 8/8/8/P3P3/8/8/8/P3P3[pppppppppppppppppppppppppppp] b - - 0 1
-go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANTS" qubic <<<'position fen 8/8/8/P3P3/8/8/8/P3P3[pppppppppppppppppppppppppppp] b - - 0 1
+go perft 1')
+assert_nodes "$out" 0
 
-out=$(run_cmds "setoption name UCI_Variant value qubic
-position fen 8/8/8/8/8/8/8/P7[ppppppppppppppppppppppppppppppp] b - - 0 1
-go perft 1")
-grep -Fxq "Nodes searched: 63" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANTS" qubic <<<'position fen 8/8/8/8/8/8/8/P7[ppppppppppppppppppppppppppppppp] b - - 0 1
+go perft 1')
+assert_nodes "$out" 63
 
-out=$(run_cmds "setoption name UCI_Variant value qubic
-position fen 7P/2P5/8/8/8/8/5P2/P7[pppppppppppppppppppppppppppp] b - - 0 1
-go perft 1")
-grep -Fxq "Nodes searched: 0" <<<"$out"
+out=$(run_uci "$ENGINE" "$VARIANTS" qubic <<<'position fen 7P/2P5/8/8/8/8/5P2/P7[pppppppppppppppppppppppppppp] b - - 0 1
+go perft 1')
+assert_nodes "$out" 0
 
 echo "qubic regression tests passed"


### PR DESCRIPTION
This PR cleans up the test harness by migrating 6 regression test scripts to use the shared `tests/lib/uci.sh` library:
- `tests/dots-and-boxes.sh`
- `tests/qubic.sh`
- `tests/hex-connection-variants.sh`
- `tests/hex-chess-variants.sh`
- `tests/battleotk.sh`
- `tests/gating-regressions.sh`

It also fixes a critical core bug in move generation for VLB (`VERY_LARGE_BOARDS`) builds where evaluating legality compared the custom 256-bit `Bitboard` structure to `0` instead of `Bitboard(0)`. This caused implicit conversion to a 64-bit integer, only checking the lowest 64-bits and letting the king walk into or remain in illegal check states.

The perft baselines for affected VLB hex chess variants have been corrected to match the correct move counts:
- `glinski-chess`: 40 (was 48)
- `glinski-chess-3shift`: 35 (was 44)
- `glinski-chess-5shift`: 37 (was 46)
- `van-gennip-hexchess`: 29 (was 36)
- `mccooey-chess`: 25 (was 31)

All syntax, direct test runs, and fast-regression checks pass successfully.