### PR TITLE
Add destructors to PieceMap, VariantMap, and ThreadPool for clean resource lifecycle

### DIFF
--- a/src/piece.h
+++ b/src/piece.h
@@ -196,6 +196,7 @@ struct PieceMap : public std::map<PieceType, PieceInfo*> {
     direct.fill(nullptr);
     runtimeRiderAugmentTypes = PieceSet(0);
   }
+  ~PieceMap() { clear_all(); }
   void init(const Variant* v = nullptr);
   void add(PieceType pt, PieceInfo* v);
   void clear_all();

--- a/src/thread.h
+++ b/src/thread.h
@@ -123,6 +123,7 @@ struct MainThread : public Thread {
 /// is done through this class.
 
 struct ThreadPool : public std::vector<Thread*> {
+  ~ThreadPool() { set(0); }
 
   void start_thinking(Position&, StateListPtr&, const Search::LimitsType&, bool = false);
   void clear();

--- a/src/variant.h
+++ b/src/variant.h
@@ -584,6 +584,7 @@ struct Variant {
 
 class VariantMap : public std::map<std::string, const Variant*> {
 public:
+  ~VariantMap() { clear_all(); }
   void init();
   template <bool DoCheck> void parse(std::string path);
   template <bool DoCheck> void parse_istream(std::istream& file);


### PR DESCRIPTION
This PR adds destructors to stateful global/collection objects (PieceMap, VariantMap, ThreadPool) to ensure they automatically clean up allocated template memory and join worker threads upon program termination or library unload (e.g. pyffish, ffishdll).