### PR TITLE
Optimize variant parser: remove redundant string trimming

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -62,8 +62,7 @@ namespace {
         return s.substr(first, last - first + 1);
     }
 
-    std::string read_piece_token(const std::string& value) {
-        std::string s = trim(value);
+    std::string read_piece_token(const std::string& s) {
         if (s.empty() || !Variant::is_piece_id_start(s[0]))
             return "";
         std::string token(1, s[0]);


### PR DESCRIPTION
Optimizes the variant configuration parsing loop in `src/parser.cpp` by updating `read_piece_token` to accept and process an already-trimmed string. This avoids duplicate trimming operations at every step since all calling contexts trim the string beforehand.