### PR TITLE
Fix logic, parsing, and robustness issues in evaluation, PSQT, endgame, and tablebase probing

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -223,11 +223,11 @@ Value Endgame<KPK>::operator()(const Position& pos) const {
 
   // KPK is registered only for literal PAWN material signatures.
   // For non-standard promotion rules, skip bitbase probing and use fallback eval.
-  if (   pos.promotion_zone(us, PAWN) != rank_bb(relative_rank(us, RANK_8, pos.max_rank()))
+  if (   pos.promotion_zone(strongSide, PAWN) != rank_bb(relative_rank(strongSide, RANK_8, pos.max_rank()))
       || pos.max_file() != FILE_H
       || pos.max_rank() != RANK_8
       || RANK_MAX != RANK_8
-      || !(pos.promotion_piece_types(us) & QUEEN))
+      || !(pos.promotion_piece_types(strongSide) & QUEEN))
   {
       Value result = PawnValueEg + Value(rank_of(strongPawn));
       return strongSide == pos.side_to_move() ? result : -result;
@@ -1034,11 +1034,11 @@ ScaleFactor Endgame<KPKP>::operator()(const Position& pos) const {
   // Probe the KPK bitbase with the weakest side's pawn removed. If it's a draw,
   // it's probably at least a draw even with the pawn.
   // KPKP is registered only for literal PAWN material signatures.
-  if (   pos.promotion_zone(us, PAWN) != rank_bb(relative_rank(us, RANK_8, pos.max_rank()))
+  if (   pos.promotion_zone(strongSide, PAWN) != rank_bb(relative_rank(strongSide, RANK_8, pos.max_rank()))
       || pos.max_file() != FILE_H
       || pos.max_rank() != RANK_8
       || RANK_MAX != RANK_8
-      || !(pos.promotion_piece_types(us) & QUEEN))
+      || !(pos.promotion_piece_types(strongSide) & QUEEN))
       return SCALE_FACTOR_NONE;
 
   return Bitbases::probe(strongKing, strongPawn, weakKing, us) ? SCALE_FACTOR_NONE : SCALE_FACTOR_DRAW;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -347,23 +347,17 @@ namespace {
 
 #undef S
 
-  // Map promotion distance on arbitrary board heights into the 8x8-tuned
-  // PassedRank buckets, preserving exact mapping on 8x8.
-  inline int scaled_passed_rank_bucket(int distanceToPromo, Rank maxRank) {
-    int maxDistance = int(maxRank);
-    int clamped = std::clamp(distanceToPromo, 0, maxDistance);
-    return maxDistance > 0
-         ? (int(RANK_8) * (maxDistance - clamped) + maxDistance / 2) / maxDistance
-         : 0;
-  }
-
   inline int passed_rank_bucket(const Position& pos, Color c, Square s) {
     Square promo = pos.promotion_square(c, s);
     if (promo == SQ_NONE)
       return 0;
 
     int distanceToPromo = relative_rank(c, promo, pos.max_rank()) - relative_rank(c, s, pos.max_rank());
-    return scaled_passed_rank_bucket(distanceToPromo, pos.max_rank());
+    int maxDistance = int(pos.max_rank());
+    int clamped = std::clamp(distanceToPromo, 0, maxDistance);
+    return maxDistance > 0
+         ? (int(RANK_8) * (maxDistance - clamped) + maxDistance / 2) / maxDistance
+         : 0;
   }
 
   inline Score mobility_bonus(PieceType pt, int mobility) {
@@ -1014,9 +1008,8 @@ namespace {
     int kingFlankAttack  = popcount(b1) + popcount(b2);
     int kingFlankDefense = popcount(b3);
 
-    kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
-                 +       kingAttackersCountInHand[Them] * kingAttackersWeight[Them]
-                 +       kingAttackersCount[Them] * kingAttackersWeightInHand[Them]
+    kingDanger +=        (kingAttackersCount[Them] + kingAttackersCountInHand[Them])
+                       * (kingAttackersWeight[Them] + kingAttackersWeightInHand[Them])
                  + 183 * popcount(kingRing[Us] & (weak | ~pos.board_bb(Us, KING))) * (1 + pos.captures_to_hand() + pos.check_counting())
                  + 148 * popcount(unsafeChecks) * (1 + pos.check_counting())
                  +  98 * popcount(pos.blockers_for_king(Us))
@@ -1051,7 +1044,7 @@ namespace {
     // For drop games, king danger is independent of game phase, but dependent on material density
     if (pos.captures_to_hand() || pos.two_boards())
         score = make_score(mg_value(score) * me->material_density() / 11000,
-                           mg_value(score) * me->material_density() / 11000);
+                           eg_value(score) * me->material_density() / 11000);
 
     if constexpr (T)
         Trace::add(KING, Us, score);
@@ -1812,7 +1805,7 @@ namespace {
         // In every other case use scale factor based on
         // the number of pawns of the strong side reduced if pawns are on a single flank.
         else
-            sf = std::min(sf, 36 + 7 * (pos.count<PAWN>(strongSide) + pos.count<SOLDIER>(strongSide))) - 4 * !pawnsOnBothFlanks;
+            sf = std::min(sf, 36 + 7 * (pos.count<PAWN>(strongSide) + pos.count<SOLDIER>(strongSide)));
 
         // Reduce scale factor in case of pawns being on a single flank
         sf -= 4 * !pawnsOnBothFlanks;

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -310,7 +310,7 @@ void init(const Variant* v) {
       {
           if (std::any_of(pi->steps[0][MODALITY_CAPTURE].begin(), pi->steps[0][MODALITY_CAPTURE].end(), [](const std::pair<const Direction, int>& d) { return dist(d.first) > 1 && !d.second; }))
               score = make_score(mg_value(score) * 4200 / (3500 + mg_value(score)),
-                                 eg_value(score) * 4700 / (3500 + mg_value(score)));
+                                 eg_value(score) * 4700 / (3500 + eg_value(score)));
       }
 
       // Adjust piece values for atomic captures
@@ -352,6 +352,7 @@ void init(const Variant* v) {
 
       // Determine pawn rank
       std::istringstream ss(v->startFen);
+      ss >> std::noskipws;
       unsigned char token;
       Rank rc = v->maxRank;
       Rank pawnRank = RANK_2;

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -214,26 +214,33 @@ public:
         if (fd == -1)
             return *baseAddress = nullptr, nullptr;
 
-        fstat(fd, &statbuf);
+        if (fstat(fd, &statbuf) == -1)
+        {
+            ::close(fd);
+            return *baseAddress = nullptr, nullptr;
+        }
 
         if (statbuf.st_size % 64 != 16)
         {
+            ::close(fd);
             std::cerr << "Corrupt tablebase file " << fname << std::endl;
             exit(EXIT_FAILURE);
         }
 
         *mapping = statbuf.st_size;
         *baseAddress = mmap(nullptr, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
+
+        if (*baseAddress == MAP_FAILED)
+        {
+            ::close(fd);
+            std::cerr << "Could not mmap() " << fname << std::endl;
+            exit(EXIT_FAILURE);
+        }
+
 #if defined(MADV_RANDOM)
         madvise(*baseAddress, statbuf.st_size, MADV_RANDOM);
 #endif
         ::close(fd);
-
-        if (*baseAddress == MAP_FAILED)
-        {
-            std::cerr << "Could not mmap() " << fname << std::endl;
-            exit(EXIT_FAILURE);
-        }
 #else
         // Note FILE_FLAG_RANDOM_ACCESS is only a hint to Windows and as such may get ignored.
         HANDLE fd = CreateFile(fname.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,


### PR DESCRIPTION
This PR resolves 9 correctness, logic, parsing, and error-handling issues:

1. **King Danger Calculation**: Factored in the missing `kingAttackersCountInHand[Them] * kingAttackersWeightInHand[Them]` term so that in-hand attackers are counted correctly even if there are no board attackers.
2. **King Danger Endgame Scaling**: Modified the second argument of `make_score` in drop/two-board variant king evaluation to scale the endgame value of `score` (`eg_value(score)`) instead of duplicating the middlegame value.
3. **Winnable Single-Flank Pawn Penalty**: Removed the duplicate subtraction of `- 4 * !pawnsOnBothFlanks` from the `else` block of `Evaluation::winnable()`.
4. **Makpong Leaper Scaling Denominator**: Changed the denominator of the Makpong leaper scaling endgame value to use `eg_value(score)` instead of `mg_value(score)`.
5. **Pawn-Rank Scan Stream**: Set `ss >> std::noskipws` to ensure that token extraction does not skip spaces and correctly stops at the end of the FEN board field.
6. **KPK/KPKP Promotion Check**: Replaced the side-to-move `us` with `strongSide` (the pawn owner's side) when performing pawn promotion eligibility checks.
7. **Robust fstat Error Handling in tbprobe.cpp**: Checked the return value of `fstat(fd, &statbuf)`. If it fails, `fd` is closed and a clean mapping failure is returned.
8. **Robust mmap/madvise Check Sequence in tbprobe.cpp**: Moved the check for `MAP_FAILED` immediately after `mmap()` and before invoking `madvise()` to prevent undefined behavior on failed mapping.
9. **Premature Abstraction Inlining**: Inlined the private helper `scaled_passed_rank_bucket()` directly into its single caller `passed_rank_bucket()`.

All regression tests pass successfully.