### PR TITLE
Support combined promotion and potion moves in spell chess

### DIFF
--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -258,7 +258,7 @@ inline Disambiguation disambiguation_level(const Position& pos, Move m, Notation
     {
         if (pos.capture(m))
             return FILE_DISAMBIGUATION;
-        if (type_of(m) == PROMOTION && from != to && pos.sittuyin_promotion())
+        if (is_promotion_move(m) && from != to && pos.sittuyin_promotion())
             return SQUARE_DISAMBIGUATION;
     }
 
@@ -358,7 +358,7 @@ inline const std::string move_to_san(Position& pos, Move m, Notation n) {
             san += square(pos, to, n);
 
         // Suffix
-        if (type_of(m) == PROMOTION)
+        if (is_promotion_move(m))
             san += std::string("=") + display_symbol(pos.piece_symbol(make_piece(us, promotion_type(m))));
         else if (type_of(m) == PIECE_PROMOTION)
             san += is_shogi(n) ? std::string("+") : std::string("=") + display_symbol(pos.piece_symbol(make_piece(us, pos.promoted_piece_type(type_of(pos.moved_piece(m))))));

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -1286,14 +1286,16 @@ namespace {
 
   template<GenType Type>
   inline bool try_append_potion_gating_move(const Position& pos, ExtMove*& cur, ExtMove* maxEnd,
-                                            Square from, Square to, MoveType mt,
-                                            PieceType potionPiece, Square gate, int value) {
+                                            Square from, Square to, MoveType mt, Move base,
+                                            Variant::PotionType potion, PieceType potionPiece, Square gate, int value) {
       if (cur >= maxEnd)
           return false;
 
-      Move gatingMove = mt == NORMAL
-                        ? make_gating<NORMAL>(from, to, potionPiece, gate)
-                        : make_gating<CASTLING>(from, to, potionPiece, gate);
+      Move gatingMove = mt == PROMOTION
+                        ? make_promotion_potion(from, to, promotion_type(base), potion, gate)
+                        : (mt == NORMAL
+                            ? make_gating<NORMAL>(from, to, potionPiece, gate)
+                            : make_gating<CASTLING>(from, to, potionPiece, gate));
 
       // Filter by original Type and legality
       bool isCapture = pos.capture_or_promotion(gatingMove);
@@ -1342,12 +1344,12 @@ namespace {
                 {
                     Move base = it->move;
                     MoveType mt = type_of(base);
-                    if (is_gating(base) || (mt != NORMAL && mt != CASTLING))
+                    if (is_gating(base) || (mt != NORMAL && mt != CASTLING && mt != PROMOTION))
                         continue;
                     Square from = from_sq(base);
                     Square to = to_sq(base);
 
-                    if (!try_append_potion_gating_move<Type>(pos, cur, maxEnd, from, to, mt, potionPiece, gate, it->value))
+                    if (!try_append_potion_gating_move<Type>(pos, cur, maxEnd, from, to, mt, base, potion, potionPiece, gate, it->value))
                         return maxEnd;
                 }
             }
@@ -1383,7 +1385,7 @@ namespace {
                     continue;
 
                 MoveType mt = type_of(base);
-                if (mt != NORMAL && mt != CASTLING)
+                if (mt != NORMAL && mt != CASTLING && mt != PROMOTION)
                     continue;
 
                 Square from = from_sq(base);
@@ -1395,7 +1397,7 @@ namespace {
 
                 PieceType moverType = type_of(mover);
                 // Pure leapers cannot have an intermediate path square.
-                if (mt == NORMAL
+                if ((mt == NORMAL || mt == PROMOTION)
                     && AttackRiderTypes[moverType] == NO_RIDER
                     && moverType != PAWN
                     && moverType != SHOGI_PAWN
@@ -1414,7 +1416,7 @@ namespace {
                 if (to == gate)
                     continue;
 
-                if (!try_append_potion_gating_move<Type>(pos, cur, maxEnd, from, to, mt, potionPiece, gate, it->value))
+                if (!try_append_potion_gating_move<Type>(pos, cur, maxEnd, from, to, mt, base, potion, potionPiece, gate, it->value))
                     return maxEnd;
             }
         }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -4770,15 +4770,18 @@ bool Position::gives_check(Move m) const {
 
 PotionContext Position::setup_potion_context(Move m, Color us) const {
     PotionContext pc;
-    if (is_gating(m) && gating_type(m) != NO_PIECE_TYPE)
+    bool hasPotion = (is_gating(m) && gating_type(m) != NO_PIECE_TYPE) || (type_of(m) == PROMOTION_POTION);
+    if (hasPotion)
     {
-        Square gs = gating_square(m);
+        Square gs = (type_of(m) == PROMOTION_POTION) ? potion_target_square(m) : gating_square(m);
         if (!is_ok(gs))
         {
             pc.valid = false;
             return pc;
         }
-        pc.potion = potion_type_from_piece(var, gating_type(m));
+        pc.potion = (type_of(m) == PROMOTION_POTION)
+                     ? static_cast<Variant::PotionType>(potion_type(m))
+                     : potion_type_from_piece(var, gating_type(m));
         if (pc.potion != Variant::POTION_TYPE_NB)
         {
             if (!can_cast_potion(us, pc.potion))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2956,7 +2956,7 @@ bool Position::legal(Move m) const {
   if (potCtx.jumpRemoved && (square_bb(to) & potCtx.jumpRemoved))
       return false;
 
-  if (from == to && !(is_pass(m) || is_self_destruct(m) || (type_of(m) == PROMOTION && sittuyin_promotion()) || pureWallMove))
+  if (from == to && !(is_pass(m) || is_self_destruct(m) || (is_promotion_move(m) && sittuyin_promotion()) || pureWallMove))
       return false;
 
   if (st->pendingClaimPass)
@@ -3001,7 +3001,7 @@ bool Position::legal(Move m) const {
   PieceType movePt = type_of(moverPiece);
   PieceType finalMovePt = movePt;
 
-  if (type_of(m) == PROMOTION)
+  if (is_promotion_move(m))
       finalMovePt = promotion_type(m);
   else if (type_of(m) == PIECE_PROMOTION)
       finalMovePt = promoted_piece_type(movePt);
@@ -3014,7 +3014,7 @@ bool Position::legal(Move m) const {
 
   if (   !dropMove
       && type_of(m) != CASTLING
-      && type_of(m) != PROMOTION
+      && !is_promotion_move(m)
       && type_of(m) != PIECE_PROMOTION
       && !is_pass(m))
   {
@@ -3030,13 +3030,13 @@ bool Position::legal(Move m) const {
           finalMovePt = moveMorphType;
   }
 
-  if (type_of(m) == PROMOTION && !promotion_allowed(us, promotion_type(m), to))
+  if (is_promotion_move(m) && !promotion_allowed(us, promotion_type(m), to))
       return false;
   if (type_of(m) == PIECE_PROMOTION && (is_promoted(from) || !promotion_allowed(us, promoted_piece_type(type_of(moved_piece(m))))))
       return false;
-  if (rifleShot && (type_of(m) == PROMOTION || type_of(m) == PIECE_PROMOTION))
+  if (rifleShot && (is_promotion_move(m) || type_of(m) == PIECE_PROMOTION))
       return false;
-  if (!dropMove && type_of(m) != PROMOTION && type_of(m) != PIECE_PROMOTION)
+  if (!dropMove && !is_promotion_move(m) && type_of(m) != PIECE_PROMOTION)
   {
       Piece mover = moved_piece(m);
       Bitboard mandatoryZone = mover == NO_PIECE ? Bitboard(0) : mandatory_promotion_zone(mover);
@@ -3096,7 +3096,7 @@ bool Position::legal(Move m) const {
   }
 
   // Illegal checks
-  if (((!checking_permitted() && !allow_checks()) || (sittuyin_promotion() && type_of(m) == PROMOTION) || (!drop_checks() && dropMove)) && gives_check(m))
+  if (((!checking_permitted() && !allow_checks()) || (sittuyin_promotion() && is_promotion_move(m)) || (!drop_checks() && dropMove)) && gives_check(m))
       return false;
 
   // Optional rule: disallow checkmate by drops.
@@ -3721,7 +3721,7 @@ bool Position::legal(Move m) const {
           pseudoRoyals |= kto;
       else if (!rifleShot && is_ok(from) && (pseudoRoyals & from))
           pseudoRoyals ^= square_bb(from) ^ kto;
-      if (type_of(m) == PROMOTION && (pseudo_royal_types() & promotion_type(m)))
+      if (is_promotion_move(m) && (pseudo_royal_types() & promotion_type(m)))
       {
           if (count(sideToMove, promotion_type(m)) >= pseudo_royal_count())
               // increase in count leads to loss of pseudo-royalty
@@ -3756,7 +3756,7 @@ bool Position::legal(Move m) const {
               pseudoRoyalCandidates |= kto;
           else if (!rifleShot && is_ok(from) && (pseudoRoyalCandidates & from))
               pseudoRoyalCandidates ^= square_bb(from) ^ kto;
-          if (type_of(m) == PROMOTION && (pseudo_royal_types() & promotion_type(m)))
+          if (is_promotion_move(m) && (pseudo_royal_types() & promotion_type(m)))
               pseudoRoyalCandidates |= kto;
           bool allCheck = bool(pseudoRoyalCandidates);
           while (allCheck && pseudoRoyalCandidates)
@@ -3974,7 +3974,7 @@ bool Position::legal(Move m) const {
       else if (!rifleShot)
       {
           PieceType finalPt = movePt;
-          if (type_of(m) == PROMOTION)
+          if (is_promotion_move(m))
               finalPt = promotion_type(m);
           else if (type_of(m) == PIECE_PROMOTION)
               finalPt = promoted_piece_type(movePt);
@@ -4163,7 +4163,7 @@ bool Position::pseudo_legal(const Move m) const {
       && !is_pass(m))
       return false;
 
-  if (from == to && !(is_pass(m) || is_self_destruct(m) || (type_of(m) == PROMOTION && sittuyin_promotion()) || pureWallMove))
+  if (from == to && !(is_pass(m) || is_self_destruct(m) || (is_promotion_move(m) && sittuyin_promotion()) || pureWallMove))
       return false;
 
   if (st->pendingClaimPass)
@@ -4177,11 +4177,11 @@ bool Position::pseudo_legal(const Move m) const {
           return false;
   }
 
-  if (type_of(m) == PROMOTION && !promotion_allowed(us, promotion_type(m), to))
+  if (is_promotion_move(m) && !promotion_allowed(us, promotion_type(m), to))
       return false;
   if (type_of(m) == PIECE_PROMOTION && (is_promoted(from) || !promotion_allowed(us, promoted_piece_type(type_of(pc)))))
       return false;
-  if (!dropMove && type_of(m) != PROMOTION && type_of(m) != PIECE_PROMOTION)
+  if (!dropMove && !is_promotion_move(m) && type_of(m) != PIECE_PROMOTION)
   {
       Bitboard mandatoryZone = pc == NO_PIECE ? Bitboard(0) : mandatory_promotion_zone(pc);
       if ((mandatoryZone & effectiveTo) && !(mandatoryZone & from))
@@ -4643,7 +4643,7 @@ bool Position::gives_check(Move m) const {
       return true;
 
   // Is there a direct check?
-  if (type_of(m) != PROMOTION && type_of(m) != PIECE_PROMOTION && type_of(m) != PIECE_DEMOTION && type_of(m) != CASTLING
+  if (!is_promotion_move(m) && type_of(m) != PIECE_PROMOTION && type_of(m) != PIECE_DEMOTION && type_of(m) != CASTLING
       && !((var->petrifyOnCaptureTypes & type_of(mover)) && capture(m)))
   {
       PieceType pt = type_of(mover);
@@ -4729,6 +4729,7 @@ bool Position::gives_check(Move m) const {
       return false;
 
   case PROMOTION:
+  case PROMOTION_POTION:
       return attacks_bb(sideToMove, promotion_type(m), to, pieces() ^ from) & royalSq;
 
   case PIECE_PROMOTION:
@@ -5064,7 +5065,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
 
   if (to == from)
   {
-      assert((type_of(m) == PROMOTION && sittuyin_promotion()) || is_pass(m) || openingSelfRemoval || pureWallMove);
+      assert((is_promotion_move(m) && sittuyin_promotion()) || is_pass(m) || openingSelfRemoval || pureWallMove);
       captured = NO_PIECE;
   }
 
@@ -5424,7 +5425,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
       // - irreversible pawn/piece promotions
       // - irreversible pawn moves
       if (   !pureWallMove
-          && (   type_of(m) == PROMOTION
+          && (   is_promotion_move(m)
           || (type_of(m) == PIECE_PROMOTION && !piece_demotion())
           || (    (var->nMoveRuleTypes.get(us) & piece_set(type_of(pc)))
               && !(PseudoMoves[0][us][type_of(pc)][to] & from))))
@@ -5701,9 +5702,9 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
   if (type_of(pc) == PAWN)
   {
       st->rule50 = 0;
-      if (type_of(m) == PROMOTION || type_of(m) == PIECE_PROMOTION)
+      if (is_promotion_move(m) || type_of(m) == PIECE_PROMOTION)
       {
-          Piece promotion = make_piece(us, type_of(m) == PROMOTION ? promotion_type(m) : promoted_piece_type(PAWN));
+          Piece promotion = make_piece(us, is_promotion_move(m) ? promotion_type(m) : promoted_piece_type(PAWN));
           Piece promotedHandPiece = make_piece(us, type_of(promotion));
 
           assert((promotion_zone(pc) & to) || sittuyin_promotion());
@@ -5713,7 +5714,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
           remove_piece(to);
           // Preserve exact source piece for variants with multiple promotion pawn types.
           put_piece(promotion, to, true, pc);
-          if (prison_pawn_promotion() && type_of(m) == PROMOTION) {
+          if (prison_pawn_promotion() && is_promotion_move(m)) {
               int addedN = add_to_prison(st->promotionPawn);
               int removedN = remove_from_prison(promotion);
               // Keep prison inventory hash in sync with promotion swap.
@@ -5818,9 +5819,9 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
       // Update pawn hash key
       st->pawnKey ^= (!dropMove ? Zobrist::psq[pc][from] : 0) ^ Zobrist::psq[pc][to];
   }
-  else if (type_of(m) == PROMOTION || type_of(m) == PIECE_PROMOTION)
+  else if (is_promotion_move(m) || type_of(m) == PIECE_PROMOTION)
   {
-      Piece promotion = make_piece(us, type_of(m) == PROMOTION ? promotion_type(m) : promoted_piece_type(type_of(pc)));
+      Piece promotion = make_piece(us, is_promotion_move(m) ? promotion_type(m) : promoted_piece_type(type_of(pc)));
       Piece promotedHandPiece = make_piece(us, type_of(promotion));
 
       st->promotionPawn = piece_on(to);
@@ -5947,7 +5948,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
       && captured != NO_PIECE
       && !dropMove
       && type_of(m) != CASTLING
-      && type_of(m) != PROMOTION
+      && !is_promotion_move(m)
       && type_of(m) != PIECE_PROMOTION
       && !is_pass(m))
   {
@@ -5960,7 +5961,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
 
   if (   !dropMove
       && type_of(m) != CASTLING
-      && type_of(m) != PROMOTION
+      && !is_promotion_move(m)
       && type_of(m) != PIECE_PROMOTION
       && !is_pass(m))
   {
@@ -6507,7 +6508,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
                                     : false;
           st->forcedJumpStep = st->previous->forcedJumpStep;
       }
-      else if (jumpCapsq != SQ_NONE && type_of(m) != PROMOTION && type_of(m) != PIECE_PROMOTION
+      else if (jumpCapsq != SQ_NONE && !is_promotion_move(m) && type_of(m) != PIECE_PROMOTION
             && piece_on(moverSq) != NO_PIECE
             && color_of(piece_on(moverSq)) == us)
       {
@@ -6606,7 +6607,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
           st->countingPly = 2 * count<ALL_PIECES>() - 1;
       }
 
-      if ((!st->countingLimit || ((captured || type_of(m) == PROMOTION) && count<ALL_PIECES>(sideToMove) == 1)) && count_limit(sideToMove))
+      if ((!st->countingLimit || ((captured || is_promotion_move(m)) && count<ALL_PIECES>(sideToMove) == 1)) && count_limit(sideToMove))
       {
           st->countingLimit = 2 * count_limit(sideToMove);
           st->countingPly = counting_rule() == ASEAN_COUNTING || count<ALL_PIECES>(sideToMove) > 1 ? 0 : 2 * count<ALL_PIECES>();
@@ -6690,7 +6691,7 @@ void Position::undo_move(Move m) {
                             && !st->pass;
 
   assert(is_drop_move(m) || empty(from) || type_of(m) == CASTLING || is_gating(m)
-         || (type_of(m) == PROMOTION && sittuyin_promotion())
+         || (is_promotion_move(m) && sittuyin_promotion())
          || is_pass(m)
          || pullMove
          || swapMove
@@ -6823,7 +6824,7 @@ void Position::undo_move(Move m) {
       commit_piece(make_piece(color_of(st->captured.piece), st->capturedGatingType), file_of(to));
   }
 
-  if (type_of(m) == PROMOTION)
+  if (is_promotion_move(m))
   {
       assert((promotion_zone(st->promotionPawn) & to) || sittuyin_promotion());
       Piece promotedPiece = piece_on(moverSq);
@@ -6888,7 +6889,7 @@ void Position::undo_move(Move m) {
               put_piece(st->dead.piece, from, st->dead.promoted, st->dead.unpromoted);
               pc = piece_on(from);
           }
-          else if (st->dead.piece && type_of(m) != PROMOTION && type_of(m) != PIECE_PROMOTION)
+          else if (st->dead.piece && !is_promotion_move(m) && type_of(m) != PIECE_PROMOTION)
           {
               if (st->deadSquares & moverSq)
               {
@@ -7589,7 +7590,7 @@ bool Position::is_optional_game_end(Value& result, int ply, int countStarted) co
   {
       bool promotionsOnly = true;
       for (const auto& m : MoveList<LEGAL>(*this))
-          if (type_of(m) != PROMOTION)
+          if (!is_promotion_move(m))
           {
               promotionsOnly = false;
               break;

--- a/src/position.h
+++ b/src/position.h
@@ -4216,7 +4216,7 @@ inline bool Position::is_chess960() const {
 
 inline bool Position::capture_or_promotion(Move m) const {
   assert(is_ok(m));
-  return type_of(m) == PROMOTION || capture(m);
+  return is_promotion_move(m) || capture(m);
 }
 inline Position::HopperMoveDetails Position::resolve_hopper_move_details(Square from, Square to, Bitboard occupied) const {
   assert(is_ok(from));
@@ -4532,7 +4532,7 @@ inline Bitboard Position::universal_hopper_potential_bb(PieceType pt, Square s) 
 
 inline bool Position::is_jump_capture(Move m) const {
   assert(is_ok(m));
-  return (type_of(m) == NORMAL || type_of(m) == PROMOTION) && jump_capture_square(from_sq(m), to_sq(m)) != SQ_NONE;
+  return (type_of(m) == NORMAL || is_promotion_move(m)) && jump_capture_square(from_sq(m), to_sq(m)) != SQ_NONE;
 }
 
 inline bool Position::capture(Move m) const {
@@ -4548,7 +4548,7 @@ inline bool Position::capture(Move m) const {
   if (analyze_push(m, pushInfo))
       return pushInfo.captures;
 
-  if (type_of(m) == NORMAL || type_of(m) == PROMOTION)
+  if (type_of(m) == NORMAL || is_promotion_move(m))
   {
       Piece mover = moved_piece(m);
       if (mover != NO_PIECE)

--- a/src/types.h
+++ b/src/types.h
@@ -1188,6 +1188,10 @@ inline PieceType promotion_type(Move m) {
   return NO_PIECE_TYPE;
 }
 
+inline bool is_promotion_move(Move m) {
+  return type_of(m) == PROMOTION || type_of(m) == PROMOTION_POTION;
+}
+
 inline Square potion_target_square(Move m) {
   return Square((m >> (2 * SQUARE_BITS + MOVE_TYPE_BITS)) & SQUARE_BIT_MASK);
 }

--- a/src/types.h
+++ b/src/types.h
@@ -554,6 +554,7 @@ enum MoveType : int {
   INSERT             = 9 << (2 * SQUARE_BITS),
   PULL               = 10 << (2 * SQUARE_BITS),
   SWAP               = 11 << (2 * SQUARE_BITS),
+  PROMOTION_POTION   = 12 << (2 * SQUARE_BITS),
 };
 
 constexpr int MOVE_TYPE_BITS = 4;
@@ -1178,7 +1179,21 @@ inline int from_to(Move m) {
 }
 
 inline PieceType promotion_type(Move m) {
-  return type_of(m) == PROMOTION ? PieceType((m >> (2 * SQUARE_BITS + MOVE_TYPE_BITS)) & (PIECE_TYPE_NB - 1)) : NO_PIECE_TYPE;
+  if (type_of(m) == PROMOTION)
+    return PieceType((m >> (2 * SQUARE_BITS + MOVE_TYPE_BITS)) & (PIECE_TYPE_NB - 1));
+  if (type_of(m) == PROMOTION_POTION) {
+    int choice = (m >> (2 * SQUARE_BITS + MOVE_TYPE_BITS + SQUARE_BITS)) & 3;
+    return choice == 0 ? KNIGHT : (choice == 1 ? BISHOP : (choice == 2 ? ROOK : QUEEN));
+  }
+  return NO_PIECE_TYPE;
+}
+
+inline Square potion_target_square(Move m) {
+  return Square((m >> (2 * SQUARE_BITS + MOVE_TYPE_BITS)) & SQUARE_BIT_MASK);
+}
+
+inline int potion_type(Move m) {
+  return (m >> (2 * SQUARE_BITS + MOVE_TYPE_BITS + SQUARE_BITS + 2)) & 1;
 }
 
 inline PieceType gating_type(Move m) {
@@ -1317,6 +1332,20 @@ constexpr Move make_pull(Square from, Square to, Square pullFrom) {
             + static_cast<uint64_t>(to));
 }
 
+constexpr Move make_promotion_potion(Square from, Square to, PieceType prom_pt, int potion, Square target) {
+  uint64_t prom_val = (prom_pt == KNIGHT ? 0 : (prom_pt == BISHOP ? 1 : (prom_pt == ROOK ? 2 : 3)));
+  uint64_t potion_val = static_cast<uint64_t>(potion);
+  uint64_t target_val = static_cast<uint64_t>(target);
+  return Move(
+      (potion_val << (2 * SQUARE_BITS + MOVE_TYPE_BITS + SQUARE_BITS + 2))
+    + (prom_val << (2 * SQUARE_BITS + MOVE_TYPE_BITS + SQUARE_BITS))
+    + (target_val << (2 * SQUARE_BITS + MOVE_TYPE_BITS))
+    + static_cast<uint64_t>(PROMOTION_POTION)
+    + (static_cast<uint64_t>(from) << SQUARE_BITS)
+    + static_cast<uint64_t>(to)
+  );
+}
+
 constexpr PieceType dropped_piece_type(Move m) {
   return PieceType((m >> (2 * SQUARE_BITS + MOVE_TYPE_BITS)) & (PIECE_TYPE_NB - 1));
 }
@@ -1333,7 +1362,8 @@ inline bool is_ok(Move m) {
   return from_sq(m) != to_sq(m)
       || type_of(m) == PROMOTION
       || type_of(m) == SPECIAL
-      || type_of(m) == CASTLING; // Catch MOVE_NULL and MOVE_NONE, allow stationary castling
+      || type_of(m) == CASTLING
+      || type_of(m) == PROMOTION_POTION; // Catch MOVE_NULL and MOVE_NONE, allow stationary castling and promotion/potions
 }
 
 inline int dist(Direction d) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -677,18 +677,34 @@ string UCI::move(const Position& pos, Move m) {
   bool potionMove = false;
   std::string potionPrefix;
 
-  if (pos.potions_enabled() && is_gating(m))
-      for (int idx = 0; idx < Variant::POTION_TYPE_NB; ++idx)
+  if (pos.potions_enabled())
+  {
+      if (type_of(m) == PROMOTION_POTION)
       {
-          PieceType potionPiece = pos.potion_piece(static_cast<Variant::PotionType>(idx));
-          if (!potionMove && potionPiece != NO_PIECE_TYPE
-              && gating_type(m) == potionPiece)
+          Variant::PotionType pot = static_cast<Variant::PotionType>(potion_type(m));
+          PieceType potionPiece = pos.potion_piece(pot);
+          if (potionPiece != NO_PIECE_TYPE)
           {
               potionMove = true;
-              potionPrefix = pos.piece_symbol(make_piece(BLACK, gating_type(m)))
-                             + "@" + UCI::square(pos, gating_square(m));
+              potionPrefix = pos.piece_symbol(make_piece(BLACK, potionPiece))
+                             + "@" + UCI::square(pos, potion_target_square(m));
           }
       }
+      else if (is_gating(m))
+      {
+          for (int idx = 0; idx < Variant::POTION_TYPE_NB; ++idx)
+          {
+              PieceType potionPiece = pos.potion_piece(static_cast<Variant::PotionType>(idx));
+              if (!potionMove && potionPiece != NO_PIECE_TYPE
+                  && gating_type(m) == potionPiece)
+              {
+                  potionMove = true;
+                  potionPrefix = pos.piece_symbol(make_piece(BLACK, gating_type(m)))
+                                 + "@" + UCI::square(pos, gating_square(m));
+              }
+          }
+      }
+  }
 
   if (is_gating(m) && gating_square(m) == to && !potionMove)
       from = to_sq(m), to = from_sq(m);
@@ -710,7 +726,7 @@ string UCI::move(const Position& pos, Move m) {
   if (wallMove && CurrentProtocol == XBOARD)
       move += "," + UCI::square(pos, to) + UCI::square(pos, gating_square(m));
 
-  if (type_of(m) == PROMOTION)
+  if (type_of(m) == PROMOTION || type_of(m) == PROMOTION_POTION)
       move += pos.piece_symbol(make_piece(BLACK, promotion_type(m)));
   else if (type_of(m) == PIECE_PROMOTION)
       move += '+';

--- a/src/xboard.cpp
+++ b/src/xboard.cpp
@@ -182,7 +182,7 @@ namespace XBoard {
         Square from = from_sq(m), to = to_sq(m);
         if (is_ok(from) && UCI::square(pos, from) == square && !is_pass(m))
         {
-            if (type_of(m) == PROMOTION)
+            if (is_promotion_move(m))
                 promotions |= to;
             else if (pos.capture(m))
                 captures |= to;


### PR DESCRIPTION
This PR implements Solution 1 (compact 32-bit bit-packing) to allow casting a potion and promoting a pawn on the same turn, matching the chess.com rules.