### PR TITLE
Fix Spell Chess potions, surround-capture logic, and narrow king fallback

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -1349,6 +1349,18 @@ namespace {
                     Square from = from_sq(base);
                     Square to = to_sq(base);
 
+                    if (gate == to)
+                        continue;
+                    Piece mover = pos.piece_on(from);
+                    if (mover != NO_PIECE)
+                    {
+                        if (pos.freeze_squares() & from)
+                            continue;
+                        PieceType moverType = type_of(mover);
+                        if ((between_bb(from, to, moverType) & ~square_bb(to)) & gate)
+                            continue;
+                    }
+
                     if (!try_append_potion_gating_move<Type>(pos, cur, maxEnd, from, to, mt, base, potion, potionPiece, gate, it->value))
                         return maxEnd;
                 }
@@ -1413,6 +1425,17 @@ namespace {
                     continue;
 
                 Square gate = lsb(intersection);
+
+                bool moveOk = false;
+                {
+                    ScopedSpellContext revalGuard(Bitboard(0), square_bb(gate));
+                    bool isInitial = pos.not_moved_pieces(Us) & from;
+                    Bitboard okSquares = isInitial ? (pos.moves_from<true>(Us, moverType, from) | pos.attacks_from<true>(Us, moverType, from))
+                                                   : (pos.moves_from<false>(Us, moverType, from) | pos.attacks_from<false>(Us, moverType, from));
+                    moveOk = bool(okSquares & to);
+                }
+                if (!moveOk)
+                    continue;
 
                 if (!try_append_potion_gating_move<Type>(pos, cur, maxEnd, from, to, mt, base, potion, potionPiece, gate, it->value))
                     return maxEnd;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -3916,7 +3916,12 @@ bool Position::legal(Move m) const {
       // "cannot castle through attack", with frozen attackers ignored.
       bool spellLikeCastler = type_of(piece_on(from)) != KING && potions_enabled();
       auto attackers_for_castling = [&](Square s, Bitboard occ) {
-          return attackers_to_king(s, occ, ~us) & ~removedAttackers;
+          Bitboard att = spellLikeCastler ? attackers_to(s, occ, ~us)
+                                          : attackers_to_king(s, occ, ~us);
+          att &= ~removedAttackers;
+          if (spellLikeCastler)
+              att &= ~freeze_squares(~us);
+          return att;
       };
 
       if (((!allow_checks()) || spellLikeCastler) && attackers_for_castling(from, pieces()))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2871,6 +2871,67 @@ Bitboard Position::checked_anti_royals(Color c) const {
 }
 
 
+Bitboard Position::compute_surround_capture_mask(Square moverSq, Bitboard usPieces, Bitboard themPieces, Bitboard occupied) const {
+  Bitboard mask = 0;
+  if (!(surround_capture_opposite() || surround_capture_intervene() || surround_capture_edge()))
+      return mask;
+
+  for (int sign : {-1, 1})
+  {
+      for (const Direction& d : var->connectDirections)
+      {
+          Direction mod_d = d * sign;
+          Square s = moverSq + mod_d;
+          if (!is_ok(s) || !(square_bb(s) & themPieces & occupied))
+              continue;
+
+          if (s & surround_capture_max_region())
+          {
+              bool surrounded = true;
+              Bitboard adj = attacks_bb<WAZIR>(s, occupied) & board_bb();
+              while (adj)
+              {
+                  Square s2 = pop_lsb(adj);
+                  if (!((s2 & surround_capture_hostile_region()) || (s2 & usPieces & occupied) || (s2 == moverSq)))
+                  {
+                      surrounded = false;
+                      break;
+                  }
+              }
+              if (surrounded)
+                  mask |= s;
+              else
+                  continue;
+          }
+
+          Square oppSquare = s + mod_d;
+          if (!is_ok(oppSquare))
+          {
+              if (surround_capture_edge())
+                  mask |= s;
+          }
+          else
+          {
+              if (surround_capture_opposite() && ((usPieces & oppSquare & occupied) || (oppSquare == moverSq) || (surround_capture_hostile_region() & oppSquare)))
+                  mask |= s;
+          }
+      }
+  }
+  if (surround_capture_intervene())
+  {
+      for (const Direction& d : var->connectDirections)
+      {
+          Square s1 = moverSq + d;
+          Square s2 = moverSq - d;
+          if (is_ok(s1) && is_ok(s2) && (themPieces & s1 & occupied) && (themPieces & s2 & occupied))
+              mask |= square_bb(s1) | s2;
+      }
+  }
+  return mask;
+}
+
+
+
 /// Position::legal() tests whether a pseudo-legal move is legal
 
 bool Position::legal(Move m) const {
@@ -2919,10 +2980,6 @@ bool Position::legal(Move m) const {
   if (!potCtx.valid)
       return false;
 
-  ScopedSpellContext spellScope(potCtx.freezeExtra, potCtx.jumpRemoved);
-  bool pureWallMove = is_gating(m) && potCtx.potion == Variant::POTION_TYPE_NB
-                   && walling(us) && wall_or_move() && from == to;
-
   if (!dropMove && (freeze_squares() & from))
       return false;
   // Castling is also blocked if the participating rook is frozen.
@@ -2936,9 +2993,14 @@ bool Position::legal(Move m) const {
       if (freeze_squares() & rookFrom)
           return false;
   }
-  if (type_of(m) == CASTLING && gamePly < var->castlingForbiddenPlies)
-      return false;
   if (potCtx.jumpRemoved && (square_bb(to) & potCtx.jumpRemoved))
+      return false;
+
+  ScopedSpellContext spellScope(potCtx.freezeExtra, potCtx.jumpRemoved);
+  bool pureWallMove = is_gating(m) && potCtx.potion == Variant::POTION_TYPE_NB
+                   && walling(us) && wall_or_move() && from == to;
+
+  if (type_of(m) == CASTLING && gamePly < var->castlingForbiddenPlies)
       return false;
 
   if (from == to && !(is_pass(m) || is_self_destruct(m) || (is_promotion_move(m) && sittuyin_promotion()) || pureWallMove))
@@ -3538,51 +3600,10 @@ bool Position::legal(Move m) const {
       // Surround capture
       if (surround_capture_opposite() || surround_capture_intervene() || surround_capture_edge())
       {
-          for (int sign : {-1, 1})
-          {
-              for (const Direction& d : var->connectDirections)
-              {
-                  Direction mod_d = d * sign;
-                  Square s = effectiveTo + mod_d;
-                  if (!is_ok(s) || !(square_bb(s) & pieces(~us) & ~square_bb(shotSq))) continue;
-
-                  if (s & surround_capture_max_region())
-                  {
-                      bool surrounded = true;
-                      Bitboard b = (attacks_bb<WAZIR>(s, postMoveOccupied) & postMoveOccupied) & ~square_bb(from) & pieces(~us);
-                      while(b)
-                      {
-                          Square s2 = pop_lsb(b);
-                          if (!((s2 & surround_capture_hostile_region()) || (s2 & (pieces(us) | effectiveTo))))
-                          {
-                              surrounded = false;
-                              break;
-                          }
-                      }
-                      if (surrounded) { removedByEffects |= s; structuralRemoval |= s; }
-                  }
-
-                  Square oppSquare = s + mod_d;
-                  if (!is_ok(oppSquare))
-                  {
-                      if (surround_capture_edge()) { removedByEffects |= s; structuralRemoval |= s; }
-                  }
-                  else
-                  {
-                      if (surround_capture_opposite() && ((pieces(us) & oppSquare) || (oppSquare == effectiveTo) || (surround_capture_hostile_region() & oppSquare)))
-                          { removedByEffects |= s; structuralRemoval |= s; }
-                  }
-              }
-          }
-          if (surround_capture_intervene())
-          {
-              for (const Direction& d : var->connectDirections)
-              {
-                  Square s1 = effectiveTo + d, s2 = effectiveTo - d;
-                  if (is_ok(s1) && is_ok(s2) && (pieces(~us) & s1) && (pieces(~us) & s2))
-                      { removedByEffects |= square_bb(s1) | s2; structuralRemoval |= square_bb(s1) | s2; }
-              }
-          }
+          Bitboard usPostMove = dropMove ? (pieces(us) | effectiveTo) : (pieces(us) ^ from ^ effectiveTo);
+          Bitboard surroundMask = compute_surround_capture_mask(effectiveTo, usPostMove, (pieces(~us) & ~square_bb(shotSq)), postMoveOccupied);
+          removedByEffects |= surroundMask;
+          structuralRemoval |= surroundMask;
       }
       // Remove connect N
       if (remove_connect_n() > 0)
@@ -3895,12 +3916,7 @@ bool Position::legal(Move m) const {
       // "cannot castle through attack", with frozen attackers ignored.
       bool spellLikeCastler = type_of(piece_on(from)) != KING && potions_enabled();
       auto attackers_for_castling = [&](Square s, Bitboard occ) {
-          Bitboard att = spellLikeCastler ? attackers_to(s, occ, ~us)
-                                          : attackers_to_king(s, occ, ~us);
-          att &= ~removedAttackers;
-          if (spellLikeCastler)
-              att &= ~freeze_squares(~us);
-          return att;
+          return attackers_to_king(s, occ, ~us) & ~removedAttackers;
       };
 
       if (((!allow_checks()) || spellLikeCastler) && attackers_for_castling(from, pieces()))
@@ -4320,8 +4336,6 @@ bool Position::pseudo_legal(const Move m) const {
   if (!potCtx.valid)
       return false;
 
-  ScopedSpellContext spellScope(potCtx.freezeExtra, potCtx.jumpRemoved);
-
   if (!dropMove && (freeze_squares() & from))
       return false;
   if (type_of(m) == CASTLING && gamePly < var->castlingForbiddenPlies)
@@ -4336,6 +4350,8 @@ bool Position::pseudo_legal(const Move m) const {
                                                           : MoveList<NON_EVASIONS>(*this).contains(m))
           && !violates_same_player_board_repetition(m);
   }
+
+  ScopedSpellContext spellScope(potCtx.freezeExtra, potCtx.jumpRemoved);
 
   // Handle the case where a mandatory piece promotion/demotion is not taken
   if (    mandatory_piece_promotion()
@@ -6111,53 +6127,7 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
       //A piece could be immune to blast but not immune to custodial.
 
       if ( surround_capture_opposite() || surround_capture_intervene() || surround_capture_edge() ) {
-          for (int sign : {-1, 1}) {
-
-              for (const Direction& d : var->connectDirections)
-              //using getConnectDirections to determine whether two pieces are connected
-              //in that they can capture a piece between them. if there was a
-              //variant with connection as a victory condition, and different
-              //directions for surround-capture, yes, we'd have to separate them
-              {
-                  Direction mod_d = d * sign;
-                  Square s = moverSq + mod_d;
-                  if (!is_ok(s)) continue;
-                  if (!(s&pieces(~us))) continue;
-                  Square oppSquare = s + mod_d;
-
-                  if (s & surround_capture_max_region()) {
-                      bool surrounded = true;
-                      Bitboard b = attacks_bb(us, WAZIR, s, pieces(~us));
-                      while(b) {
-                          Square s2 = pop_lsb(b);
-                          if (!((s2 & surround_capture_hostile_region()) || (s2 & pieces(us)))) {
-                              surrounded = false;
-                              break;
-                          };
-                      };
-                      if (surrounded) { removal_mask |= s; } else continue;
-                  };
-
-                  if (!is_ok(oppSquare)) {
-                      if (surround_capture_edge()) removal_mask |= s;
-                  }
-                  else {
-                      if (surround_capture_opposite() && ((pieces(us) & oppSquare) || (surround_capture_hostile_region() & oppSquare))) removal_mask |= s;
-                  };
-              };
-          };
-      };
-
-      if (surround_capture_intervene()) {
-          for (const Direction& d : var->connectDirections)
-          {
-              Square s1 = moverSq + d;
-              Square s2 = moverSq - d;
-              if (!is_ok(s1) || !is_ok(s2))
-                  continue;
-              if ((s1 & pieces(~us)) && (s2 & pieces(~us)))
-                  removal_mask |= s1 | s2;
-          }
+          removal_mask |= compute_surround_capture_mask(moverSq, pieces(us), pieces(~us), pieces());
       }
 
       if (pi && pi->has_universal_hopper() && jumpCapsq != SQ_NONE)
@@ -7614,7 +7584,7 @@ bool Position::is_immediate_game_end(Value& result, int ply) const {
   // because st->captured is empty in the reconstructed state.
   if (king_type() != NO_PIECE_TYPE)
       for (Color c : { ~sideToMove, sideToMove })
-          if (!count(c, king_type()) && (allow_checks() || flag_piece(c) == king_type()))
+          if (!count(c, king_type()) && is_actual_runtime_royal(c, king_type()))
           {
               result = c == sideToMove ? mated_in(ply) : mate_in(ply);
               return true;

--- a/src/position.h
+++ b/src/position.h
@@ -327,6 +327,7 @@ public:
   bool surround_capture_edge() const;
   Bitboard surround_capture_max_region() const;
   Bitboard surround_capture_hostile_region() const;
+  Bitboard compute_surround_capture_mask(Square moverSq, Bitboard usPieces, Bitboard themPieces, Bitboard occupied) const;
   EndgameEval endgame_eval() const;
   Bitboard double_step_region(Color c) const;
   Bitboard double_step_region(Color c, PieceType pt) const;
@@ -345,6 +346,7 @@ public:
   PieceSet castling_rook_pieces(Color c) const;
   PieceType king_type() const;
   PieceType royal_piece_type(Color c) const;
+  bool is_actual_runtime_royal(Color c, PieceType pt) const;
   Square royal_square(Color c) const;
   PieceType nnue_king() const;
   Square nnue_king_square(Color c) const;
@@ -1323,6 +1325,12 @@ inline PieceType Position::royal_piece_type(Color c) const {
       return pt;
   // Fallback: no uniquely identifiable royal found for this side.
   return NO_PIECE_TYPE;
+}
+
+inline bool Position::is_actual_runtime_royal(Color c, PieceType pt) const {
+  if (pt == NO_PIECE_TYPE)
+      return false;
+  return pt == royal_piece_type(c) || allow_checks() || flag_piece(c) == pt;
 }
 
 inline Square Position::royal_square(Color c) const {

--- a/tests/fast-regression.sh
+++ b/tests/fast-regression.sh
@@ -71,6 +71,7 @@ run_step "universal hopper" timeout 90s bash tests/universal-hopper.sh "${ENGINE
 run_step "gating check regressions" timeout 60s bash tests/gating-check-regression.sh "${ENGINE}"
 run_step "binding regression" timeout 60s "${PYTHON}" tests/test_binding_regression.py
 run_step "royal capture no kings" timeout 60s "${PYTHON}" tests/test_royal_capture_no_kings.py
+run_step "potion custom" timeout 60s bash tests/potion-custom.sh "${ENGINE}"
 if [[ -n "${UPSTREAM_ENGINE:-}" ]]; then
   run_step "upstream movecount baseline" timeout 60s "${PYTHON}" tests/upstream_movecount_baseline.py "${ENGINE}" "${UPSTREAM_ENGINE}"
 else

--- a/tests/potion-custom.sh
+++ b/tests/potion-custom.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+error() {
+  echo "potion custom test failed on line $1"
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+ENGINE=${1:-./stockfish}
+DEFAULT_VARIANT_PATH="variants.ini"
+if [[ ! -f "${DEFAULT_VARIANT_PATH}" && -f "src/variants.ini" ]]; then
+  DEFAULT_VARIANT_PATH="src/variants.ini"
+fi
+VARIANT_PATH=${2:-${DEFAULT_VARIANT_PATH}}
+
+run_cmds() {
+  cat <<CMDS | "${ENGINE}"
+uci
+setoption name VariantPath value ${VARIANT_PATH}
+$1
+quit
+CMDS
+}
+
+echo "potion custom tests started"
+
+# Issue 2: Jump potion with two blockers where removing both would make the move possible,
+# but removing only the encoded gate square does not.
+out=$(run_cmds "setoption name UCI_Variant value spell-chess
+position fen 7k/8/8/p7/8/p7/8/R3K3[J] w - - 0 1
+go perft 1")
+
+# j@a3,a1a4 is legal (only a3 blocks)
+echo "${out}" | grep -q "^j@a3,a1a4: 1$"
+# j@a3,a1a5 is legal (a5 is capture destination, only a3 blocks)
+echo "${out}" | grep -q "^j@a3,a1a5: 1$"
+# j@a3,a1a6 is illegal (a5 is on the path and not removed)
+! echo "${out}" | grep -q "^j@a3,a1a6:"
+
+# Issue 4: Verify that a checkers king (where allow_checks() is false and there is no royal)
+# does not trigger the fallback when missing.
+# In checkers, startpos has no kings, but king_type() is KING.
+# If the fallback triggered, checkers startpos would think the king is missing
+# and immediately declare checkmate/end of game (0 perft nodes).
+# Let's verify that checkers has valid moves from startpos.
+out=$(run_cmds "setoption name UCI_Variant value checkers
+position startpos
+go perft 1")
+echo "${out}" | grep -q "Nodes searched: 7"
+
+echo "potion custom tests passed"


### PR DESCRIPTION
This PR fixes Spell Chess potion pseudo-legality and freeze ordering, adds jump-potion blocker path revalidation, extracts surround-capture logic to a shared helper, and narrows the runtime king fallback.