### PR TITLE
Fix Spell Chess promotion potion moves and castling under frozen attackers

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -213,10 +213,8 @@ namespace {
 
 
   template<GenType Type>
-  bool potion_move_matches(const Position& pos, Move m, bool isCapture) {
-      return !((Type == CAPTURES && !isCapture)
-            || (Type == QUIETS && isCapture)
-            || (Type == QUIET_CHECKS && (isCapture || !pos.gives_check(m)))
+  bool potion_move_matches(const Position& pos, Move m, [[maybe_unused]] bool isCapture) {
+      return !((Type == QUIET_CHECKS && !pos.gives_check(m))
             || !pos.legal(m));
   }
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -6019,6 +6019,22 @@ void Position::do_move(Move m, StateInfo& newSt, [[maybe_unused]] bool givesChec
       }
   }
 
+  if (type_of(m) == PROMOTION_POTION && potCtx.potion != Variant::POTION_TYPE_NB)
+  {
+      PieceType potionPiece = potion_piece(potCtx.potion);
+      if (potionPiece != NO_PIECE_TYPE)
+      {
+          Piece gating_piece = make_piece(us, potionPiece);
+          int oldCount = pieceCountInHand[us][potionPiece];
+          remove_from_hand(gating_piece);
+          int newCount = pieceCountInHand[us][potionPiece];
+          xor_in_hand_count(k, gating_piece, oldCount, newCount);
+
+          if (Eval::useNNUE)
+              append_dirty(st, gating_piece, SQ_NONE, SQ_NONE, gating_piece, pieceCountInHand[us][potionPiece]);
+      }
+  }
+
   // Musketeer gating
   if(commit_gates() && !rifleShot){
       {
@@ -6737,6 +6753,17 @@ void Position::undo_move(Move m) {
               if (gating_from_hand())
                   add_to_hand(gating_piece);
           }
+      }
+  }
+
+  if (type_of(m) == PROMOTION_POTION)
+  {
+      Variant::PotionType potion = static_cast<Variant::PotionType>(potion_type(m));
+      PieceType potionPiece = potion_piece(potion);
+      if (potionPiece != NO_PIECE_TYPE)
+      {
+          Piece gating_piece = make_piece(us, potionPiece);
+          add_to_hand(gating_piece);
       }
   }
 

--- a/test.py
+++ b/test.py
@@ -2169,5 +2169,24 @@ stepwisePushing = true
                 sf.set_option("VariantPath", str(path))
             os.remove(temp_name)
 
+    def test_spell_chess(self):
+        # 1. Verification of promotion potion moves and hands
+        fen_promo = "7k/P7/8/8/8/8/8/K7[F] w - - 0 1"
+        next_fen = sf.get_fen("spell-chess", fen_promo, ["a7a8q"])
+        self.assertEqual(next_fen, "Q6k/8/8/8/8/8/8/K7[F] b - - 0 1")
+
+        # 2. Frozen attackers block castling?
+        # White commoner e1, rook h1, enemy king on e8. Enemy bishop at d4 controls f2.
+        # Without freezing, White cannot castle e1g1.
+        fen_freeze_test = "4k3/8/8/8/3b4/8/8/R3K2R[F] w K - 0 1"
+        
+        # Test 2a: Dropping freeze potion on d4 AND castling e1g1 in the same turn (double move) should be legal
+        moves = sf.legal_moves("spell-chess", fen_freeze_test, [])
+        self.assertIn("f@d4,e1g1", moves, "Should be allowed to castle by freezing the attacker in the same turn")
+
+        # Test 2b: Castling e1g1 on its own without freezing the attacker first should NOT be legal
+        self.assertNotIn("e1g1", moves, "Should not be allowed to castle through unfrozen attacker on its own")
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)
+


### PR DESCRIPTION
This PR fixes Spell Chess quiet promotion potion moves validation, ensures hand piece updates/undos for promotion potions are correctly handled, and validates castling checks under frozen attackers.