### PR TITLE
Add `goRule` variant support (Go-style capture and suicide rules for drops)

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1460,6 +1460,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("surroundCaptureEdge", v->surroundCaptureEdge);
     parse_attribute("surroundCaptureMaxRegion", v->surroundCaptureMaxRegion);
     parse_attribute("surroundCaptureHostileRegion", v->surroundCaptureHostileRegion);
+    parse_attribute("goRule", v->goRule);
     parse_attribute("doubleStep", v->doubleStep);
     parse_color_setting("doubleStepRegion", v->doubleStepRegion);
     parse_color_setting("tripleStepRegion", v->tripleStepRegion);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -3124,6 +3124,37 @@ Bitboard Position::compute_surround_capture_mask(Square moverSq, Bitboard usPiec
   return mask;
 }
 
+Bitboard Position::compute_go_capture_mask(Square placed, Color us, Bitboard occupied) const {
+  Bitboard mask = 0;
+  Bitboard candidates = attacks_bb<WAZIR>(placed, occupied) & board_bb() & pieces(~us);
+
+  while (candidates)
+  {
+      Square root = pop_lsb(candidates);
+      Bitboard group = 0, fringe = square_bb(root);
+      bool hasLiberty = false;
+
+      while (fringe)
+      {
+          Square s = pop_lsb(fringe);
+          group |= s;
+          Bitboard adj = attacks_bb<WAZIR>(s, occupied) & board_bb();
+          if (adj & ~occupied)
+          {
+              hasLiberty = true;
+              break;
+          }
+          fringe |= adj & pieces(~us) & ~group;
+      }
+
+      candidates &= ~group;
+      if (!hasLiberty)
+          mask |= group;
+  }
+
+  return mask;
+}
+
 
 Bitboard Position::compute_remove_connect_n_mask(
     const std::vector<Bitboard>& baseLines,
@@ -3577,6 +3608,9 @@ bool Position::legal(Move m) const {
       }
 
       if (!(drop_region(us, type_of(moved_piece(m))) & legalDropTargets & to))
+          return false;
+
+      if (var->goRule && !go_drop_legal(to, us))
           return false;
   }
 
@@ -4648,7 +4682,8 @@ bool Position::pseudo_legal(const Move m) const {
                         && count_in_prison(us, exchange_piece(m)) > 0
                         && count_in_prison(~us, in_hand_piece_type(m)) > 0))
             && (drop_region(us, type_of(pc)) & legalDropTargets & to)
-            && (drop_piece_types(in_hand_piece_type(m)) & type_of(pc));
+            && (drop_piece_types(in_hand_piece_type(m)) & type_of(pc))
+            && (!var->goRule || go_drop_legal(to, us));
   }
 
   // Use a slower but simpler function for uncommon cases
@@ -6371,6 +6406,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool countNode) {
          ( blast_on_self_destruct() && is_self_destruct(m) ) ||
          var->blastPassiveTypes ||
          ( remove_connect_n() > 0 ) ||
+         ( var->goRule && dropMove ) ||
          ( pi && pi->has_universal_hopper() && jumpCapsq != SQ_NONE )
        )
        && !is_pass(m)
@@ -6407,6 +6443,9 @@ void Position::do_move(Move m, StateInfo& newSt, bool countNode) {
       if ( surround_capture_opposite() || surround_capture_intervene() || surround_capture_edge() ) {
           removal_mask |= compute_surround_capture_mask(moverSq, pieces(us), pieces(~us), pieces());
       }
+
+      if (var->goRule && dropMove)
+          removal_mask |= compute_go_capture_mask(moverSq, us, pieces());
 
       if (pi && pi->has_universal_hopper() && jumpCapsq != SQ_NONE)
       {

--- a/src/position.h
+++ b/src/position.h
@@ -453,6 +453,8 @@ public:
   Bitboard surround_capture_max_region() const;
   Bitboard surround_capture_hostile_region() const;
   Bitboard compute_surround_capture_mask(Square moverSq, Bitboard usPieces, Bitboard themPieces, Bitboard occupied) const;
+  Bitboard compute_go_capture_mask(Square placed, Color us, Bitboard occupied) const;
+  bool go_drop_legal(Square to, Color us) const;
   Bitboard compute_remove_connect_n_mask(const std::vector<Bitboard>& baseLines, Bitboard alreadyRemoved, Bitboard blastMask, Bitboard& connectMask) const;
   EndgameEval endgame_eval() const;
   Bitboard double_step_region(Color c) const;
@@ -1376,6 +1378,27 @@ inline Bitboard Position::surround_capture_max_region() const {
 inline Bitboard Position::surround_capture_hostile_region() const {
   assert(var != nullptr);
   return var->surroundCaptureHostileRegion;
+}
+
+inline bool Position::go_drop_legal(Square to, Color us) const {
+  if (!var->goRule || !(board_bb() & to) || !empty(to))
+      return false;
+
+  Bitboard occupied = pieces() | to;
+  Bitboard captured = compute_go_capture_mask(to, us, occupied);
+  if (captured)
+      return true;
+
+  Bitboard ownGroup = 0, fringe = square_bb(to);
+  while (fringe)
+  {
+      Square s = pop_lsb(fringe);
+      ownGroup |= s;
+      if (attacks_bb<WAZIR>(s, occupied) & board_bb() & ~occupied)
+          return true;
+      fringe |= attacks_bb<WAZIR>(s, occupied) & board_bb() & (pieces(us) | to) & ~ownGroup;
+  }
+  return false;
 }
 
 inline EndgameEval Position::endgame_eval() const {

--- a/src/variant.h
+++ b/src/variant.h
@@ -174,6 +174,7 @@ struct Variant {
   bool surroundCaptureEdge = false;
   Bitboard surroundCaptureMaxRegion = 0;
   Bitboard surroundCaptureHostileRegion = 0;
+  bool goRule = false;
   bool doubleStep = true;
   ColorSetting<PieceTypeBitboardGroup> doubleStepRegion = ColorSetting<PieceTypeBitboardGroup>(Rank2BB, Rank7BB);
   ColorSetting<PieceTypeBitboardGroup> tripleStepRegion = ColorSetting<PieceTypeBitboardGroup>(Bitboard(0));

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -328,6 +328,7 @@
 # surroundCaptureEdge: enemy piece can be captured by having your piece opposite an edge [bool] (default: false)
 # surroundCaptureMaxRegion: pieces in this region can be surround-captured if and only if they are surrounded on all possible orthogonal squares (ie. 4 in the center, 3 on an edge, 2 on a corner) [Bitboard] (default: -)
 # surroundCaptureHostileRegion: squares in this region are treated as enemy pieces by both sides for surround-capture requirements [Bitboard] (default: -)
+# goRule: after a drop, remove adjacent opponent groups with no liberties and reject suicide drops [bool] (default: false)
 # Pawn stepping and en passant
 # doubleStep: enable pawn double step [bool] (default: true)
 # doubleStepRegionWhite: region where pawn double step is allowed for white; supports global Bitboard or PieceTypeBitboardGroup [PieceTypeBitboardGroup] (default: *2)
@@ -1204,6 +1205,28 @@ connectValue = loss
 maxRank = 9
 startFen = 3/3/3/3/3/3/3/3/3[] w - - 0 1
 connect3D = true
+
+[go9]
+maxRank = 9
+maxFile = 9
+pieceToCharTable = -
+king = -
+immobile = p
+startFen = 9/9/9/9/9/9/9/9/9[] b - - 0 1
+pieceDrops = true
+freeDrops = true
+goRule = true
+pass = true
+doubleStep = false
+castling = false
+stalemateValue = draw
+immobilityIllegal = false
+nMoveRule = 0
+
+[go13:go9]
+maxRank = 13
+maxFile = 13
+startFen = 13/13/13/13/13/13/13/13/13/13/13/13/13[] b - - 0 1
 
 [qubic:tictactoe]
 maxRank = 8

--- a/test.py
+++ b/test.py
@@ -995,6 +995,41 @@ piecePoints = n:5
         paired_moves_9 = [m for m in moves_9 if "," in m]
         self.assertEqual(len(paired_moves_9), 0)
 
+    def test_go_rule_drop_capture_and_suicide(self):
+        sf.load_variant_config(
+            """[gotest]
+maxRank = 5
+maxFile = 5
+pieceToCharTable = -
+king = -
+immobile = p
+startFen = 5/5/5/5/5[] b - - 0 1
+pieceDrops = true
+freeDrops = true
+goRule = true
+pass = true
+doubleStep = false
+castling = false
+stalemateValue = draw
+immobilityIllegal = false
+nMoveRule = 0
+"""
+        )
+
+        start = sf.start_fen("gotest")
+        start_moves = sf.legal_moves("gotest", start, [])
+        self.assertIn("P@c3", start_moves)
+        self.assertIn("P@a1", start_moves)
+
+        capture_moves = ["P@c3", "P@c2", "P@b2", "P@a1", "P@d2", "P@a2", "P@c1"]
+        after_capture = sf.get_fen("gotest", start, capture_moves)
+        self.assertEqual(after_capture.split()[0], "5/5/2p2/Pp1p1/P1p2")
+
+        suicide_fen = "5/5/2p2/1p1p1/2p2[] w - - 0 1"
+        suicide_moves = sf.legal_moves("gotest", suicide_fen, [])
+        self.assertNotIn("P@c2", suicide_moves)
+        self.assertIn("P@a1", suicide_moves)
+
     def test_ichess_setup_basics(self):
         load_repo_variants_or_skip()
         fen = sf.start_fen("ichess")


### PR DESCRIPTION
### Motivation
- Add optional Go-like rules for drop games to remove adjacent opponent groups with no liberties and to disallow suicide drops. 
- Provide example Go variants and expose the rule as a configurable `goRule` variant option.

### Description
- Add a `goRule` boolean to `Variant` and parse it from configuration with `parse_attribute("goRule", v->goRule)` in `parser.cpp` and document it in `variants.ini`.
- Implement `Position::compute_go_capture_mask(Square placed, Color us, Bitboard occupied)` to detect adjacent opponent groups with no liberties using orthogonal (`WAZIR`) adjacency.
- Add `Position::go_drop_legal(Square to, Color us)` (declared in `position.h`) and use it in `legal()` and `pseudo_legal()` to reject suicide drops and allow capture drops when `var->goRule` is enabled.
- Apply Go-style captures during move execution by OR-ing `compute_go_capture_mask` into the overall `removal_mask` in `do_move()` when `var->goRule` and `dropMove` are set.
- Add example variants `go9` and `go13` to `variants.ini` and a unit test `test_go_rule_drop_capture_and_suicide` in `test.py` exercising drop captures and suicide rejection.

### Testing
- Ran the Python unit tests in `test.py` including the new `test_go_rule_drop_capture_and_suicide` test; the new test passed.
- Existing test suite was executed and reported no regressions related to drop legality or capture behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a430d5a1bc0833085b359e2b0fd2509)