### PR TITLE
Add restricted-capture-chess variant with color-specific capture rules and castling-ignore-check

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -1291,7 +1291,7 @@ namespace {
             *moveList++ = make<SPECIAL>(royalSq, royalSq);
 
         if (royalPt == KING && !restrictToForcedJumper
-            && (Type == QUIETS || Type == NON_EVASIONS)
+            && (Type == QUIETS || Type == NON_EVASIONS || (Type == EVASIONS && pos.castling_ignore_check()))
             && pos.can_castle(Us == WHITE ? WHITE_CASTLING : BLACK_CASTLING))
             for (CastlingRights cr : { Us & KING_SIDE, Us & QUEEN_SIDE } )
                 if (!pos.castling_impeded(cr) && pos.can_castle(cr))

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1481,6 +1481,7 @@ bool VariantParser<DoCheck>::parse_official_options(Variant* v) {
     parse_attribute("castling", v->castling);
     parse_attribute("castlingDroppedPiece", v->castlingDroppedPiece);
     parse_attribute("castlingPromotedPiece", v->castlingPromotedPiece);
+    parse_attribute("castlingIgnoreCheck", v->castlingIgnoreCheck);
     parse_attribute("castlingForbiddenPlies", v->castlingForbiddenPlies);
     parse_attribute("castlingKingsideFile", v->castlingKingsideFile);
     parse_attribute("castlingQueensideFile", v->castlingQueensideFile);
@@ -2186,6 +2187,11 @@ bool VariantParser<DoCheck>::parse_gating_piece_after(Variant* v) {
 template <bool DoCheck>
 bool VariantParser<DoCheck>::parse_capture_maps(Variant* v) {
     const bool hasCaptureForbidden = config.find("captureForbidden") != config.end();
+    auto sync_color_maps = [&]() {
+        for (Color c : { WHITE, BLACK })
+            std::copy(v->captureForbidden, v->captureForbidden + PIECE_TYPE_NB, v->captureForbiddenByColor[c]);
+    };
+    sync_color_maps();
     auto parse_capture_map = [&](const std::string& key, bool allow) {
         auto it = config.find(key);
         if (it == config.end())
@@ -2237,13 +2243,54 @@ bool VariantParser<DoCheck>::parse_capture_maps(Variant* v) {
             }
         }
         std::copy(parsed, parsed + PIECE_TYPE_NB, v->captureForbidden);
+        sync_color_maps();
         return true;
     };
     if (!parse_capture_map("captureForbidden", false))
         return false;
     if (!parse_capture_map("captureAllowed", true))
         return false;
-    return true;
+
+    auto parse_color_capture_map = [&](const std::string& key, Color c, bool allow) {
+        auto it = config.find(key);
+        if (it == config.end())
+            return true;
+
+        std::string entry;
+        std::stringstream ss(it->second);
+        PieceSet parsed[PIECE_TYPE_NB];
+        std::copy(v->captureForbiddenByColor[c], v->captureForbiddenByColor[c] + PIECE_TYPE_NB, parsed);
+        while (ss >> entry) {
+            size_t sep = entry.find(':');
+            if (sep == std::string::npos || sep == 0 || sep + 1 >= entry.size()) {
+                if (DoCheck)
+                    std::cerr << key << " - Invalid mapping token: " << entry << std::endl;
+                return false;
+            }
+            PieceSet attackerSet = NO_PIECE_SET, targetSet = NO_PIECE_SET;
+            if (!parse_piece_set_token_string(entry.substr(0, sep), v, attackerSet, true, false)
+                || !parse_piece_set_token_string(entry.substr(sep + 1), v, targetSet, true, true)
+                || !attackerSet || !targetSet)
+            {
+                if (DoCheck)
+                    std::cerr << key << " - Invalid capture mapping: " << entry << std::endl;
+                return false;
+            }
+            for (PieceSet ps = attackerSet; ps; ) {
+                PieceType attacker = pop_lsb(ps);
+                if (allow)
+                    parsed[attacker] &= ~targetSet;
+                else
+                    parsed[attacker] |= targetSet;
+            }
+        }
+        std::copy(parsed, parsed + PIECE_TYPE_NB, v->captureForbiddenByColor[c]);
+        return true;
+    };
+    return parse_color_capture_map("captureForbiddenWhite", WHITE, false)
+        && parse_color_capture_map("captureForbiddenBlack", BLACK, false)
+        && parse_color_capture_map("captureAllowedWhite", WHITE, true)
+        && parse_color_capture_map("captureAllowedBlack", BLACK, true);
 }
 
 template <bool DoCheck>

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2847,7 +2847,7 @@ Bitboard Position::attackers_to_king(Square s, Bitboard occupied, Color c, Bitbo
       for (PieceSet ps = piece_types(); ps; )
       {
           PieceType apt = pop_lsb(ps);
-          if (var->captureForbidden[apt] & royalType)
+          if (var->captureForbiddenByColor[c][apt] & royalType)
               attackers &= ~pieces(c, apt);
       }
   return attackers;
@@ -4257,7 +4257,7 @@ bool Position::legal(Move m) const {
   {
       PieceType attacker = type_of(moved_piece(m));
       PieceType target = type_of(captured_piece(m));
-      if (attacker < PIECE_TYPE_NB && target < PIECE_TYPE_NB && (var->captureForbidden[attacker] & target))
+      if (attacker < PIECE_TYPE_NB && target < PIECE_TYPE_NB && (var->captureForbiddenByColor[us][attacker] & target))
           return false;
   }
 
@@ -4316,11 +4316,11 @@ bool Position::legal(Move m) const {
           return att;
       };
 
-      if (((!allow_checks()) || spellLikeCastler) && attackers_for_castling(from, pieces()))
+      if (((!allow_checks() && !var->castlingIgnoreCheck) || spellLikeCastler) && attackers_for_castling(from, pieces()))
           return false;
 
       for (Square s = to; s != from; s += step)
-          if (   (((!allow_checks()) || spellLikeCastler) && attackers_for_castling(s, pieces()))
+          if (   (((!allow_checks() && !var->castlingIgnoreCheck) || spellLikeCastler) && attackers_for_castling(s, pieces()))
               || (var->flyingGeneral && (attacks_bb(~us, ROOK, s, pieces() ^ from) & pieces(~us, KING)))
               || (var->diagonalGeneral && (attacks_bb(~us, BISHOP, s, pieces() ^ from) & pieces(~us, KING))))
               return false;
@@ -4976,14 +4976,14 @@ bool Position::gives_check(Move m) const {
 
   if (usingPhysicalKingTarget
       && (attackers_to_king(royalSq, occupied, sideToMove, janggiCannons) & square_bb(attackFrom)))
-      return !(var->captureForbidden[type_of(mover)] & royalType);
+      return !(var->captureForbiddenByColor[color_of(mover)][type_of(mover)] & royalType);
 
   // Is there a direct check?
   if (!is_promotion_move(m) && type_of(m) != PIECE_PROMOTION && type_of(m) != PIECE_DEMOTION && type_of(m) != CASTLING
       && !((var->petrifyOnCaptureTypes & type_of(mover)) && capture(m)))
   {
       PieceType pt = type_of(mover);
-      if (!(var->captureForbidden[pt] & royalType))
+      if (!(var->captureForbiddenByColor[sideToMove][pt] & royalType))
       {
           if (pt == JANGGI_CANNON)
           {

--- a/src/position.h
+++ b/src/position.h
@@ -503,6 +503,7 @@ public:
   bool is_hex_board() const;
   bool checking_permitted() const;
   bool allow_checks() const;
+  bool castling_ignore_check() const;
   bool drop_checks() const;
   bool drop_mates() const;
   bool shogi_pawn_drop_mate_illegal() const;
@@ -1580,6 +1581,11 @@ inline bool Position::checking_permitted() const {
 inline bool Position::allow_checks() const {
   assert(var != nullptr);
   return var->allowChecks;
+}
+
+inline bool Position::castling_ignore_check() const {
+  assert(var != nullptr);
+  return var->castlingIgnoreCheck;
 }
 
 inline bool Position::free_drops() const {

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -2179,13 +2179,20 @@ Variant* Variant::conclude() {
     {
         PieceType pt = pop_lsb(ps);
         captureForbidden[pt] |= pt;
+        for (Color c : { WHITE, BLACK })
+            captureForbiddenByColor[c][pt] |= pt;
     }
     captureForbiddenToKing = NO_PIECE_SET;
+    for (Color c : { WHITE, BLACK })
+        captureForbiddenToKingByColor[c] = NO_PIECE_SET;
     for (PieceSet ps = pieceTypes; ps; )
     {
         PieceType pt = pop_lsb(ps);
         if (captureForbidden[pt] & KING)
             captureForbiddenToKing |= pt;
+        for (Color c : { WHITE, BLACK })
+            if (captureForbiddenByColor[c][pt] & KING)
+                captureForbiddenToKingByColor[c] |= pt;
     }
 
     // Enforce consistency to allow runtime optimizations

--- a/src/variant.h
+++ b/src/variant.h
@@ -169,7 +169,9 @@ struct Variant {
   PieceSet deathOnCaptureTypes = NO_PIECE_SET;
   PieceSet mutuallyHopIllegalTypes = NO_PIECE_SET;
   PieceSet captureForbidden[PIECE_TYPE_NB] = {};
+  PieceSet captureForbiddenByColor[COLOR_NB][PIECE_TYPE_NB] = {};
   PieceSet captureForbiddenToKing = NO_PIECE_SET;
+  PieceSet captureForbiddenToKingByColor[COLOR_NB] = {};
   PieceSet petrifyOnCaptureTypes = NO_PIECE_SET;
   bool petrifyOnCaptureSuppressTransfer = false;
   bool petrifyBlastPieces = false;
@@ -191,6 +193,7 @@ struct Variant {
   bool castling = true;
   bool castlingDroppedPiece = false;
   bool castlingPromotedPiece = false;
+  bool castlingIgnoreCheck = false;
   int castlingForbiddenPlies = 0;
   File castlingKingsideFile = FILE_G;
   File castlingQueensideFile = FILE_C;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -321,6 +321,8 @@
 # rexExclusiveMorph: kings do not morph when captureMorph is enabled [bool] (default: false)
 # captureForbidden: forbidden capture pairs attacker:targets, e.g. q:k b:pn *:i [str] (default: )
 # captureAllowed: remove captureForbidden pairs (applied after captureForbidden), same format [str] (default: )
+# captureForbiddenWhite/Black: side-specific forbidden capture pairs, applied after global maps [str] (default: )
+# captureAllowedWhite/Black: side-specific allowed capture pairs, applied after side-specific forbidden maps [str] (default: )
 # petrifyOnCaptureTypes: defined pieces are turned into wall squares when capturing [PieceSet] (default: -)
 # petrifyOnCaptureSuppressTransfer: petrifying captures do not also transfer captured material to hand/prison [bool] (default: false)
 # petrifyBlastPieces: if petrify and blast combined, should pieces destroyed in the blast be petrified? [bool] (default: false)
@@ -351,6 +353,7 @@
 # castling: enable/disable castling [bool] (default: true)
 # castlingDroppedPiece: enable castling with dropped rooks/kings [bool] (default: false)
 # castlingPromotedPiece: enable castling with rooks/kings that arrive by promotion on the castling rank [bool] (default: false)
+# castlingIgnoreCheck: allow castling while in check and through attacked transit squares [bool] (default: false)
 # castlingForbiddenPlies: disable castling while gamePly is below this threshold [int] (default: 0)
 # castlingKingsideFile: destination file of king after kingside castling [File] (default: g)
 # castlingQueensideFile: destination file of king after queenside castling [File] (default: c)
@@ -613,6 +616,16 @@
 # pawns with extra sideways and backwards movement
 # example for defining a custom pawn type
 # resetting the original "p" piece with "pawn = -" is optional as already done implicitly
+
+# Chess with asymmetric capture restrictions: kings and black pawns cannot capture;
+# white pawns can only capture black pawns and the king; castling ignores check.
+[restricted-capture-chess:chess]
+captureForbidden = k:*
+captureForbiddenWhite = p:*
+captureAllowedWhite = p:pk
+captureForbiddenBlack = p:*
+castlingIgnoreCheck = true
+
 [allwayspawns:chess]
 customPiece1 = p:mWfceFifmnD
 pawnTypes = p


### PR DESCRIPTION
### Motivation
- Implement an asymmetric chess variant where kings cannot capture, white pawns may only capture black pawns and the king, and black pawns cannot capture, using configurable `.ini` settings rather than ad-hoc C++ hacks.
- Allow a variant flag to permit castling while in check or through attacked transit squares so the castling rule can be adjusted via configuration.

### Description
- Add per-color capture restriction storage `captureForbiddenByColor` and `captureForbiddenToKingByColor` to `Variant` and populate derived masks at `Variant::conclude()` to support side-specific capture rules.
- Extend the variant parser to accept `captureForbiddenWhite`, `captureForbiddenBlack`, `captureAllowedWhite`, `captureAllowedBlack`, and the new boolean `castlingIgnoreCheck` via `src/parser.cpp` and document the keys in `src/variants.ini`.
- Enforce color-specific capture restrictions in legality and check detection by consulting `captureForbiddenByColor[...]` in `src/position.cpp` and by filtering `attackers_to_king()` accordingly.
- Add `Position::castling_ignore_check()` accessor and update move generation/legal checks in `src/movegen.cpp` and `src/position.cpp` so castling can optionally ignore normal transit-square attack checks when `castlingIgnoreCheck` is set.
- Add a `restricted-capture-chess` variant entry to `src/variants.ini` that configures the requested asymmetric pawn and king capture behaviour and enables `castlingIgnoreCheck`.

### Testing
- Built the engine with `cd src && make -j2 build ARCH=x86-64-modern` and the build completed successfully.
- Ran configuration validation with `src/stockfish check src/variants.ini` which parsed the new variant without errors.
- Exercised the variant interactively via UCI perft probes using `src/stockfish` (set `VariantPath`/`UCI_Variant` to `restricted-capture-chess`) and observed expected move lists for capture and castling-related positions (perft probes succeeded).
- `bash tests/fast-regression.sh src/stockfish` could not complete in this environment due to a missing `/usr/bin/time`, and `tests/protocol.sh` could not run because `expect` is not available (environment tool limitations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ab8909b0883308dbefe2982fe52c2)